### PR TITLE
fix(cli): match command guidance to invocation mode

### DIFF
--- a/cmd/root/alias.go
+++ b/cmd/root/alias.go
@@ -12,6 +12,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/docker/docker-agent/pkg/cli"
+	"github.com/docker/docker-agent/pkg/cli/invocation"
 	"github.com/docker/docker-agent/pkg/config"
 	latestcfg "github.com/docker/docker-agent/pkg/config/latest"
 	pathx "github.com/docker/docker-agent/pkg/path"
@@ -201,9 +202,9 @@ func runAliasAddCommand(cmd *cobra.Command, args []string, flags *aliasAddFlags)
 	}
 
 	if name == "default" {
-		out.Printf("\nYou can now run: docker agent run %s (or even docker agent run)\n", name)
+		out.Printf("\nYou can now run: %s run %s (or even %s run)\n", invocation.DockerAgent(), name, invocation.DockerAgent())
 	} else {
-		out.Printf("\nYou can now run: docker agent run %s\n", name)
+		out.Printf("\nYou can now run: %s run %s\n", invocation.DockerAgent(), name)
 	}
 
 	return nil
@@ -250,7 +251,7 @@ func runAliasListCommand(cmd *cobra.Command, args []string, asJSON bool) (comman
 
 	if len(allAliases) == 0 {
 		out.Println("No aliases registered.")
-		out.Println("\nCreate an alias with: docker agent alias add <name> <agent-path>")
+		out.Printf("\nCreate an alias with: %s alias add <name> <agent-path>\n", invocation.DockerAgent())
 		return nil
 	}
 
@@ -291,7 +292,7 @@ func runAliasListCommand(cmd *cobra.Command, args []string, asJSON bool) (comman
 		}
 	}
 
-	out.Println("\nRun an alias with: docker agent run <alias>")
+	out.Printf("\nRun an alias with: %s run <alias>\n", invocation.DockerAgent())
 
 	return nil
 }

--- a/cmd/root/doctor.go
+++ b/cmd/root/doctor.go
@@ -15,6 +15,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/docker/docker-agent/pkg/chatgpt"
+	"github.com/docker/docker-agent/pkg/cli/invocation"
 	"github.com/docker/docker-agent/pkg/codingharness"
 	"github.com/docker/docker-agent/pkg/config"
 	"github.com/docker/docker-agent/pkg/config/latest"
@@ -290,8 +291,8 @@ func (f *doctorFlags) buildReport(ctx context.Context, agentRef string) (*doctor
 		if environment.IsTrustedDockerURL(f.runConfig.ModelsGateway) {
 			if _, ok := findSource(ctx, sources, environment.DockerDesktopTokenEnv); !ok {
 				autoStatus.Usable = false
-				autoIssues = append(autoIssues,
-					"the models gateway requires Docker Desktop sign-in and no DOCKER_TOKEN was found; sign in to Docker Desktop (check with `docker agent debug auth`)")
+				autoIssues = append(autoIssues, fmt.Sprintf(
+					"the models gateway requires Docker Desktop sign-in and no DOCKER_TOKEN was found; sign in to Docker Desktop (check with `%s debug auth`)", invocation.DockerAgent()))
 			}
 		}
 
@@ -306,8 +307,8 @@ func (f *doctorFlags) buildReport(ctx context.Context, agentRef string) (*doctor
 		case dmrDown:
 			autoStatus.Usable = false
 			autoIssues = append(autoIssues, fmt.Sprintf(
-				"no usable model: no provider credential was found and Docker Model Runner is %s; run `docker agent setup`, or set an API key for one of the providers above (%s) or install Docker Model Runner (%s)",
-				describeDMRStatus(report.DMR.Status), environment.SecretsDocsURL, dmrDocsURL))
+				"no usable model: no provider credential was found and Docker Model Runner is %s; run `%s setup`, or set an API key for one of the providers above (%s) or install Docker Model Runner (%s)",
+				describeDMRStatus(report.DMR.Status), invocation.DockerAgent(), environment.SecretsDocsURL, dmrDocsURL))
 		case !slices.Contains(dmrModels, auto.Model):
 			autoStatus.Note = fmt.Sprintf("not pulled yet; run `docker model pull %s` or let the first run pull it", auto.Model)
 		}
@@ -485,7 +486,7 @@ func (f *doctorFlags) listDMRModels(ctx context.Context) ([]string, error) {
 // the rest at their API-key env var.
 func providerCredentialHint(provider, envVar string) string {
 	if provider == chatgpt.ProviderName {
-		return "sign in with `docker agent setup` (pick chatgpt) or set " + envVar
+		return fmt.Sprintf("sign in with `%s setup` (pick chatgpt) or set %s", invocation.DockerAgent(), envVar)
 	}
 	return "set " + envVar
 }

--- a/cmd/root/doctor_test.go
+++ b/cmd/root/doctor_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/docker/docker-agent/pkg/cli/invocation"
 	"github.com/docker/docker-agent/pkg/codingharness"
 	"github.com/docker/docker-agent/pkg/config"
 	"github.com/docker/docker-agent/pkg/config/latest"
@@ -130,7 +131,7 @@ func TestDoctorCommand_ChatGPTDefaultModelWithoutLoginSuggestsSignIn(t *testing.
 
 	require.Error(t, err, "a default model without credentials is an issue")
 	assert.Regexp(t, `chatgpt\s+not set\s+CHATGPT_OAUTH_TOKEN`, output)
-	assert.Contains(t, output, "sign in with `docker agent setup` (pick chatgpt) or set CHATGPT_OAUTH_TOKEN")
+	assert.Contains(t, output, "sign in with `"+invocation.DockerAgent()+" setup` (pick chatgpt) or set CHATGPT_OAUTH_TOKEN")
 }
 
 func TestDoctorCommand_EmptyValueIsNotACredential(t *testing.T) {

--- a/cmd/root/models.go
+++ b/cmd/root/models.go
@@ -16,6 +16,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/docker/docker-agent/pkg/cli"
+	"github.com/docker/docker-agent/pkg/cli/invocation"
 	"github.com/docker/docker-agent/pkg/config"
 	"github.com/docker/docker-agent/pkg/config/latest"
 	"github.com/docker/docker-agent/pkg/environment"
@@ -73,11 +74,11 @@ func newModelsCmd(opts ...modelsCmdOption) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "models",
 		Short: "List available models",
-		Long: `List models available for use with --model flag.
+		Long: fmt.Sprintf(`List models available for use with --model flag.
 
-Shows models that can be passed to 'docker agent run --model' or
-'docker agent new --model'. By default shows models from providers
-you have credentials for. Use --all to include all providers.`,
+Shows models that can be passed to '%s run --model' or
+'%s new --model'. By default shows models from providers
+you have credentials for. Use --all to include all providers.`, invocation.DockerAgent(), invocation.DockerAgent()),
 		GroupID: "diagnose",
 	}
 
@@ -104,10 +105,10 @@ func newModelsListCmd(flags *modelsListFlags) *cobra.Command {
 		Use:     "list",
 		Aliases: []string{"ls"},
 		Short:   "List available models",
-		Example: `  docker agent models
-  docker agent models list --provider openai
-  docker agent models ls --all
-  docker agent models --format json`,
+		Example: `  docker-agent models
+  docker-agent models list --provider openai
+  docker-agent models ls --all
+  docker-agent models --format json`,
 		Args: cobra.NoArgs,
 		RunE: flags.runModelsListCommand,
 	}

