### PR TITLE
chore: replace arduino/setup-task with go-task/setup-task

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
           cache-dependency-path: go.sum
 
       - name: Install Task
-        uses: arduino/setup-task@b91d5d2c96a56797b48ac1e0e89220bf64044611 # v2.0.0
+        uses: go-task/setup-task@01a4adf9db2d14c1de7a560f09170b6e0df736aa # v2.1.0
         with:
           version: 3.51.1
 

--- a/.github/workflows/update-models.yml
+++ b/.github/workflows/update-models.yml
@@ -27,7 +27,7 @@ jobs:
           cache-dependency-path: go.sum
 
       - name: Install Task
-        uses: arduino/setup-task@b91d5d2c96a56797b48ac1e0e89220bf64044611 # v2.0.0
+        uses: go-task/setup-task@01a4adf9db2d14c1de7a560f09170b6e0df736aa # v2.1.0
         with:
           version: 3.51.1
 


### PR DESCRIPTION
> 🤖 **Automated implementer agent** — *this comment was posted by the implementer bot from Docker Agentic Platform, not by a human developer*

Replace the unofficial `arduino/setup-task` action with the official `go-task/setup-task` action in both CI workflow files. Also bumps the pinned version from v2.0.0 to the latest release, v2.1.0 (`01a4adf9db2d14c1de7a560f09170b6e0df736aa`).

**Files changed:** `.github/workflows/ci.yml`, `.github/workflows/update-models.yml`

**Testing:** `go build ./...` succeeds; `scripts/workflow-lint.sh` (checks SHA pinning, concurrency blocks, broken payload refs) passes clean.