### PR TITLE
fix(kit): retry promote() retire-rename on Windows ACCESS_DENIED

### DIFF
--- a/pkg/sandbox/kit/kit.go
+++ b/pkg/sandbox/kit/kit.go
@@ -34,6 +34,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"runtime"
 	"slices"
 	"sort"
 	"strconv"
@@ -341,12 +342,22 @@ func classifyRef(ref string) (tag, key string) {
 // leftover .old-* sibling from a crashed run is harmless and will be
 // reaped on the next successful build.
 //
-// Publishing is wrapped in a bounded retry loop to absorb a three-way
-// race: between our failed rename and our recovery Stat, a *different*
-// concurrent build can retire finalDir to publish its own kit, leaving
-// finalDir transiently absent. A single Stat would misread that as a
-// hard failure; retrying lets us simply take the now-empty slot. The
-// contention window is microseconds and real concurrency is a handful
+// Publishing is wrapped in a bounded retry loop to absorb two races:
+//
+//  1. Three-way rename race: between our failed rename and our
+//     recovery Stat, a *different* concurrent build can retire
+//     finalDir to publish its own kit, leaving finalDir transiently
+//     absent. A single Stat would misread that as a hard failure;
+//     retrying lets us simply take the now-empty slot.
+//
+//  2. Windows access-denied race: Windows refuses to rename a
+//     directory while another goroutine holds an open handle to it
+//     (ERROR_ACCESS_DENIED). A concurrent Build holding finalDir open
+//     makes the retire rename fail; retrying waits for the handle to
+//     be released. On POSIX, renames succeed regardless of open
+//     handles, so this path is never taken there.
+//
+// Both windows are microseconds wide and real concurrency is a handful
 // of builds, so the loop converges in one or two iterations.
 func promote(stagingDir, finalDir string) error {
 	const maxAttempts = 100
@@ -369,6 +380,14 @@ func promote(stagingDir, finalDir string) error {
 		if _, err := os.Stat(finalDir); err == nil {
 			retired := fmt.Sprintf("%s.old-%s-%d", finalDir, filepath.Base(stagingDir), attempt)
 			if err := os.Rename(finalDir, retired); err != nil && !os.IsNotExist(err) {
+				// On Windows another goroutine may hold finalDir open,
+				// causing ERROR_ACCESS_DENIED. That's transient — retry
+				// rather than failing the build.
+				if isRetryableRenameErr(err) {
+					lastErr = err
+					runtime.Gosched() // yield to the goroutine holding the handle
+					continue
+				}
 				return fmt.Errorf("retiring previous kit: %w", err)
 			}
 			retiredDirs = append(retiredDirs, retired)

--- a/pkg/sandbox/kit/rename_other.go
+++ b/pkg/sandbox/kit/rename_other.go
@@ -1,0 +1,10 @@
+//go:build !windows
+
+package kit
+
+// isRetryableRenameErr is Windows-only; see rename_windows.go.
+// On POSIX, directory renames succeed even when another process holds the
+// directory open, so EACCES is a genuine hard error — nothing to retry.
+func isRetryableRenameErr(error) bool {
+	return false
+}

--- a/pkg/sandbox/kit/rename_windows.go
+++ b/pkg/sandbox/kit/rename_windows.go
@@ -1,0 +1,22 @@
+//go:build windows
+
+package kit
+
+import (
+	"errors"
+	"syscall"
+)
+
+// isRetryableRenameErr reports whether err from renaming a directory aside
+// during promote is a transient Windows failure worth retrying.
+//
+// Windows refuses to rename a directory while another process or goroutine
+// holds an open handle to it, surfacing as ERROR_ACCESS_DENIED. Concurrent
+// Builds for the same agent hit exactly this: one goroutine holds finalDir
+// open while another tries to retire it. The condition clears once the
+// other goroutine releases the handle, so promote retries rather than
+// failing hard. On POSIX, renames succeed even with open handles, so the
+// non-Windows build always returns false.
+func isRetryableRenameErr(err error) bool {
+	return errors.Is(err, syscall.ERROR_ACCESS_DENIED)
+}


### PR DESCRIPTION
> 🤖 **Automated implementer agent** — *this comment was posted by the implementer bot from Docker Agentic Platform, not by a human developer*

Fixes `TestBuild_ConcurrentRunsForSameAgentAreSafe` failing on Windows in CI run [31013010316](https://github.com/docker/docker-agent/actions/runs/31013010316/job/92330933439).

**Root cause:** `promote()` in `pkg/sandbox/kit/kit.go` renames `finalDir` aside (to a `.old-…` sibling) before atomically installing the new kit. On Windows, `os.Rename` fails with `ERROR_ACCESS_DENIED` when another goroutine holds an open handle to that directory. Concurrent `Build()` calls for the same agent hit this exactly.

**Fix:** Add a build-tagged helper `isRetryableRenameErr()`:
- `rename_windows.go` (`//go:build windows`): returns `errors.Is(err, syscall.ERROR_ACCESS_DENIED)`
- `rename_other.go` (`//go:build !windows`): always returns `false`

In the retire-rename error path, treat a retryable error as a loop continuation (set `lastErr`, call `runtime.Gosched()` to yield to the competing goroutine, then `continue`) instead of returning hard. On POSIX, `EACCES` on a rename is a genuine hard error and the path is unchanged.

**Testing:** `TestBuild_ConcurrentRunsForSameAgentAreSafe` passes on POSIX; the Windows path compiles cleanly (`GOOS=windows go build/vet`).

**Reviewer note:** The reviewer noted that `isRetryableRenameErr` has no Windows unit test (since CI doesn't run Windows-tagged tests on Linux). The function is a single `errors.Is` call with no branch; correctness is covered by the concurrent integration test in Windows CI.