--- a/cmd/root/new.go
+++ b/cmd/root/new.go
@@ -11,6 +11,7 @@ import (
 	"go.opentelemetry.io/otel"
 
 	"github.com/docker/docker-agent/pkg/app"
+	"github.com/docker/docker-agent/pkg/cli/invocation"
 	"github.com/docker/docker-agent/pkg/config"
 	"github.com/docker/docker-agent/pkg/creator"
 	"github.com/docker/docker-agent/pkg/runtime"
@@ -48,7 +49,7 @@ Optionally provide a description as an argument to skip the initial prompt.`,
 		RunE:    flags.runNewCommand,
 	}
 
-	cmd.PersistentFlags().StringVar(&flags.modelParam, "model", "", "Model to use, optionally as provider/model where provider is one of: anthropic, openai, google, dmr, or a custom provider from `docker agent setup`. If omitted, provider is auto-selected based on available credentials or gateway")
+	cmd.PersistentFlags().StringVar(&flags.modelParam, "model", "", "Model to use, optionally as provider/model where provider is one of: anthropic, openai, google, dmr, or a custom provider from `"+invocation.DockerAgent()+" setup`. If omitted, provider is auto-selected based on available credentials or gateway")
 	cmd.PersistentFlags().IntVar(&flags.maxIterationsParam, "max-iterations", 0, "Maximum number of agentic loop iterations to prevent infinite loops (default: 20 for DMR, unlimited for other providers)")
 	addRuntimeConfigFlags(cmd, &flags.runConfig)
 

--- a/cmd/root/root.go
+++ b/cmd/root/root.go
@@ -16,6 +16,7 @@ import (
 	"github.com/docker/cli/cli/command"
 	"github.com/spf13/cobra"
 
+	"github.com/docker/docker-agent/pkg/cli/invocation"
 	"github.com/docker/docker-agent/pkg/feedback"
 	"github.com/docker/docker-agent/pkg/logging"
 	"github.com/docker/docker-agent/pkg/paths"
@@ -56,9 +57,9 @@ func NewRootCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "docker-agent",
 		Short: "Docker AI Agent Runner",
-		Long: `Docker AI Agent Runner.
+		Long: fmt.Sprintf(`Docker AI Agent Runner.
 
-New to docker agent? Take the hands-on tour: docker agent getting-started`,
+New to docker agent? Take the hands-on tour: %s getting-started`, invocation.DockerAgent()),
 		Example: `  docker-agent run
   docker-agent run ./agent.yaml`,
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/root/sandbox.go
+++ b/cmd/root/sandbox.go
@@ -17,6 +17,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
+	"github.com/docker/docker-agent/pkg/cli/invocation"
 	"github.com/docker/docker-agent/pkg/config"
 	latestcfg "github.com/docker/docker-agent/pkg/config/latest"
 	"github.com/docker/docker-agent/pkg/environment"
@@ -568,7 +569,7 @@ func printToolInstallAllowance(w io.Writer, kitResult *kit.Result) {
 		fmt.Fprintf(w, "  ! %s (using fallback host set)\n", e.Error())
 	}
 	if len(kitResult.ToolInstallHostsResolutionErr) > 0 {
-		fmt.Fprintln(w, "  hint: persist a missing host with `docker agent sandbox allow <host>`")
+		fmt.Fprintf(w, "  hint: persist a missing host with `%s sandbox allow <host>`\n", invocation.DockerAgent())
 	}
 }
 
@@ -595,7 +596,7 @@ func printUserSandboxAllowlist(w io.Writer, hosts []string) {
 	if len(hosts) == 0 {
 		return
 	}
-	fmt.Fprintf(w, "User sandbox allowlist: allowlisting %d host(s) from `docker agent sandbox allow`:\n", len(hosts))
+	fmt.Fprintf(w, "User sandbox allowlist: allowlisting %d host(s) from `%s sandbox allow`:\n", len(hosts), invocation.DockerAgent())
 	for _, h := range hosts {
 		fmt.Fprintf(w, "  - %s\n", h)
 	}

--- a/cmd/root/sandbox_cmd.go
+++ b/cmd/root/sandbox_cmd.go
@@ -8,6 +8,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/docker/docker-agent/pkg/cli"
+	"github.com/docker/docker-agent/pkg/cli/invocation"
 	"github.com/docker/docker-agent/pkg/telemetry"
 	"github.com/docker/docker-agent/pkg/userconfig"
 )
@@ -50,7 +51,7 @@ This is the recommended fix for "Blocked by network policy" 403s on a
 host the auto-installer can't infer (custom MCP endpoint, third-party
 API, registry not covered by the aqua resolver):
 
-  docker agent sandbox allow api.example.com`,
+  docker-agent sandbox allow api.example.com`,
 		Args: cobra.MinimumNArgs(1),
 		RunE: runSandboxAllowCommand,
 	}
@@ -150,7 +151,7 @@ func runSandboxListCommand(cmd *cobra.Command, args []string) (commandErr error)
 
 	if len(cfg.SandboxAllowlist) == 0 {
 		out.Println("Persistent sandbox allowlist is empty.")
-		out.Println("\nAdd a host with: docker agent sandbox allow <host>")
+		out.Printf("\nAdd a host with: %s sandbox allow <host>\n", invocation.DockerAgent())
 		return nil
 	}
 

--- a/cmd/root/sandbox_test.go
+++ b/cmd/root/sandbox_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/docker/docker-agent/pkg/cli/invocation"
 	"github.com/docker/docker-agent/pkg/sandbox/kit"
 )
 
@@ -290,7 +291,7 @@ func TestPrintToolInstallAllowance(t *testing.T) {
 			want: "Tool install: agent has at least one MCP/LSP toolset, allowlisting 1 package host(s) in the sandbox proxy:\n" +
 				"  - api.github.com\n" +
 				"  ! resolving install hosts for \"gopls\"@\"golang/tools@v0.21.0\": boom (using fallback host set)\n" +
-				"  hint: persist a missing host with `docker agent sandbox allow <host>`\n",
+				"  hint: persist a missing host with `" + invocation.DockerAgent() + " sandbox allow <host>`\n",
 			wantNot: []string{},
 		},
 	}

--- a/cmd/root/setup.go
+++ b/cmd/root/setup.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/docker/docker-agent/pkg/chatgpt"
 	"github.com/docker/docker-agent/pkg/cli"
+	"github.com/docker/docker-agent/pkg/cli/invocation"
 	"github.com/docker/docker-agent/pkg/codingharness"
 	"github.com/docker/docker-agent/pkg/config"
 	"github.com/docker/docker-agent/pkg/config/latest"
@@ -40,7 +41,7 @@ var errSetupCancelled = errors.New("setup cancelled")
 // errNoUsableModel is the concise error returned when the setup offer is
 // declined or cancelled: the full failure was already printed just above the
 // offer, so returning the original error would print it twice.
-var errNoUsableModel = errors.New("no usable model is configured; run `docker agent setup` or see `docker agent doctor`")
+var errNoUsableModel = invocationError("no usable model is configured; run `{{docker_agent_command}} setup` or see `{{docker_agent_command}} doctor`")
 
 // errClaudeHarnessConfigured ends an offered setup that took the Claude Code
 // harness path: the wizard configured an agent file for the external CLI,
@@ -48,7 +49,17 @@ var errNoUsableModel = errors.New("no usable model is configured; run `docker ag
 // never happened and must not exit as a success. The message stays concise:
 // the wizard already printed the agent file (or its content) and the exact
 // command to run.
-var errClaudeHarnessConfigured = errors.New("this run was not retried: setup configured a Claude Code harness agent; start it with the `docker agent run <file>` command shown above")
+var errClaudeHarnessConfigured = invocationError("this run was not retried: setup configured a Claude Code harness agent; start it with the `{{docker_agent_command}} run <file>` command shown above")
+
+// invocationError is a sentinel error whose message names the runnable
+// command for the current invocation mode. The {{docker_agent_command}}
+// placeholder (shared with pkg/creator/instructions.txt) is resolved at
+// Error() time so the mode is read when the message is rendered.
+type invocationError string
+
+func (e invocationError) Error() string {
+	return strings.ReplaceAll(string(e), "{{docker_agent_command}}", invocation.DockerAgent())
+}
 
 // setupResult reports what the wizard configured, so the caller that offered
 // setup after a failed run can retry with the new credential in place.
@@ -96,10 +107,11 @@ type setupWizard struct {
 }
 
 func newSetupCmd() *cobra.Command {
+	command := invocation.DockerAgent()
 	return &cobra.Command{
 		Use:   "setup",
 		Short: "Interactively set up a model (built-in provider, local, custom endpoint, or Claude Code)",
-		Long: `Set up a model for docker agent, interactively.
+		Long: fmt.Sprintf(`Set up a model for docker agent, interactively.
 
 Four paths:
   - Built-in cloud provider: pick a provider docker agent already knows
@@ -120,7 +132,7 @@ Four paths:
     credentials.
 
 Ends with the exact command to start chatting. Secret values are never
-printed. Check the result anytime with 'docker agent doctor'.`,
+printed. Check the result anytime with '%s doctor'.`, command),
 		Example:      `  docker-agent setup`,
 		GroupID:      "core",
 		Args:         cobra.NoArgs,
@@ -133,10 +145,10 @@ printed. Check the result anytime with 'docker agent doctor'.`,
 			}()
 
 			if !isatty.IsTerminal(os.Stdin.Fd()) || !isatty.IsTerminal(os.Stdout.Fd()) {
-				return fmt.Errorf("docker agent setup is interactive and needs a terminal\n"+
+				return fmt.Errorf("%s setup is interactive and needs a terminal\n"+
 					"Without one, set a provider API key directly (e.g. export ANTHROPIC_API_KEY=<value>)\n"+
 					"or pull a local model with `docker model pull ai/qwen3`.\n"+
-					"See %s for every secret source", environment.SecretsDocsURL)
+					"See %s for every secret source", command, environment.SecretsDocsURL)
 			}
 
 			wizard := newTerminalSetupWizard(cmd.InOrStdin(), cmd.OutOrStdout())
@@ -330,10 +342,10 @@ func (w *setupWizard) setupLocalModel(ctx context.Context) (*setupResult, error)
 	switch {
 	case errors.Is(err, dmr.ErrNotInstalled):
 		return nil, fmt.Errorf("cannot use a local model: Docker Model Runner is not installed.\n"+
-			"Install it (%s), then run `docker agent setup` again", dmrDocsURL)
+			"Install it (%s), then run `%s setup` again", dmrDocsURL, invocation.DockerAgent())
 	case err != nil:
 		return nil, fmt.Errorf("cannot use a local model: Docker Model Runner is not reachable: %w\n"+
-			"Start it (or install it: %s), then run `docker agent setup` again", err, dmrDocsURL)
+			"Start it (or install it: %s), then run `%s setup` again", err, dmrDocsURL, invocation.DockerAgent())
 	}
 
 	if len(models) > 0 {
@@ -509,7 +521,7 @@ func (w *setupWizard) promptCustomProviderModel(ctx context.Context, baseURL, ke
 		fmt.Fprintf(w.out, "The endpoint lists %d model(s):\n", len(models))
 		for i, m := range models {
 			if i == maxModelsShown {
-				fmt.Fprintf(w.out, "  ... and %d more (see `docker agent models`)\n", len(models)-maxModelsShown)
+				fmt.Fprintf(w.out, "  ... and %d more (see `%s models`)\n", len(models)-maxModelsShown, invocation.DockerAgent())
 				break
 			}
 			fmt.Fprintf(w.out, "  - %s\n", m)
@@ -566,8 +578,8 @@ func (w *setupWizard) setupClaudeHarness(ctx context.Context) (*setupResult, err
 	status := w.probeClaudeCLI(ctx)
 	if !status.Installed() {
 		return nil, fmt.Errorf("cannot use the Claude Code harness: the `claude` CLI was not found in PATH.\n"+
-			"Install Claude Code (%s) and log in with `%s`, then run `docker agent setup` again",
-			codingharness.ClaudeInstallDocsURL, codingharness.ClaudeLoginCommand)
+			"Install Claude Code (%s) and log in with `%s`, then run `%s setup` again",
+			codingharness.ClaudeInstallDocsURL, codingharness.ClaudeLoginCommand, invocation.DockerAgent())
 	}
 
 	if status.Authenticated() {
@@ -594,7 +606,7 @@ func (w *setupWizard) setupClaudeHarness(ctx context.Context) (*setupResult, err
 	fmt.Fprintln(w.out, "Heads-up: the harness runs the official `claude` CLI non-interactively with")
 	fmt.Fprintln(w.out, "its own tools and skips Claude Code's permission prompts")
 	fmt.Fprintln(w.out, "(--dangerously-skip-permissions). Use it in a repository you trust, and prefer")
-	fmt.Fprintln(w.out, "`docker agent run --worktree` to isolate its changes in a git worktree.")
+	fmt.Fprintf(w.out, "`%s run --worktree` to isolate its changes in a git worktree.\n", invocation.DockerAgent())
 	fmt.Fprintln(w.out, "`--sandbox` does not carry the `claude` CLI or its login into the sandbox;")
 	fmt.Fprintln(w.out, "use it only with a sandbox image that ships and authenticates the CLI.")
 
@@ -636,7 +648,7 @@ func (w *setupWizard) claudeLoginFlow(ctx context.Context, status codingharness.
 	answer = strings.TrimSpace(strings.ToLower(answer))
 	if answer != "y" && answer != "yes" {
 		return fmt.Errorf("the Claude Code CLI is not logged in.\n"+
-			"Run `%s` yourself, then run `docker agent setup` again", codingharness.ClaudeLoginCommand)
+			"Run `%s` yourself, then run `%s setup` again", codingharness.ClaudeLoginCommand, invocation.DockerAgent())
 	}
 
 	fmt.Fprintln(w.out)
@@ -646,9 +658,9 @@ func (w *setupWizard) claudeLoginFlow(ctx context.Context, status codingharness.
 
 	status = w.probeClaudeCLI(ctx)
 	if !status.Authenticated() {
-		return errors.New("the `claude` CLI still reports it is not logged in after the login attempt.\n" +
-			"Check `claude auth status` as the same OS user and environment that run docker agent,\n" +
-			"then run `docker agent setup` again")
+		return fmt.Errorf("the `claude` CLI still reports it is not logged in after the login attempt.\n"+
+			"Check `claude auth status` as the same OS user and environment that run docker agent,\n"+
+			"then run `%s setup` again", invocation.DockerAgent())
 	}
 
 	fmt.Fprintf(w.out, "Logged in (%s).\n", status.AuthSummary())
@@ -736,7 +748,7 @@ func (w *setupWizard) writeClaudeAgentFile(ctx context.Context, content []byte) 
 		answer = strings.TrimSpace(strings.ToLower(answer))
 		if answer != "y" && answer != "yes" {
 			fmt.Fprintf(w.out, "\nKeeping %s. Save this configuration to a file of your choice:\n\n%s\n", path, content)
-			fmt.Fprintln(w.out, "Then start it with `docker agent run <file>`.")
+			fmt.Fprintf(w.out, "Then start it with `%s run <file>`.\n", invocation.DockerAgent())
 			return "", nil
 		}
 	} else if !errors.Is(err, os.ErrNotExist) {
@@ -776,6 +788,7 @@ func atomicWriteFile(path string, content []byte) error {
 // printNextSteps ends the wizard with ready-to-copy commands.
 func (w *setupWizard) printNextSteps(result *setupResult) {
 	fmt.Fprintln(w.out)
+	command := invocation.DockerAgent()
 
 	// The harness runs through a generated agent file, not a --model flag:
 	// the harness model belongs to the external CLI, not to a docker agent
@@ -784,11 +797,11 @@ func (w *setupWizard) printNextSteps(result *setupResult) {
 		if result.AgentFile != "" {
 			fmt.Fprintln(w.out, "You're all set. Start the Claude Code agent with:")
 			fmt.Fprintln(w.out)
-			fmt.Fprintf(w.out, "  docker agent run %s\n", result.AgentFile)
+			fmt.Fprintf(w.out, "  %s run %s\n", command, result.AgentFile)
 			fmt.Fprintln(w.out)
-			fmt.Fprintf(w.out, "Check the harness anytime with `docker agent doctor %s`.\n", result.AgentFile)
+			fmt.Fprintf(w.out, "Check the harness anytime with `%s doctor %s`.\n", command, result.AgentFile)
 		} else {
-			fmt.Fprintln(w.out, "Check your setup anytime with `docker agent doctor <file>`.")
+			fmt.Fprintf(w.out, "Check your setup anytime with `%s doctor <file>`.\n", command)
 		}
 		return
 	}
@@ -800,29 +813,29 @@ func (w *setupWizard) printNextSteps(result *setupResult) {
 		if result.Model != "" {
 			fmt.Fprintln(w.out, "You're all set. Start chatting with:")
 			fmt.Fprintln(w.out)
-			fmt.Fprintf(w.out, "  docker agent run --model %s\n", result.Model)
+			fmt.Fprintf(w.out, "  %s run --model %s\n", command, result.Model)
 		} else {
 			fmt.Fprintf(w.out, "Provider %q is set up. List its models with:\n", result.ProviderName)
 			fmt.Fprintln(w.out)
-			fmt.Fprintf(w.out, "  docker agent models --provider %s\n", result.ProviderName)
+			fmt.Fprintf(w.out, "  %s models --provider %s\n", command, result.ProviderName)
 			fmt.Fprintln(w.out)
 			fmt.Fprintln(w.out, "Then start chatting with:")
 			fmt.Fprintln(w.out)
-			fmt.Fprintf(w.out, "  docker agent run --model %s/<model>\n", result.ProviderName)
+			fmt.Fprintf(w.out, "  %s run --model %s/<model>\n", command, result.ProviderName)
 		}
 		fmt.Fprintln(w.out)
-		fmt.Fprintln(w.out, "Check your setup anytime with `docker agent doctor`.")
+		fmt.Fprintf(w.out, "Check your setup anytime with `%s doctor`.\n", command)
 		return
 	}
 
 	fmt.Fprintln(w.out, "You're all set. Start chatting with:")
 	fmt.Fprintln(w.out)
-	fmt.Fprintln(w.out, "  docker agent run")
+	fmt.Fprintf(w.out, "  %s run\n", command)
 	fmt.Fprintln(w.out)
 	if result.Model != "" {
-		fmt.Fprintf(w.out, "Or pin the model explicitly: docker agent run --model %s\n", result.Model)
+		fmt.Fprintf(w.out, "Or pin the model explicitly: %s run --model %s\n", command, result.Model)
 	}
-	fmt.Fprintln(w.out, "Check your setup anytime with `docker agent doctor`.")
+	fmt.Fprintf(w.out, "Check your setup anytime with `%s doctor`.\n", command)
 }
 
 // promptChoice reads a 1-based menu choice, re-asking on invalid input. An

--- a/cmd/root/setup_test.go
+++ b/cmd/root/setup_test.go
@@ -13,16 +13,45 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/docker/cli/cli-plugins/metadata"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/docker/docker-agent/pkg/chatgpt"
+	"github.com/docker/docker-agent/pkg/cli/invocation"
 	"github.com/docker/docker-agent/pkg/codingharness"
 	"github.com/docker/docker-agent/pkg/config"
 	"github.com/docker/docker-agent/pkg/config/latest"
 	"github.com/docker/docker-agent/pkg/environment"
 	"github.com/docker/docker-agent/pkg/model/provider/dmr"
 )
+
+func TestSetupWizard_CommandsMatchInvocation(t *testing.T) {
+	tests := []struct {
+		name        string
+		originalCLI string
+		command     string
+		unexpected  string
+	}{
+		{name: "standalone", command: "docker-agent", unexpected: "docker agent run"},
+		{name: "plugin", originalCLI: "docker", command: "docker agent", unexpected: "docker-agent run"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Setenv(metadata.ReexecEnvvar, test.originalCLI)
+
+			var out bytes.Buffer
+			wizard := &setupWizard{out: &out}
+			wizard.printNextSteps(&setupResult{ClaudeHarness: true, AgentFile: "claude-code-agent.yaml"})
+
+			assert.Contains(t, out.String(), test.command+" run claude-code-agent.yaml")
+			assert.Contains(t, out.String(), test.command+" doctor claude-code-agent.yaml")
+			assert.NotContains(t, out.String(), test.unexpected)
+			assert.Contains(t, errClaudeHarnessConfigured.Error(), test.command+" run <file>")
+		})
+	}
+}
 
 // fakeSecretStore records stored secrets in memory and can be made to fail.
 type fakeSecretStore struct {
@@ -103,9 +132,9 @@ func TestSetupWizard_CloudPathStoresKey(t *testing.T) {
 	assert.Contains(t, output, "anthropic credential", "the built-in prompt asks for a credential")
 	assert.NotContains(t, output, "anthropic API key", "not every built-in credential is an API key (docker/docker-agent#3805)")
 	assert.Contains(t, output, "Stored ANTHROPIC_API_KEY in the config-env-file (fake).")
-	assert.Contains(t, output, "docker agent run")
+	assert.Contains(t, output, invocation.DockerAgent()+" run")
 	assert.Contains(t, output, "--model anthropic/claude-sonnet-4-6")
-	assert.Contains(t, output, "docker agent doctor")
+	assert.Contains(t, output, invocation.DockerAgent()+" doctor")
 	assert.NotContains(t, output, "sk-cloud-key", "secret values must never be printed")
 }
 
@@ -236,7 +265,7 @@ func TestSetupWizard_LocalPathWithPulledModels(t *testing.T) {
 	assert.Empty(t, *pulled, "no pull needed when a model is already available")
 	assert.Equal(t, "dmr/ai/smollm2", result.Model)
 	assert.Contains(t, out.String(), "- ai/smollm2")
-	assert.Contains(t, out.String(), "docker agent run")
+	assert.Contains(t, out.String(), invocation.DockerAgent()+" run")
 }
 
 func TestSetupWizard_LocalPathPullsDefaultModel(t *testing.T) {
@@ -382,7 +411,7 @@ func TestSetupWizard_CustomPathSavesProviderAndKey(t *testing.T) {
 
 	output := out.String()
 	assert.Contains(t, output, "corp-model-a")
-	assert.Contains(t, output, "docker agent run --model myprovider/corp-model-a")
+	assert.Contains(t, output, invocation.DockerAgent()+" run --model myprovider/corp-model-a")
 	assert.NotContains(t, output, "sk-custom-key", "secret values must never be printed")
 }
 
@@ -409,8 +438,8 @@ func TestSetupWizard_CustomPathWithoutKeyOrModels(t *testing.T) {
 
 	output := out.String()
 	assert.Contains(t, output, "Could not list models from the endpoint")
-	assert.Contains(t, output, "docker agent models --provider local-vllm")
-	assert.Contains(t, output, "docker agent run --model local-vllm/<model>")
+	assert.Contains(t, output, invocation.DockerAgent()+" models --provider local-vllm")
+	assert.Contains(t, output, invocation.DockerAgent()+" run --model local-vllm/<model>")
 }
 
 func TestSetupWizard_CustomPathValidatesNameAndURL(t *testing.T) {
@@ -534,8 +563,8 @@ func TestSetupWizard_ClaudeHarnessAlreadyLoggedIn(t *testing.T) {
 	assert.Contains(t, output, "--dangerously-skip-permissions")
 	assert.Contains(t, output, "--worktree")
 	assert.Contains(t, output, "`--sandbox` does not carry the `claude` CLI or its login", "sandbox mode must not be presented as harness isolation")
-	assert.Contains(t, output, "docker agent run "+result.AgentFile)
-	assert.Contains(t, output, "docker agent doctor "+result.AgentFile)
+	assert.Contains(t, output, invocation.DockerAgent()+" run "+result.AgentFile)
+	assert.Contains(t, output, invocation.DockerAgent()+" doctor "+result.AgentFile)
 	assert.NotContains(t, output, "--model", "the harness model is not a docker agent provider model")
 }
 
@@ -718,7 +747,7 @@ func TestSetupWizard_ClaudeHarnessDoesNotOverwriteWithoutConfirmation(t *testing
 			assert.Contains(t, output, "already exists")
 			assert.Contains(t, output, "type: claude-code")
 			assert.Contains(t, output, "effort: medium")
-			assert.Contains(t, output, "docker agent run")
+			assert.Contains(t, output, invocation.DockerAgent()+" run")
 		})
 	}
 }
@@ -763,7 +792,7 @@ func TestCompleteOfferedSetup_ClaudeHarnessFailsWithoutRetry(t *testing.T) {
 
 		require.ErrorIs(t, err, errClaudeHarnessConfigured)
 		assert.False(t, retried, "the old configuration must not be retried")
-		assert.Contains(t, err.Error(), "docker agent run")
+		assert.Contains(t, err.Error(), invocation.DockerAgent()+" run")
 		assert.Empty(t, out.String(), "no retry banner when nothing is retried")
 	}
 }

--- a/cmd/root/toolsets.go
+++ b/cmd/root/toolsets.go
@@ -30,8 +30,8 @@ Each type can be referenced under 'toolsets:' in an agent YAML file, for example
     - type: shell`,
 		GroupID: "diagnose",
 		Args:    cobra.NoArgs,
-		Example: `  docker agent toolsets
-  docker agent toolsets --format json`,
+		Example: `  docker-agent toolsets
+  docker-agent toolsets --format json`,
 		RunE: flags.run,
 	}
 

--- a/cmd/root/version.go
+++ b/cmd/root/version.go
@@ -1,10 +1,10 @@
 package root
 
 import (
-	"github.com/docker/cli/cli-plugins/plugin"
 	"github.com/spf13/cobra"
 
 	"github.com/docker/docker-agent/pkg/cli"
+	"github.com/docker/docker-agent/pkg/cli/invocation"
 	"github.com/docker/docker-agent/pkg/telemetry"
 	"github.com/docker/docker-agent/pkg/version"
 )
@@ -24,13 +24,6 @@ func runVersionCommand(cmd *cobra.Command, args []string) {
 
 	out := cli.NewPrinter(cmd.OutOrStdout())
 
-	commandName := "docker-agent"
-	if cmd.Parent() != nil {
-		commandName = cmd.Parent().Name()
-	}
-	if !plugin.RunningStandalone() {
-		commandName = "docker " + commandName
-	}
-	out.Printf("%s version %s\n", commandName, version.Version)
+	out.Printf("%s version %s\n", invocation.DockerAgent(), version.Version)
 	out.Printf("Commit: %s\n", version.Commit)
 }

--- a/e2e/tui/tour_test.go
+++ b/e2e/tui/tour_test.go
@@ -5,6 +5,7 @@ import (
 
 	tea "charm.land/bubbletea/v2"
 
+	"github.com/docker/docker-agent/pkg/cli/invocation"
 	"github.com/docker/docker-agent/pkg/tui"
 	"github.com/docker/docker-agent/pkg/tui/tuitest"
 )
@@ -32,7 +33,7 @@ func TestTour_WalkThrough(t *testing.T) {
 		WaitFor(tuitest.Contains("Slash commands")).
 		Enter(). // skip step 4 (slash commands)
 		WaitFor(tuitest.Contains("Agents are just YAML")).
-		WaitFor(tuitest.Contains("docker agent new")).
+		WaitFor(tuitest.Contains(invocation.DockerAgent() + " new")).
 		Enter(). // read step
 		WaitFor(tuitest.Contains("You're all set")).
 		Enter(). // finish

--- a/pkg/chatgpt/chatgpt_test.go
+++ b/pkg/chatgpt/chatgpt_test.go
@@ -13,6 +13,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/docker/docker-agent/pkg/cli/invocation"
 )
 
 // makeJWT builds an unsigned JWT carrying the given claims. Signature
@@ -214,7 +216,7 @@ func TestAccessToken_RefreshRejectedSuggestsSigningInAgain(t *testing.T) {
 	})
 
 	_, err := AccessToken(t.Context())
-	require.ErrorContains(t, err, "docker agent setup")
+	require.ErrorContains(t, err, invocation.DockerAgent()+" setup")
 }
 
 func TestAccessToken_ExpiredWithoutRefreshToken(t *testing.T) {

--- a/pkg/chatgpt/token.go
+++ b/pkg/chatgpt/token.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/golang-jwt/jwt/v5"
 
+	"github.com/docker/docker-agent/pkg/cli/invocation"
 	"github.com/docker/docker-agent/pkg/httpclient"
 )
 
