### PR TITLE
fix(acp): intercept /new, /compact, /usage commands agent-side

### DIFF
--- a/pkg/acp/agent.go
+++ b/pkg/acp/agent.go
@@ -406,8 +406,28 @@ func (a *Agent) Prompt(ctx context.Context, params acp.PromptRequest) (acp.Promp
 	// These are handled agent-side and never forwarded to the LLM; without
 	// this the client's /new only clears its own transcript while the
 	// persisted session keeps every message and reloads them on resume.
-	if handled, err := a.handleCommand(ctx, acpSess, params.Prompt); handled {
-		return acp.PromptResponse{StopReason: acp.StopReasonEndTurn}, err
+	//
+	// Commands run under a cancellable turn context registered on the
+	// session (like a normal prompt) so the ACP Cancel/CloseSession
+	// notifications can interrupt a long-running /compact.
+	if name, isCmd := commandName(params.Prompt); isCmd {
+		turnCtx, cancel := context.WithCancel(ctx)
+		a.mu.Lock()
+		acpSess.cancel = cancel
+		a.mu.Unlock()
+		defer func() {
+			a.mu.Lock()
+			acpSess.cancel = nil
+			a.mu.Unlock()
+			cancel()
+		}()
+
+		if handled, err := a.handleCommand(turnCtx, acpSess, name); handled {
+			if err != nil && turnCtx.Err() != nil {
+				return acp.PromptResponse{StopReason: acp.StopReasonCancelled}, nil
+			}
+			return acp.PromptResponse{StopReason: acp.StopReasonEndTurn}, err
+		}
 	}
 
 	turnCtx, cancel := context.WithCancel(ctx)
@@ -434,19 +454,12 @@ func (a *Agent) Prompt(ctx context.Context, params acp.PromptRequest) (acp.Promp
 	return acp.PromptResponse{StopReason: acp.StopReasonEndTurn}, nil
 }
 
-// handleCommand intercepts the slash commands advertised through
-// emitAvailableCommands (/new, /compact, /usage). It returns handled=true
-// when the prompt was a recognised command (so the caller must not forward it
-// to the LLM), along with any error from executing it.
-//
-// The command name is taken from the leading token of the prompt's text; the
-// ACP client sends it verbatim (e.g. "/new") as a normal text block.
-func (a *Agent) handleCommand(ctx context.Context, acpSess *Session, prompt []acp.ContentBlock) (bool, error) {
-	name, ok := commandName(prompt)
-	if !ok {
-		return false, nil
-	}
-
+// handleCommand dispatches a slash command advertised through
+// emitAvailableCommands (/new, /compact, /usage). name is the already-parsed
+// command (without the leading slash). It returns handled=true when the
+// command was recognised (so the caller must not forward it to the LLM),
+// along with any error from executing it.
+func (a *Agent) handleCommand(ctx context.Context, acpSess *Session, name string) (bool, error) {
 	switch name {
 	case "new":
 		return true, a.handleNewCommand(ctx, acpSess)
@@ -460,15 +473,19 @@ func (a *Agent) handleCommand(ctx context.Context, acpSess *Session, prompt []ac
 }
 
 // commandName extracts a leading slash-command name from the prompt's text
-// content (e.g. "/new" → "new"). It returns ok=false when the prompt is not a
-// single bare slash command, so ordinary messages that merely start with "/"
-// followed by arguments are still sent to the LLM.
+// content (e.g. "/new" → "new"). It returns ok=false unless the prompt is a
+// single bare slash command with no other (text or non-text) content, so
+// ordinary messages that merely start with "/" — or a "/usage" typed next to
+// an attachment — are still sent to the LLM.
 func commandName(prompt []acp.ContentBlock) (string, bool) {
 	var b strings.Builder
 	for _, block := range prompt {
-		if block.Text != nil {
-			b.WriteString(block.Text.Text)
+		if block.Text == nil {
+			// Any non-text content means this is a real message, not a
+			// bare command.
+			return "", false
 		}
+		b.WriteString(block.Text.Text)
 	}
 	text := strings.TrimSpace(b.String())
 	if !strings.HasPrefix(text, "/") {
@@ -491,29 +508,35 @@ func (a *Agent) handleNewCommand(ctx context.Context, acpSess *Session) error {
 }
 
 // clearSessionHistory resets the session's conversation in memory and in the
-// persistent store. The same session ID is reused (deleted, then recreated
-// empty) so the client's session handle stays valid while the previously
-// persisted messages are dropped and cannot reload on the next resume.
+// persistent store. The session row is kept (only its items are dropped and
+// its counters reset) so the client's session handle stays valid while the
+// previously persisted messages can no longer reload on the next resume.
+//
+// The in-memory reset happens first and under the session lock; the store
+// clear is a single atomic operation, so a failure can never leave the
+// session missing or half-cleared.
 func (a *Agent) clearSessionHistory(ctx context.Context, acpSess *Session) error {
-	acpSess.sess.Messages = nil
-	acpSess.sess.InputTokens = 0
-	acpSess.sess.OutputTokens = 0
-	acpSess.sess.Cost = 0
+	acpSess.sess.ResetHistory()
 
 	if a.sessionStore == nil {
 		return nil
 	}
-	if err := a.sessionStore.DeleteSession(ctx, acpSess.id); err != nil {
+	if err := a.sessionStore.ClearSessionHistory(ctx, acpSess.id); err != nil {
+		// A never-persisted session (no messages sent yet) has no store row;
+		// clearing an already-empty conversation is a no-op, not an error.
+		if errors.Is(err, session.ErrNotFound) {
+			return nil
+		}
 		return fmt.Errorf("failed to clear session: %w", err)
-	}
-	if err := a.sessionStore.AddSession(ctx, acpSess.sess); err != nil {
-		return fmt.Errorf("failed to recreate session: %w", err)
 	}
 	return nil
 }
 
-// handleCompactCommand summarizes the conversation and compacts the history,
-// streaming the runtime's compaction events to the ACP client.
+// handleCompactCommand summarizes the conversation and compacts the history.
+// It mirrors the runtime's compaction events to the store — the direct
+// Summarize path bypasses the persistence observer that RunStream wires in,
+// so without this the summary would live only in memory and the old,
+// un-compacted history would reload on the next resume.
 func (a *Agent) handleCompactCommand(ctx context.Context, acpSess *Session) error {
 	ctx = withSessionID(ctx, acpSess.id)
 
@@ -523,17 +546,41 @@ func (a *Agent) handleCompactCommand(ctx context.Context, acpSess *Session) erro
 		acpSess.rt.Summarize(ctx, acpSess.sess, "", runtime.NewChannelSink(events))
 	}()
 
+	var (
+		summarized bool
+		failed     bool
+	)
 	for event := range events {
 		if ctx.Err() != nil {
 			return ctx.Err()
 		}
-		if e, ok := event.(*runtime.ErrorEvent); ok {
+		switch e := event.(type) {
+		case *runtime.SessionSummaryEvent:
+			summarized = true
+			if a.sessionStore != nil {
+				if err := a.sessionStore.AddSummary(ctx, e.SessionID, e.Summary, e.FirstKeptEntry); err != nil {
+					return fmt.Errorf("failed to persist summary: %w", err)
+				}
+			}
+		case *runtime.TokenUsageEvent:
+			if e.Usage != nil && a.sessionStore != nil {
+				if err := a.sessionStore.UpdateSessionTokens(ctx, e.SessionID, e.Usage.InputTokens, e.Usage.OutputTokens, e.Usage.Cost); err != nil {
+					return fmt.Errorf("failed to persist token usage: %w", err)
+				}
+			}
+		case *runtime.ErrorEvent:
+			failed = true
 			if err := a.sendUpdate(ctx, acpSess.id, acp.UpdateAgentMessageText(fmt.Sprintf("\n\nError: %s\n", e.Error))); err != nil {
 				return err
 			}
 		}
 	}
 
+	if failed || !summarized {
+		// Compaction was skipped (e.g. by a hook) or errored; the error, if
+		// any, was already surfaced above. Don't claim success.
+		return nil
+	}
 	return a.sendUpdate(ctx, acpSess.id, acp.UpdateAgentMessageText("Compacted the conversation."))
 }
 

--- a/pkg/acp/agent.go
+++ b/pkg/acp/agent.go
@@ -402,6 +402,14 @@ func (a *Agent) Prompt(ctx context.Context, params acp.PromptRequest) (acp.Promp
 		a.mu.Unlock()
 	}
 
+	// Intercept the slash commands advertised via emitAvailableCommands.
+	// These are handled agent-side and never forwarded to the LLM; without
+	// this the client's /new only clears its own transcript while the
+	// persisted session keeps every message and reloads them on resume.
+	if handled, err := a.handleCommand(ctx, acpSess, params.Prompt); handled {
+		return acp.PromptResponse{StopReason: acp.StopReasonEndTurn}, err
+	}
+
 	turnCtx, cancel := context.WithCancel(ctx)
 	a.mu.Lock()
 	acpSess.cancel = cancel
@@ -424,6 +432,117 @@ func (a *Agent) Prompt(ctx context.Context, params acp.PromptRequest) (acp.Promp
 	acpSess.cancel = nil
 
 	return acp.PromptResponse{StopReason: acp.StopReasonEndTurn}, nil
+}
+
+// handleCommand intercepts the slash commands advertised through
+// emitAvailableCommands (/new, /compact, /usage). It returns handled=true
+// when the prompt was a recognised command (so the caller must not forward it
+// to the LLM), along with any error from executing it.
+//
+// The command name is taken from the leading token of the prompt's text; the
+// ACP client sends it verbatim (e.g. "/new") as a normal text block.
+func (a *Agent) handleCommand(ctx context.Context, acpSess *Session, prompt []acp.ContentBlock) (bool, error) {
+	name, ok := commandName(prompt)
+	if !ok {
+		return false, nil
+	}
+
+	switch name {
+	case "new":
+		return true, a.handleNewCommand(ctx, acpSess)
+	case "compact":
+		return true, a.handleCompactCommand(ctx, acpSess)
+	case "usage":
+		return true, a.handleUsageCommand(ctx, acpSess)
+	default:
+		return false, nil
+	}
+}
+
+// commandName extracts a leading slash-command name from the prompt's text
+// content (e.g. "/new" → "new"). It returns ok=false when the prompt is not a
+// single bare slash command, so ordinary messages that merely start with "/"
+// followed by arguments are still sent to the LLM.
+func commandName(prompt []acp.ContentBlock) (string, bool) {
+	var b strings.Builder
+	for _, block := range prompt {
+		if block.Text != nil {
+			b.WriteString(block.Text.Text)
+		}
+	}
+	text := strings.TrimSpace(b.String())
+	if !strings.HasPrefix(text, "/") {
+		return "", false
+	}
+	fields := strings.Fields(text)
+	if len(fields) != 1 {
+		return "", false
+	}
+	return strings.TrimPrefix(fields[0], "/"), true
+}
+
+// handleNewCommand clears the session's conversation, both in memory and in
+// the persistent store, so a subsequent resume starts fresh.
+func (a *Agent) handleNewCommand(ctx context.Context, acpSess *Session) error {
+	if err := a.clearSessionHistory(ctx, acpSess); err != nil {
+		return err
+	}
+	return a.sendUpdate(ctx, acpSess.id, acp.UpdateAgentMessageText("Started a new session."))
+}
+
+// clearSessionHistory resets the session's conversation in memory and in the
+// persistent store. The same session ID is reused (deleted, then recreated
+// empty) so the client's session handle stays valid while the previously
+// persisted messages are dropped and cannot reload on the next resume.
+func (a *Agent) clearSessionHistory(ctx context.Context, acpSess *Session) error {
+	acpSess.sess.Messages = nil
+	acpSess.sess.InputTokens = 0
+	acpSess.sess.OutputTokens = 0
+	acpSess.sess.Cost = 0
+
+	if a.sessionStore == nil {
+		return nil
+	}
+	if err := a.sessionStore.DeleteSession(ctx, acpSess.id); err != nil {
+		return fmt.Errorf("failed to clear session: %w", err)
+	}
+	if err := a.sessionStore.AddSession(ctx, acpSess.sess); err != nil {
+		return fmt.Errorf("failed to recreate session: %w", err)
+	}
+	return nil
+}
+
+// handleCompactCommand summarizes the conversation and compacts the history,
+// streaming the runtime's compaction events to the ACP client.
+func (a *Agent) handleCompactCommand(ctx context.Context, acpSess *Session) error {
+	ctx = withSessionID(ctx, acpSess.id)
+
+	events := make(chan runtime.Event, 100)
+	go func() {
+		defer close(events)
+		acpSess.rt.Summarize(ctx, acpSess.sess, "", runtime.NewChannelSink(events))
+	}()
+
+	for event := range events {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		if e, ok := event.(*runtime.ErrorEvent); ok {
+			if err := a.sendUpdate(ctx, acpSess.id, acp.UpdateAgentMessageText(fmt.Sprintf("\n\nError: %s\n", e.Error))); err != nil {
+				return err
+			}
+		}
+	}
+
+	return a.sendUpdate(ctx, acpSess.id, acp.UpdateAgentMessageText("Compacted the conversation."))
+}
+
+// handleUsageCommand reports the session's cumulative token usage to the
+// client as an agent message.
+func (a *Agent) handleUsageCommand(ctx context.Context, acpSess *Session) error {
+	input, output := acpSess.sess.Usage()
+	msg := fmt.Sprintf("Token usage: %d input, %d output, %d total.", input, output, input+output)
+	return a.sendUpdate(ctx, acpSess.id, acp.UpdateAgentMessageText(msg))
 }
 
 // buildUserContent constructs user message text from ACP content blocks.

--- a/pkg/acp/agent_test.go
+++ b/pkg/acp/agent_test.go
@@ -243,3 +243,72 @@ func TestACPSessionPersistence(t *testing.T) {
 	assert.True(t, hasUserMsg, "Session should have a user message")
 	assert.True(t, hasAssistantMsg, "Session should have an assistant message")
 }
+
+func TestCommandName(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		text   string
+		want   string
+		wantOk bool
+	}{
+		{"new command", "/new", "new", true},
+		{"compact command", "/compact", "compact", true},
+		{"usage command", "/usage", "usage", true},
+		{"leading/trailing space", "  /new  ", "new", true},
+		{"command with args is not a bare command", "/compact focus on tests", "", false},
+		{"plain message", "hello there", "", false},
+		{"message starting with slash but with words", "/path/to/file please read", "", false},
+		{"empty", "", "", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			name, ok := commandName([]acpsdk.ContentBlock{acpsdk.TextBlock(tt.text)})
+			assert.Equal(t, tt.wantOk, ok)
+			assert.Equal(t, tt.want, name)
+		})
+	}
+}
+
+// TestClearSessionHistory verifies that /new drops the persisted conversation
+// so it cannot reload on a subsequent resume (the bug behind "/new clears the
+// session but it comes back when I reopen sbx and gordon").
+func TestClearSessionHistory(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	dbPath := filepath.Join(t.TempDir(), "session.db")
+	sessStore, err := session.NewSQLiteSessionStore(ctx, dbPath)
+	require.NoError(t, err)
+	if closer, ok := sessStore.(io.Closer); ok {
+		defer closer.Close()
+	}
+
+	sess := session.New(session.WithWorkingDir(t.TempDir()))
+	sess.AddMessage(session.UserMessage("first message"))
+	require.NoError(t, sessStore.AddSession(ctx, sess))
+
+	loaded, err := sessStore.GetSession(ctx, sess.ID)
+	require.NoError(t, err)
+	require.Len(t, loaded.Messages, 1)
+
+	acpAgent := &Agent{
+		runConfig:    &config.RuntimeConfig{},
+		sessionStore: sessStore,
+		sessions:     make(map[string]*Session),
+	}
+	acpSess := &Session{id: sess.ID, sess: sess}
+
+	require.NoError(t, acpAgent.clearSessionHistory(ctx, acpSess))
+
+	// In-memory session is cleared.
+	assert.Empty(t, acpSess.sess.Messages)
+
+	// A resume (GetSession) must not bring the old messages back.
+	reloaded, err := sessStore.GetSession(ctx, sess.ID)
+	require.NoError(t, err)
+	assert.Empty(t, reloaded.Messages, "cleared session must not reload previous messages")
+}

--- a/pkg/acp/agent_test.go
+++ b/pkg/acp/agent_test.go
@@ -287,8 +287,9 @@ func TestClearSessionHistory(t *testing.T) {
 		defer closer.Close()
 	}
 
-	sess := session.New(session.WithWorkingDir(t.TempDir()))
+	sess := session.New(session.WithWorkingDir(t.TempDir()), session.WithTitle("Keep me"))
 	sess.AddMessage(session.UserMessage("first message"))
+	sess.SetUsage(10, 5)
 	require.NoError(t, sessStore.AddSession(ctx, sess))
 
 	loaded, err := sessStore.GetSession(ctx, sess.ID)
@@ -304,11 +305,44 @@ func TestClearSessionHistory(t *testing.T) {
 
 	require.NoError(t, acpAgent.clearSessionHistory(ctx, acpSess))
 
-	// In-memory session is cleared.
+	// In-memory session is cleared, including token counters.
 	assert.Empty(t, acpSess.sess.Messages)
+	in, out := acpSess.sess.Usage()
+	assert.Zero(t, in)
+	assert.Zero(t, out)
 
-	// A resume (GetSession) must not bring the old messages back.
+	// A resume (GetSession) must not bring the old messages back, but the
+	// session row itself (id, title, working dir) must survive.
 	reloaded, err := sessStore.GetSession(ctx, sess.ID)
 	require.NoError(t, err)
 	assert.Empty(t, reloaded.Messages, "cleared session must not reload previous messages")
+	assert.Equal(t, "Keep me", reloaded.Title)
+	assert.Equal(t, sess.WorkingDir, reloaded.WorkingDir)
+	assert.Zero(t, reloaded.InputTokens)
+	assert.Zero(t, reloaded.OutputTokens)
+}
+
+// TestClearSessionHistoryNeverPersisted verifies /new on a session that was
+// never written to the store (no messages sent yet) is a no-op rather than an
+// error.
+func TestClearSessionHistoryNeverPersisted(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	dbPath := filepath.Join(t.TempDir(), "session.db")
+	sessStore, err := session.NewSQLiteSessionStore(ctx, dbPath)
+	require.NoError(t, err)
+	if closer, ok := sessStore.(io.Closer); ok {
+		defer closer.Close()
+	}
+
+	sess := session.New(session.WithWorkingDir(t.TempDir()))
+	acpAgent := &Agent{
+		runConfig:    &config.RuntimeConfig{},
+		sessionStore: sessStore,
+		sessions:     make(map[string]*Session),
+	}
+	acpSess := &Session{id: sess.ID, sess: sess}
+
+	assert.NoError(t, acpAgent.clearSessionHistory(ctx, acpSess))
 }

--- a/pkg/runtime/remote_runtime.go
+++ b/pkg/runtime/remote_runtime.go
@@ -806,6 +806,10 @@ func (s *RemoteSessionStore) DeleteSession(ctx context.Context, id string) error
 	return s.client.DeleteRemoteSession(ctx, id)
 }
 
+func (s *RemoteSessionStore) ClearSessionHistory(context.Context, string) error {
+	return fmt.Errorf("clear session history: %w", ErrUnsupported)
+}
+
 func (s *RemoteSessionStore) UpdateSession(context.Context, *session.Session) error {
 	return fmt.Errorf("update session: %w", ErrUnsupported)
 }

--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -547,6 +547,19 @@ func (s *Session) ApplyCompaction(inputTokens, outputTokens int64, item Item) {
 	s.Messages = append(s.Messages, item)
 }
 
+// ResetHistory clears the conversation and its cumulative token/cost counters
+// under s.mu, so a fresh conversation can start on the same session. It mirrors
+// the fields the store persists for a message-free session, keeping the
+// in-memory view consistent with a cleared row.
+func (s *Session) ResetHistory() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.Messages = nil
+	s.InputTokens = 0
+	s.OutputTokens = 0
+	s.Cost = 0
+}
+
 // AddSubSession adds a sub-session to the session
 func (s *Session) AddSubSession(subSession *Session) {
 	s.mu.Lock()

--- a/pkg/session/store.go
+++ b/pkg/session/store.go
@@ -95,6 +95,13 @@ type Store interface {
 	UpdateSession(ctx context.Context, session *Session) error // Updates metadata only (not messages/items)
 	SetSessionStarred(ctx context.Context, id string, starred bool) error
 
+	// ClearSessionHistory removes all items (messages, summaries, errors,
+	// sub-session links) of a session and resets its token/cost counters,
+	// keeping the session row itself. It is atomic: a session is never left
+	// partially cleared or missing. Used by the /new command so a cleared
+	// conversation cannot reload on the next resume.
+	ClearSessionHistory(ctx context.Context, id string) error
+
 	// === Granular item operations ===
 
 	// AddMessage adds a message to a session at the next position.
@@ -200,6 +207,25 @@ func (s *InMemorySessionStore) DeleteSession(_ context.Context, id string) error
 		return ErrNotFound
 	}
 	s.sessions.Delete(id)
+	return nil
+}
+
+// ClearSessionHistory removes all items and resets token/cost counters for a
+// session while keeping the session itself. See [Store.ClearSessionHistory].
+func (s *InMemorySessionStore) ClearSessionHistory(_ context.Context, id string) error {
+	if id == "" {
+		return ErrEmptyID
+	}
+	session, exists := s.sessions.Load(id)
+	if !exists {
+		return ErrNotFound
+	}
+	session.mu.Lock()
+	session.Messages = nil
+	session.InputTokens = 0
+	session.OutputTokens = 0
+	session.Cost = 0
+	session.mu.Unlock()
 	return nil
 }
 
@@ -907,6 +933,48 @@ func (s *SQLiteSessionStore) DeleteSession(ctx context.Context, id string) error
 	}
 
 	return nil
+}
+
+// ClearSessionHistory deletes all of a session's items and resets its
+// token/cost counters in a single transaction, keeping the session row.
+// See [Store.ClearSessionHistory].
+func (s *SQLiteSessionStore) ClearSessionHistory(ctx context.Context, id string) error {
+	if id == "" {
+		return ErrEmptyID
+	}
+
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	res, err := tx.ExecContext(ctx, "UPDATE sessions SET input_tokens = 0, output_tokens = 0, cost = 0 WHERE id = ?", id)
+	if err != nil {
+		return err
+	}
+	rowsAffected, err := res.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if rowsAffected == 0 {
+		return ErrNotFound
+	}
+
+	// Deleting the parent's items drops the 'subsession' link rows; the
+	// sub-session rows themselves are then orphaned, so remove them too.
+	// The ON DELETE CASCADE on session_items.session_id cleans up their
+	// items in turn.
+	if _, err := tx.ExecContext(ctx,
+		"DELETE FROM sessions WHERE parent_id = ?", id); err != nil {
+		return err
+	}
+	if _, err := tx.ExecContext(ctx,
+		"DELETE FROM session_items WHERE session_id = ?", id); err != nil {
+		return err
+	}
+
+	return tx.Commit()
 }
 
 // UpdateSession updates an existing session's metadata, or creates it if it doesn't exist (upsert).

--- a/pkg/session/store_test.go
+++ b/pkg/session/store_test.go
@@ -320,6 +320,93 @@ func TestBranchSessionClonesSubSession(t *testing.T) {
 	assert.Equal(t, "Sub message", subItem.SubSession.Messages[0].Message.Message.Content)
 }
 
+// TestClearSessionHistorySQLite verifies that clearing a session drops its
+// items and resets counters while keeping the session row, atomically, and
+// removes any sub-sessions.
+func TestClearSessionHistorySQLite(t *testing.T) {
+	t.Parallel()
+
+	tempDB := filepath.Join(t.TempDir(), "test_clear_history.db")
+	store, err := NewSQLiteSessionStore(t.Context(), tempDB)
+	require.NoError(t, err)
+	defer store.(*SQLiteSessionStore).Close()
+
+	subSession := &Session{
+		ID:        "clear-sub-session",
+		CreatedAt: time.Now(),
+		Messages:  []Item{NewMessageItem(UserMessage("Sub message"))},
+	}
+	sess := &Session{
+		ID:           "clear-session",
+		Title:        "Keep me",
+		WorkingDir:   "/tmp/work",
+		InputTokens:  10,
+		OutputTokens: 5,
+		Cost:         1.5,
+		CreatedAt:    time.Now(),
+		Messages: []Item{
+			NewMessageItem(UserMessage("Start")),
+			NewSubSessionItem(subSession),
+		},
+	}
+	require.NoError(t, store.AddSession(t.Context(), sess))
+
+	require.NoError(t, store.ClearSessionHistory(t.Context(), sess.ID))
+
+	// The session row survives with metadata intact but no items and reset counters.
+	loaded, err := store.GetSession(t.Context(), sess.ID)
+	require.NoError(t, err)
+	assert.Empty(t, loaded.Messages)
+	assert.Equal(t, "Keep me", loaded.Title)
+	assert.Equal(t, "/tmp/work", loaded.WorkingDir)
+	assert.Zero(t, loaded.InputTokens)
+	assert.Zero(t, loaded.OutputTokens)
+	assert.Zero(t, loaded.Cost)
+
+	// The sub-session row is gone too.
+	_, err = store.GetSession(t.Context(), subSession.ID)
+	assert.ErrorIs(t, err, ErrNotFound)
+}
+
+func TestClearSessionHistoryNotFound(t *testing.T) {
+	t.Parallel()
+
+	tempDB := filepath.Join(t.TempDir(), "test_clear_missing.db")
+	store, err := NewSQLiteSessionStore(t.Context(), tempDB)
+	require.NoError(t, err)
+	defer store.(*SQLiteSessionStore).Close()
+
+	require.ErrorIs(t, store.ClearSessionHistory(t.Context(), "does-not-exist"), ErrNotFound)
+	require.ErrorIs(t, store.ClearSessionHistory(t.Context(), ""), ErrEmptyID)
+}
+
+func TestClearSessionHistoryInMemory(t *testing.T) {
+	t.Parallel()
+
+	store := NewInMemorySessionStore()
+	sess := &Session{
+		ID:           "mem-clear",
+		Title:        "Keep me",
+		InputTokens:  7,
+		OutputTokens: 3,
+		CreatedAt:    time.Now(),
+		Messages:     []Item{NewMessageItem(UserMessage("hello"))},
+	}
+	require.NoError(t, store.AddSession(t.Context(), sess))
+
+	require.NoError(t, store.ClearSessionHistory(t.Context(), sess.ID))
+
+	loaded, err := store.GetSession(t.Context(), sess.ID)
+	require.NoError(t, err)
+	assert.Empty(t, loaded.Messages)
+	assert.Equal(t, "Keep me", loaded.Title)
+	assert.Zero(t, loaded.InputTokens)
+	assert.Zero(t, loaded.OutputTokens)
+
+	require.ErrorIs(t, store.ClearSessionHistory(t.Context(), "missing"), ErrNotFound)
+	require.ErrorIs(t, store.ClearSessionHistory(t.Context(), ""), ErrEmptyID)
+}
+
 func TestStoreAgentNameJSON(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
The embedded Gordon assistant (Docker Sandboxes) advertised `/new`, `/compact`, and `/usage` slash commands via `emitAvailableCommands`, but the ACP agent's `Prompt` handler never intercepted them — it forwarded them to the LLM as plain text. The result was that `/new` only cleared the client's transcript view; the persisted session in the SQLite store kept all messages and reloaded them via `ResumeSession` when the sandbox or Gordon reopened, making the clear feel like it never happened.

This change intercepts all three commands agent-side before they reach the LLM. `/new` now resets the conversation both in memory via a new lock-safe `session.Session.ResetHistory()` and in the store via a new atomic `Store.ClearSessionHistory` method — a SQLite transaction that resets token/cost counters and drops sub-sessions and session items while preserving the session row itself; an in-memory equivalent is included and the remote store stubs it as unsupported. `/compact` mirrors `SessionSummaryEvent` and `TokenUsageEvent` back to the store (the direct `Summarize` path bypasses the persistence observer that `RunStream` wires in) and only reports success when a summary was actually applied. Command interception runs under a cancellable context registered on the session so that ACP `Cancel` and `CloseSession` can interrupt a long `/compact`. The command parser also rejects prompts that mix a slash word with non-text content, so an attachment next to `/new` is not misread as a command.

New store-level and ACP-level tests cover the happy paths and the no-op case for sessions that have never been persisted.