@@ -93,8 +94,8 @@ func refreshCredentials(ctx context.Context, creds *Credentials) (*Credentials, 
 	if resp.StatusCode != http.StatusOK {
 		detail, _ := io.ReadAll(io.LimitReader(resp.Body, 2048))
 		if resp.StatusCode == http.StatusBadRequest || resp.StatusCode == http.StatusUnauthorized {
-			return nil, fmt.Errorf("the ChatGPT session is no longer valid (HTTP %d: %s); sign in again with `docker agent setup`",
-				resp.StatusCode, strings.TrimSpace(string(detail)))
+			return nil, fmt.Errorf("the ChatGPT session is no longer valid (HTTP %d: %s); sign in again with `%s setup`",
+				resp.StatusCode, strings.TrimSpace(string(detail)), invocation.DockerAgent())
 		}
 		return nil, fmt.Errorf("failed to refresh the ChatGPT access token: HTTP %d: %s", resp.StatusCode, strings.TrimSpace(string(detail)))
 	}

--- a/pkg/cli/invocation/invocation.go
+++ b/pkg/cli/invocation/invocation.go
@@ -1,0 +1,11 @@
+package invocation
+
+import "github.com/docker/cli/cli-plugins/plugin"
+
+// DockerAgent returns the command users can run for the current invocation mode.
+func DockerAgent() string {
+	if plugin.RunningStandalone() {
+		return "docker-agent"
+	}
+	return "docker agent"
+}

--- a/pkg/cli/invocation/invocation_test.go
+++ b/pkg/cli/invocation/invocation_test.go
@@ -1,0 +1,26 @@
+package invocation
+
+import (
+	"testing"
+
+	"github.com/docker/cli/cli-plugins/metadata"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDockerAgent(t *testing.T) {
+	tests := []struct {
+		name        string
+		originalCLI string
+		expected    string
+	}{
+		{name: "standalone", expected: "docker-agent"},
+		{name: "plugin", originalCLI: "docker", expected: "docker agent"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Setenv(metadata.ReexecEnvvar, test.originalCLI)
+			assert.Equal(t, test.expected, DockerAgent())
+		})
+	}
+}

--- a/pkg/cli/runner.go
+++ b/pkg/cli/runner.go
@@ -15,6 +15,7 @@ import (
 	"github.com/mattn/go-isatty"
 
 	"github.com/docker/docker-agent/pkg/chat"
+	"github.com/docker/docker-agent/pkg/cli/invocation"
 	"github.com/docker/docker-agent/pkg/input"
 	"github.com/docker/docker-agent/pkg/runtime"
 	"github.com/docker/docker-agent/pkg/runtime/jscommands"
@@ -284,7 +285,7 @@ func Run(ctx context.Context, out *Printer, cfg Config, rt runtime.Runtime, sess
 			return fmt.Errorf("failed to read from stdin: %w", err)
 		}
 		if strings.TrimSpace(string(buf)) == "" {
-			return errors.New(`no message received on stdin: with "-" the prompt is read from stdin, e.g. echo "Hello" | docker agent run <agent> -`)
+			return fmt.Errorf(`no message received on stdin: with "-" the prompt is read from stdin, e.g. echo "Hello" | %s run <agent> -`, invocation.DockerAgent())
 		}
 
 		if err := oneLoop(string(buf), os.Stdin); err != nil {
@@ -306,7 +307,7 @@ func Run(ctx context.Context, out *Printer, cfg Config, rt runtime.Runtime, sess
 		// Exiting 0 with no output on empty input (e.g. bare `docker agent`
 		// in CI) would be a silent no-op; fail with the next steps instead.
 		if strings.TrimSpace(string(buf)) == "" {
-			return errors.New("no message provided and stdin is not a terminal: pass a message (docker agent run <agent> \"<message>\"), pipe one on stdin, or run from an interactive terminal to use the chat UI")
+			return fmt.Errorf("no message provided and stdin is not a terminal: pass a message (%s run <agent> \"<message>\"), pipe one on stdin, or run from an interactive terminal to use the chat UI", invocation.DockerAgent())
 		}
 
 		if err := oneLoop(string(buf), os.Stdin); err != nil {

--- a/pkg/config/auto.go
+++ b/pkg/config/auto.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/docker/docker-agent/pkg/chatgpt"
+	"github.com/docker/docker-agent/pkg/cli/invocation"
 	"github.com/docker/docker-agent/pkg/config/latest"
 	"github.com/docker/docker-agent/pkg/environment"
 	"github.com/docker/docker-agent/pkg/model/provider"
@@ -52,7 +53,7 @@ var cloudProviders = []providerConfig{
 	// setup` sign-in, surfaced as a virtual env var by the "chatgpt-login"
 	// source. It is ordered after openai so adding a ChatGPT sign-in never
 	// changes auto-selection for users that already export OPENAI_API_KEY.
-	{"chatgpt", []string{chatgpt.TokenEnvVar}, "sign in with your ChatGPT account: `docker agent setup`", ""},
+	{"chatgpt", []string{chatgpt.TokenEnvVar}, "ChatGPT account sign-in", ""},
 	{"github-copilot", []string{"GITHUB_TOKEN", "GH_TOKEN"}, "GITHUB_TOKEN (or GH_TOKEN)", ""},
 	{"google", []string{
 		"GOOGLE_API_KEY",
@@ -122,7 +123,11 @@ type pullErrorSummarizer interface {
 func (e *AutoModelFallbackError) Error() string {
 	var hints []string
 	for _, p := range cloudProviders {
-		hints = append(hints, fmt.Sprintf("    - %s: %s", p.name, p.hint))
+		hint := p.hint
+		if p.name == "chatgpt" {
+			hint = fmt.Sprintf("sign in with your ChatGPT account: `%s setup`", invocation.DockerAgent())
+		}
+		hints = append(hints, fmt.Sprintf("    - %s: %s", p.name, hint))
 	}
 
 	var b strings.Builder
@@ -135,7 +140,7 @@ func (e *AutoModelFallbackError) Error() string {
 		}
 	}
 	b.WriteString("No model is currently available.\n\nTo fix this, you can:\n")
-	b.WriteString("  - Run `docker agent setup` to configure a provider API key or a local model interactively\n")
+	fmt.Fprintf(&b, "  - Run `%s setup` to configure a provider API key or a local model interactively\n", invocation.DockerAgent())
 	b.WriteString("  - Pull a Docker Model Runner model, e.g. `docker model pull ai/qwen3`\n")
 	b.WriteString("  - Install Docker Model Runner: https://docs.docker.com/ai/model-runner/get-started/\n")
 	b.WriteString("  - Configure an API key for a cloud provider:\n")

--- a/pkg/config/auto_test.go
+++ b/pkg/config/auto_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/docker/docker-agent/pkg/chatgpt"
+	"github.com/docker/docker-agent/pkg/cli/invocation"
 	"github.com/docker/docker-agent/pkg/config/latest"
 	"github.com/docker/docker-agent/pkg/environment"
 )
@@ -1066,7 +1067,7 @@ func TestAutoModelFallbackError(t *testing.T) {
 		err := &AutoModelFallbackError{}
 		msg := err.Error()
 		assert.Contains(t, msg, "No model is currently available")
-		assert.Contains(t, msg, "docker agent setup")
+		assert.Contains(t, msg, invocation.DockerAgent()+" setup")
 		assert.Contains(t, msg, "docker model pull")
 		assert.Contains(t, msg, "ANTHROPIC_API_KEY")
 		assert.Contains(t, msg, environment.ModelSetupDocsURL)

--- a/pkg/config/first_available.go
+++ b/pkg/config/first_available.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"strings"
 
+	"github.com/docker/docker-agent/pkg/cli/invocation"
 	"github.com/docker/docker-agent/pkg/config/latest"
 	"github.com/docker/docker-agent/pkg/environment"
 	modelprovider "github.com/docker/docker-agent/pkg/model/provider"
@@ -191,7 +192,7 @@ func (e *firstAvailableMissingEnvError) Error() string {
 	}
 	msg.WriteString("\n")
 	msg.WriteString(environment.SecretSourcesHelp(example))
-	msg.WriteString("\nOr run `docker agent setup` to configure a provider or local model interactively.\n")
+	fmt.Fprintf(&msg, "\nOr run `%s setup` to configure a provider or local model interactively.\n", invocation.DockerAgent())
 	fmt.Fprintf(&msg, "Step-by-step model setup (API key or local): %s\n", environment.ModelSetupDocsURL)
 
 	return msg.String()

--- a/pkg/creator/agent.go
+++ b/pkg/creator/agent.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/goccy/go-yaml"
 
+	"github.com/docker/docker-agent/pkg/cli/invocation"
 	"github.com/docker/docker-agent/pkg/config"
 	"github.com/docker/docker-agent/pkg/config/latest"
 	"github.com/docker/docker-agent/pkg/team"
@@ -68,7 +69,7 @@ func buildInstructions(ctx context.Context, runConfig *config.RuntimeConfig, mod
 	usableProviders := config.AvailableProviders(ctx, runConfig.ModelsGateway, runConfig.EnvProvider())
 
 	var b strings.Builder
-	b.WriteString(agentBuilderInstructions)
+	b.WriteString(strings.ReplaceAll(agentBuilderInstructions, "{{docker_agent_command}}", invocation.DockerAgent()))
 	b.WriteString("\n\nPreferred model providers to use: ")
 	b.WriteString(strings.Join(usableProviders, ", "))
 	b.WriteString(". You must always use one or more of the following model configurations: \n")
@@ -136,7 +137,7 @@ func appendCustomProviderInstructions(ctx context.Context, b *strings.Builder, r
 		}
 		fmt.Fprintf(b, "\t\tmodels:\n\t\t\t%s:\n\t\t\t\tprovider: %s\n\t\t\t\tmodel: %s\n", name, name, model)
 		if model == "REPLACE_WITH_MODEL_ID" {
-			fmt.Fprintf(b, "\t\tAsk the user which model ID to use with %q (they can list them with `docker agent models --provider %s`).\n", name, name)
+			fmt.Fprintf(b, "\t\tAsk the user which model ID to use with %q (they can list them with `%s models --provider %s`).\n", name, invocation.DockerAgent(), name)
 		}
 	}
 }

--- a/pkg/creator/agent_test.go
+++ b/pkg/creator/agent_test.go
@@ -1,11 +1,13 @@
 package creator
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/docker/docker-agent/pkg/cli/invocation"
 	"github.com/docker/docker-agent/pkg/config"
 	"github.com/docker/docker-agent/pkg/config/latest"
 	"github.com/docker/docker-agent/pkg/environment"
@@ -47,7 +49,9 @@ func TestBuildInstructions(t *testing.T) {
 	instructions := buildInstructions(ctx, runConfig, "")
 
 	// Verify the instructions contain the base instructions
-	assert.Contains(t, instructions, agentBuilderInstructions)
+	expectedBase := strings.ReplaceAll(agentBuilderInstructions, "{{docker_agent_command}}", invocation.DockerAgent())
+	assert.Contains(t, instructions, expectedBase)
+	assert.NotContains(t, instructions, "{{docker_agent_command}}")
 
 	// Verify the instructions contain provider guidance
 	assert.Contains(t, instructions, "Preferred model providers to use:")
@@ -87,7 +91,8 @@ func TestBuildInstructions_CustomProviders(t *testing.T) {
 		assert.Contains(t, instructions, "base_url: https://llm.corp.example.com/v1")
 		assert.Contains(t, instructions, "api_type: openai_chatcompletions")
 		assert.Contains(t, instructions, "token_key: MYPROVIDER_API_KEY")
-		assert.Contains(t, instructions, "docker agent models --provider myprovider")
+		assert.Contains(t, instructions, invocation.DockerAgent()+" run <file.yaml>")
+		assert.Contains(t, instructions, invocation.DockerAgent()+" models --provider myprovider")
 		assert.NotContains(t, instructions, "no-creds", "providers without credentials are excluded")
 	})
 

--- a/pkg/creator/instructions.txt
+++ b/pkg/creator/instructions.txt
@@ -189,5 +189,5 @@ agents:
 After writing the YAML file, tell the user to run their agent with:
 
 ```console
-docker agent run <file.yaml>
+{{docker_agent_command}} run <file.yaml>
 ```

--- a/pkg/environment/errors.go
+++ b/pkg/environment/errors.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/docker/docker-agent/pkg/chatgpt"
+	"github.com/docker/docker-agent/pkg/cli/invocation"
 )
 
 // SecretsDocsURL is the documentation page describing every built-in secret
@@ -29,6 +30,7 @@ var _ error = &RequiredEnvError{}
 
 func (e *RequiredEnvError) Error() string {
 	var msg strings.Builder
+	command := invocation.DockerAgent()
 
 	fmt.Fprintln(&msg, "The following environment variables must be set:")
 	for _, v := range e.Missing {
@@ -43,12 +45,12 @@ func (e *RequiredEnvError) Error() string {
 	msg.WriteString(SecretSourcesHelp(example))
 
 	if slices.Contains(e.Missing, chatgpt.TokenEnvVar) {
-		fmt.Fprintf(&msg, "\n%s is normally supplied by signing in with your ChatGPT account: docker agent setup\n", chatgpt.TokenEnvVar)
+		fmt.Fprintf(&msg, "\n%s is normally supplied by signing in with your ChatGPT account: %s setup\n", chatgpt.TokenEnvVar, command)
 	}
 
 	if e.MissingModelCredentials {
-		msg.WriteString("\nNo API key? Run a local model instead: docker agent run --model dmr/ai/qwen3 ...\n(the model is pulled on first use; `docker model ls` shows models already pulled)\n")
-		msg.WriteString("Or run `docker agent setup` to configure a provider or local model interactively.\n")
+		fmt.Fprintf(&msg, "\nNo API key? Run a local model instead: %s run --model dmr/ai/qwen3 ...\n(the model is pulled on first use; `docker model ls` shows models already pulled)\n", command)
+		fmt.Fprintf(&msg, "Or run `%s setup` to configure a provider or local model interactively.\n", command)
 		fmt.Fprintf(&msg, "Step-by-step model setup (API key or local): %s\n", ModelSetupDocsURL)
 	}
 
@@ -64,10 +66,11 @@ func (e *RequiredEnvError) Error() string {
 // drifts between them.
 func SecretSourcesHelp(exampleVar string) string {
 	var b strings.Builder
+	command := invocation.DockerAgent()
 	b.WriteString("Provide them using any of these sources:\n")
 	fmt.Fprintf(&b, " - Shell environment:      export %s=<value>\n", exampleVar)
-	b.WriteString(" - Env file:               docker agent run --env-from-file <file> ...\n")
-	b.WriteString(" - Docker Agent env file:  docker agent setup (stores the key in ~/.config/cagent/.env)\n")
+	fmt.Fprintf(&b, " - Env file:               %s run --env-from-file <file> ...\n", command)
+	fmt.Fprintf(&b, " - Docker Agent env file:  %s setup (stores the key in ~/.config/cagent/.env)\n", command)
 	fmt.Fprintf(&b, "\nSee %s for details.\n", SecretsDocsURL)
 	return b.String()
 }

--- a/pkg/environment/errors_test.go
+++ b/pkg/environment/errors_test.go
@@ -3,8 +3,39 @@ package environment
 import (
 	"testing"
 
+	"github.com/docker/cli/cli-plugins/metadata"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/docker/docker-agent/pkg/cli/invocation"
 )
+
+func TestRequiredEnvError_CommandsMatchInvocation(t *testing.T) {
+	tests := []struct {
+		name        string
+		originalCLI string
+		command     string
+		unexpected  string
+	}{
+		{name: "standalone", command: "docker-agent", unexpected: "docker agent run"},
+		{name: "plugin", originalCLI: "docker", command: "docker agent", unexpected: "docker-agent run"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Setenv(metadata.ReexecEnvvar, test.originalCLI)
+
+			msg := (&RequiredEnvError{
+				Missing:                 []string{"OPENAI_API_KEY"},
+				MissingModelCredentials: true,
+			}).Error()
+
+			assert.Contains(t, msg, test.command+" run --env-from-file")
+			assert.Contains(t, msg, test.command+" setup")
+			assert.Contains(t, msg, test.command+" run --model dmr/ai/qwen3")
+			assert.NotContains(t, msg, test.unexpected)
+		})
+	}
+}
 
 func TestRequiredEnvError_NamesSecretSources(t *testing.T) {
 	t.Parallel()
@@ -20,7 +51,7 @@ func TestRequiredEnvError_NamesSecretSources(t *testing.T) {
 	// first missing variable.
 	assert.Contains(t, msg, "export ANTHROPIC_API_KEY=<value>")
 	assert.Contains(t, msg, "--env-from-file")
-	assert.Contains(t, msg, "docker agent setup")
+	assert.Contains(t, msg, invocation.DockerAgent()+" setup")
 	assert.Contains(t, msg, SecretsDocsURL)
 
 	// Docker Desktop and the credential helper only ever resolve fixed
@@ -46,7 +77,7 @@ func TestRequiredEnvError_SuggestsLocalModelForModelCredentials(t *testing.T) {
 	assert.Contains(t, msg, "--model dmr/ai/qwen3")
 	assert.Contains(t, msg, "pulled on first use")
 	assert.Contains(t, msg, "docker model ls")
-	assert.Contains(t, msg, "docker agent setup")
+	assert.Contains(t, msg, invocation.DockerAgent()+" setup")
 	assert.Contains(t, msg, ModelSetupDocsURL)
 
 	// Pin the exact published URL so an accidental change to the constant

--- a/pkg/model/provider/openai/chatgpt.go
+++ b/pkg/model/provider/openai/chatgpt.go
@@ -15,6 +15,7 @@ import (
 	"github.com/openai/openai-go/v3/shared"
 
 	"github.com/docker/docker-agent/pkg/chatgpt"
+	"github.com/docker/docker-agent/pkg/cli/invocation"
 	"github.com/docker/docker-agent/pkg/config/latest"
 	"github.com/docker/docker-agent/pkg/environment"
 )
@@ -52,7 +53,7 @@ func chatgptTokenSource(env environment.Provider, tokenKey string) func(context.
 		}
 		token, err := chatgpt.AccessToken(ctx)
 		if err != nil {
-			return "", fmt.Errorf("chatgpt provider: %w; sign in with `docker agent setup` or set %s", err, tokenKey)
+			return "", fmt.Errorf("chatgpt provider: %w; sign in with `%s setup` or set %s", err, invocation.DockerAgent(), tokenKey)
 		}
 		return token, nil
 	}

--- a/pkg/model/provider/openai/chatgpt_test.go
+++ b/pkg/model/provider/openai/chatgpt_test.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/docker/docker-agent/pkg/chat"
 	"github.com/docker/docker-agent/pkg/chatgpt"
+	"github.com/docker/docker-agent/pkg/cli/invocation"
 	"github.com/docker/docker-agent/pkg/config/latest"
 	"github.com/docker/docker-agent/pkg/environment"
 	"github.com/docker/docker-agent/pkg/tools"
@@ -229,7 +230,7 @@ func TestChatGPTNotSignedInFailsFastWithGuidance(t *testing.T) {
 
 	_, err := NewClient(t.Context(), cfg, environment.NewNoEnvProvider())
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "docker agent setup")
+	assert.Contains(t, err.Error(), invocation.DockerAgent()+" setup")
 	assert.Contains(t, err.Error(), chatgpt.TokenEnvVar)
 }
 

--- a/pkg/remote/pull.go
+++ b/pkg/remote/pull.go
@@ -14,6 +14,7 @@ import (
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 	"github.com/google/go-containerregistry/pkg/v1/remote/transport"
 
+	"github.com/docker/docker-agent/pkg/cli/invocation"
 	"github.com/docker/docker-agent/pkg/content"
 	desktoptransport "github.com/docker/docker-agent/pkg/desktop/transport"
 )
@@ -94,7 +95,7 @@ func Pull(ctx context.Context, registryRef string, force bool, opts ...crane.Opt
 		if meta, metaErr := store.GetArtifactMetadata(localRef); metaErr == nil {
 			if meta.Digest == remoteDigest {
 				if !hasCagentAnnotation(meta.Annotations) {
-					return "", fmt.Errorf("artifact %s found in store wasn't created by `docker agent share push`\nTry to push again with `docker agent share push`", localRef)
+					return "", fmt.Errorf("artifact %s found in store wasn't created by `%s share push`\nTry to push again with `%s share push`", localRef, invocation.DockerAgent(), invocation.DockerAgent())
 				}
 				return meta.Digest, nil
 			}
@@ -111,7 +112,7 @@ func Pull(ctx context.Context, registryRef string, force bool, opts ...crane.Opt
 		return "", fmt.Errorf("getting manifest from pulled image: %w", err)
 	}
 	if !hasCagentAnnotation(manifest.Annotations) {
-		return "", fmt.Errorf("artifact %s wasn't created by `docker agent share push`\nTry to push again with `docker agent share push`", localRef)
+		return "", fmt.Errorf("artifact %s wasn't created by `%s share push`\nTry to push again with `%s share push`", localRef, invocation.DockerAgent(), invocation.DockerAgent())
 	}
 
 	digest, err := storeArtifact(ctx, store, s, ref, localRef, img)
@@ -143,7 +144,7 @@ func storeArtifact(ctx context.Context, store *content.Store, s *session, ref na
 		return "", fmt.Errorf("getting manifest from pulled image: %w", err)
 	}
 	if !hasCagentAnnotation(manifest.Annotations) {
-		return "", fmt.Errorf("artifact %s wasn't created by `docker agent share push`\nTry to push again with `docker agent share push`", localRef)
+		return "", fmt.Errorf("artifact %s wasn't created by `%s share push`\nTry to push again with `%s share push`", localRef, invocation.DockerAgent(), invocation.DockerAgent())
 	}
 	return store.StoreArtifact(img, localRef)
 }

--- a/pkg/tui/components/tour/steps.go
+++ b/pkg/tui/components/tour/steps.go
@@ -1,10 +1,12 @@
 package tour
 
 import (
+	"fmt"
 	"strings"
 
 	tea "charm.land/bubbletea/v2"
 
+	"github.com/docker/docker-agent/pkg/cli/invocation"
 	"github.com/docker/docker-agent/pkg/runtime"
 	"github.com/docker/docker-agent/pkg/tui/dialog"
 	"github.com/docker/docker-agent/pkg/tui/messages"
@@ -46,8 +48,8 @@ func buildSteps() []step {
 		{
 			title: "Agents are just YAML",
 			body: "The agent you're talking to is one YAML file: a model, instructions, and tools.\n\n" +
-				"Build your own:\n  docker agent new\n\n" +
-				"Or run one from an OCI registry:\n  docker agent run myorg/agent:tag",
+				fmt.Sprintf("Build your own:\n  %s new\n\n", invocation.DockerAgent()) +
+				fmt.Sprintf("Or run one from an OCI registry:\n  %s run myorg/agent:tag", invocation.DockerAgent()),
 		},
 		{
 			title: "🎉 You're all set",

--- a/pkg/tui/components/tour/tour_test.go
+++ b/pkg/tui/components/tour/tour_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/docker/docker-agent/pkg/cli/invocation"
 	"github.com/docker/docker-agent/pkg/runtime"
 	"github.com/docker/docker-agent/pkg/tui/dialog"
 	"github.com/docker/docker-agent/pkg/tui/messages"
@@ -212,7 +213,7 @@ func TestView_ReadStepShowsContinueHint(t *testing.T) {
 
 	view := m.view()
 	assert.Contains(t, view, "continue")
-	assert.Contains(t, view, "docker agent new")
+	assert.Contains(t, view, invocation.DockerAgent()+" new")
 }
 
 func TestView_LastStepShowsFinishHint(t *testing.T) {

--- a/pkg/tui/plans.go
+++ b/pkg/tui/plans.go
@@ -14,6 +14,7 @@ import (
 
 	tea "charm.land/bubbletea/v2"
 
+	"github.com/docker/docker-agent/pkg/cli/invocation"
 	"github.com/docker/docker-agent/pkg/plans"
 	"github.com/docker/docker-agent/pkg/runtime"
 	"github.com/docker/docker-agent/pkg/tools/builtin/plan"
@@ -448,7 +449,7 @@ func (m *appModel) handlePlanExportResult(msg planExportResultMsg) (tea.Model, t
 	switch {
 	case msg.exists:
 		return m, notification.ErrorCmd(
-			msg.path + " already exists — move it away, or export to a custom path with 'docker agent plans export'.")
+			fmt.Sprintf("%s already exists — move it away, or export to a custom path with '%s plans export'.", msg.path, invocation.DockerAgent()))
 	case msg.statErr != nil:
 		return m, notification.ErrorCmd(fmt.Sprintf("Cannot export to %s: %v", msg.path, msg.statErr))
 	case msg.err != nil:


### PR DESCRIPTION
## What changed

- add a shared helper that detects standalone versus Docker CLI plugin invocation
- update setup, doctor, model, alias, sandbox, environment, creator, and TUI guidance to use the runnable command for the current mode
- add regression coverage for both `docker-agent` and `docker agent` output

## Why

Standalone users were shown `docker agent` commands even when they launched the `docker-agent` binary directly. Command guidance was hardcoded across several sibling paths, so fixing only one message would leave the same usability bug elsewhere.

## Impact

User-facing commands now match the active invocation mode. Docker CLI plugin users continue to see `docker agent`, while standalone users see `docker-agent`.

## Validation

- `MODEL_RUNNER_HOST=http://127.0.0.1:59997 task dev`
- standalone built-binary smoke test: `docker-agent version dev`
- Docker CLI plugin smoke test: `docker agent version dev`


## Scope notes

- Only runnable command guidance is dynamic. Remaining `docker agent` strings in source are product-name prose (the tour copy, "docker agent env file", the board title) and are intentionally unchanged.
- Cobra `Example` fields stay hardcoded to `docker-agent`, matching the existing convention in `root.go` and `setup.go`. The dynamic guidance covers `Long` text, printed hints, and error messages.
- The `invocationError` sentinels and `pkg/creator/instructions.txt` share one placeholder token, `{{docker_agent_command}}`, resolved at render time.
