### PR TITLE
feat(tui): add Alt+Enter follow-up messages

### DIFF
--- a/docs/features/tui/index.md
+++ b/docs/features/tui/index.md
@@ -57,7 +57,7 @@ settings:
 
 Omit `lean` or set it to `false` to keep the full TUI as the default. You can still use `--lean` for a single run, or `--lean=false` to use the full TUI when `settings.lean` is enabled. See [User Settings](../../configuration/user-settings/index.md) for the full precedence rules between flags and user config.
 
-The lean TUI supports **steering**: messages submitted while the agent is running are queued and delivered to the active session. Pending steering messages appear with muted styling at the end of the live stream so you can see what will be sent next.
+The lean TUI supports **steering** and **follow-ups** while the agent is running. Press <kbd>Enter</kbd> to steer the active turn, or <kbd>Alt</kbd>+<kbd>Enter</kbd> to queue the message as a separate turn after the current one finishes. Pending messages appear with muted styling at the end of the live stream.
 
 The lean TUI supports a focused set of slash commands: `/new`, `/compact`, `/model`, `/effort`, `/clear`, `/help`, `/exit` (alias: `/quit`), plus any agent-defined commands. Type `/model` (or `/model <provider/model>`) to switch the active model inline — the command opens a fuzzy-searchable list of available models.
 
@@ -355,7 +355,9 @@ Customize session titles to make them more meaningful and easier to find. By def
 | Ctrl+Z     | Suspend TUI to background (resume with `fg`)    |
 | Ctrl+X     | Clear queued messages                           |
 | Escape     | Cancel current operation                        |
-| Enter      | Send message (or newline with Shift+Enter)      |
+| Enter      | Send message (or steer while the agent is running) |
+| Alt+Enter  | Queue a follow-up turn while the agent is running |
+| Shift+Enter | Insert a newline |
 | Up/Down    | Navigate message history                        |
 
 Press <kbd>Ctrl</kbd>+<kbd>H</kbd> to view the complete list of all available keyboard shortcuts.

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -1015,6 +1015,11 @@ func (a *App) Steer(ctx context.Context, msg runtime.QueuedMessage) error {
 	return a.runtime.Steer(ctx, msg)
 }
 
+// FollowUp queues a user message for a separate turn after the current turn.
+func (a *App) FollowUp(ctx context.Context, msg runtime.QueuedMessage) error {
+	return a.runtime.FollowUp(ctx, msg)
+}
+
 // SteerMessage resolves attachments into message parts and queues the result
 // for mid-turn injection into the running agent. The runtime appends the
 // message to the session (and emits the matching UserMessageEvent) when the
@@ -1025,6 +1030,16 @@ func (a *App) SteerMessage(ctx context.Context, content string, attachments []me
 		msg.MultiContent = a.buildUserMultiContent(ctx, content, attachments)
 	}
 	return a.runtime.Steer(ctx, msg)
+}
+
+// FollowUpMessage resolves attachments and queues a message for a separate turn
+// after the current agent turn finishes.
+func (a *App) FollowUpMessage(ctx context.Context, content string, attachments []messages.Attachment) error {
+	msg := runtime.QueuedMessage{Content: content}
+	if len(attachments) > 0 {
+		msg.MultiContent = a.buildUserMultiContent(ctx, content, attachments)
+	}
+	return a.runtime.FollowUp(ctx, msg)
 }
 
 // TogglePause toggles whether the runtime loop is paused at iteration

--- a/pkg/leantui/events.go
+++ b/pkg/leantui/events.go
@@ -112,6 +112,11 @@ func (m *model) handleUserMessageEvent(e *runtime.UserMessageEvent) {
 		m.addUserEcho(pending.Display)
 		return
 	}
+	if pending, ok := m.consumePendingUser(ui.PendingUserFollowUp, e.Message); ok {
+		m.screen.Transcript.FlushPending()
+		m.addUserEcho(pending.Display)
+		return
+	}
 	m.screen.Transcript.FlushPending()
 	m.addUserEcho(e.Message)
 }

--- a/pkg/leantui/update.go
+++ b/pkg/leantui/update.go
@@ -34,7 +34,7 @@ func (m *model) handleKey(ctx context.Context, k ui.Key) {
 	case ui.KeyEnter:
 		m.handleEnter(ctx)
 	case ui.KeyAltEnter:
-		m.screen.Editor.InsertNewline()
+		m.submitEditorMode(ctx, m.screen.Editor.Text(), busySubmitFollowUp)
 	case ui.KeyTab:
 		m.handleTab()
 	case ui.KeyShiftTab:
@@ -188,6 +188,7 @@ type busySubmitMode int
 const (
 	busySubmitSteer busySubmitMode = iota
 	busySubmitQueue
+	busySubmitFollowUp
 )
 
 type submitOptions struct {
@@ -196,7 +197,11 @@ type submitOptions struct {
 }
 
 func (m *model) submitEditor(ctx context.Context, text string) {
-	m.submit(ctx, text, submitOptions{fromEditor: true, busyMode: busySubmitSteer})
+	m.submitEditorMode(ctx, text, busySubmitSteer)
+}
+
+func (m *model) submitEditorMode(ctx context.Context, text string, mode busySubmitMode) {
+	m.submit(ctx, text, submitOptions{fromEditor: true, busyMode: mode})
 }
 
 func (m *model) submitFollowUp(ctx context.Context, text string) {
@@ -335,16 +340,25 @@ func (m *model) dispatchUserMessage(ctx context.Context, display, content string
 		return
 	}
 	if m.busy {
-		if mode == busySubmitSteer {
+		switch mode {
+		case busySubmitSteer:
 			if err := m.app.Steer(ctx, runtime.QueuedMessage{Content: content}); err != nil {
 				m.addNotice("⚠ ", "Could not steer current response: "+err.Error(), ui.StWarning())
 				return
 			}
 			m.addPendingUser(display, content, ui.PendingUserSteer)
 			return
+		case busySubmitFollowUp:
+			if err := m.app.FollowUp(ctx, runtime.QueuedMessage{Content: content}); err != nil {
+				m.addNotice("⚠ ", "Could not enqueue follow-up: "+err.Error(), ui.StWarning())
+				return
+			}
+			m.addPendingUser(display, content, ui.PendingUserFollowUp)
+			return
+		default:
+			m.enqueueFollowUp(display, content)
+			return
 		}
-		m.enqueueFollowUp(display, content)
-		return
 	}
 	m.addUserEcho(display)
 	m.ignoreUserEcho(content)

--- a/pkg/leantui/update_test.go
+++ b/pkg/leantui/update_test.go
@@ -25,6 +25,7 @@ type cycleThinkingRuntime struct {
 	cycleCalls int
 	setCalls   int
 	setLevel   effort.Level
+	followUps  []runtime.QueuedMessage
 	steered    []runtime.QueuedMessage
 	steerErr   error
 	models     []runtime.ModelChoice
@@ -96,8 +97,12 @@ func (r *cycleThinkingRuntime) Steer(_ context.Context, msg runtime.QueuedMessag
 	r.steered = append(r.steered, msg)
 	return nil
 }
-func (r *cycleThinkingRuntime) FollowUp(context.Context, runtime.QueuedMessage) error { return nil }
-func (r *cycleThinkingRuntime) QueueStatus() runtime.QueueStatus                      { return runtime.QueueStatus{} }
+
+func (r *cycleThinkingRuntime) FollowUp(_ context.Context, msg runtime.QueuedMessage) error {
+	r.followUps = append(r.followUps, msg)
+	return nil
+}
+func (r *cycleThinkingRuntime) QueueStatus() runtime.QueueStatus { return runtime.QueueStatus{} }
 
 func (r *cycleThinkingRuntime) TogglePause(context.Context) (bool, error) {
 	return false, nil
@@ -227,6 +232,25 @@ func TestModelCommandOpensModelAutocomplete(t *testing.T) {
 		assert.Equal(t, "openai/gpt-5", cmd.Name)
 		assert.Equal(t, "/model default", m.screen.Autocomplete.Completion(cmd))
 	}
+}
+
+func TestAltEnterWhileBusyQueuesRuntimeFollowUp(t *testing.T) {
+	t.Parallel()
+	rt := &cycleThinkingRuntime{}
+	m := bareModel(24)
+	m.app = app.New(t.Context(), rt, session.New())
+	m.busy = true
+	m.screen.Editor.SetText("do this next")
+
+	m.handleKey(t.Context(), ui.Key{Typ: ui.KeyAltEnter})
+
+	if assert.Len(t, rt.followUps, 1) {
+		assert.Equal(t, "do this next", rt.followUps[0].Content)
+	}
+	assert.Empty(t, rt.steered)
+	assert.Empty(t, m.queue)
+	assert.Len(t, m.pendingUsers, 1)
+	assert.True(t, m.screen.Editor.IsEmpty())
 }
 
 func TestEditorSubmitWhileBusySteersAndRendersAtStreamEnd(t *testing.T) {

--- a/pkg/tui/components/editor/editor.go
+++ b/pkg/tui/components/editor/editor.go
@@ -635,6 +635,10 @@ func (e *editor) ScrollByWheel(delta int) {
 // resetAndSend prepares a message for sending: processes pending file refs,
 // collects attachments, resets editor state, and returns the SendMsg command.
 func (e *editor) resetAndSend(content string) tea.Cmd {
+	return e.resetAndSendMode(content, false)
+}
+
+func (e *editor) resetAndSendMode(content string, followUp bool) tea.Cmd {
 	e.tryAddFileRef(e.pendingFileRef)
 	e.pendingFileRef = ""
 	attachments := e.collectAttachments(content)
@@ -663,7 +667,7 @@ func (e *editor) resetAndSend(content string) tea.Cmd {
 	e.textarea.Reset()
 	e.userTyped = false
 	e.clearSuggestion()
-	return core.CmdHandler(messages.SendMsg{Content: content, Attachments: finalAttachments})
+	return core.CmdHandler(messages.SendMsg{Content: content, Attachments: finalAttachments, FollowUp: followUp})
 }
 
 // configureNewlineKeybinding sets up the newline keybinding from the
@@ -856,6 +860,20 @@ func (e *editor) Update(msg tea.Msg) (layout.Model, tea.Cmd) {
 		// multi-codepoint characters like emoji (e.g., ⚠️ = U+26A0 + U+FE0F).
 		if key.Matches(msg, e.textarea.KeyMap.DeleteCharacterBackward) {
 			return e.handleGraphemeBackspace()
+		}
+
+		// Alt+Enter submits an end-of-turn follow-up. It is handled before the
+		// configurable newline binding so the two delivery modes are always
+		// available independently.
+		if msg.String() == "alt+enter" {
+			if !e.textarea.Focused() {
+				return e, nil
+			}
+			if value := e.textarea.Value(); value != "" {
+				cmd := e.resetAndSendMode(value, true)
+				return e, cmd
+			}
+			return e, nil
 		}
 
 		// Handle send/newline keys (both user-configurable, see issue #1626):

--- a/pkg/tui/components/editor/keybinding_test.go
+++ b/pkg/tui/components/editor/keybinding_test.go
@@ -3,11 +3,13 @@ package editor
 import (
 	"testing"
 
+	tea "charm.land/bubbletea/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/docker/docker-agent/pkg/history"
 	"github.com/docker/docker-agent/pkg/tui/core"
+	"github.com/docker/docker-agent/pkg/tui/messages"
 )
 
 // TestConfigureNewlineKeybinding verifies the editor wires its newline keys
@@ -36,4 +38,21 @@ func TestConfigureNewlineKeybinding(t *testing.T) {
 	require.NotEmpty(t, got)
 	assert.Equal(t, "shift+enter", got[0], "shift+enter should be offered first on capable terminals")
 	assert.Subset(t, got, want, "configured newline keys must remain available")
+}
+
+func TestAltEnterSubmitsFollowUp(t *testing.T) {
+	t.Parallel()
+	h, err := history.New(t.TempDir())
+	require.NoError(t, err)
+	e := New(h).(*editor)
+	e.SetValue("do this next")
+	e.Focus()
+
+	_, cmd := e.Update(tea.KeyPressMsg{Code: tea.KeyEnter, Mod: tea.ModAlt})
+	require.NotNil(t, cmd)
+	msg, ok := cmd().(messages.SendMsg)
+	require.True(t, ok)
+	assert.Equal(t, "do this next", msg.Content)
+	assert.True(t, msg.FollowUp)
+	assert.Empty(t, e.textarea.Value())
 }

--- a/pkg/tui/messages/session.go
+++ b/pkg/tui/messages/session.go
@@ -108,7 +108,8 @@ type (
 		Content     string       // Full content sent to the agent (with file contents expanded)
 		Attachments []Attachment // Attached files or inline content (e.g. pastes)
 		BypassQueue bool         // Process immediately even while the agent is working.
-		Queue       bool         // Force end-of-turn queueing regardless of the configured send mode.
+		Queue       bool         // Force local end-of-turn queueing regardless of the configured send mode.
+		FollowUp    bool         // Enqueue as a runtime follow-up when the agent is working.
 	}
 
 	// SendAttachmentMsg is a message for the first message with an attachment.

--- a/pkg/tui/page/chat/chat.go
+++ b/pkg/tui/page/chat/chat.go
@@ -584,6 +584,18 @@ func (p *chatPage) update(msg tea.Msg) (layout.Model, tea.Cmd) {
 			cmd,
 		)
 
+	case followUpSentMsg:
+		return p, notification.InfoCmd("Follow-up queued for the next turn")
+
+	case followUpFailedMsg:
+		msg.original.FollowUp = false
+		msg.original.Queue = true
+		model, cmd := p.handleSendMsg(msg.original)
+		return model, tea.Batch(
+			notification.WarningCmd("Could not enqueue the follow-up"),
+			cmd,
+		)
+
 	case msgtypes.RetryMsg:
 		return p.handleRetry()
 
@@ -946,6 +958,13 @@ func (p *chatPage) handleSendMsg(msg msgtypes.SendMsg) (layout.Model, tea.Cmd) {
 		return p, cmd
 	}
 
+	// Alt+Enter explicitly requests a separate end-of-turn follow-up. When the
+	// agent is idle there is no active turn to follow, so process it normally.
+	if msg.FollowUp && p.working && p.app != nil {
+		cmd := p.followUpMessage(msg)
+		return p, cmd
+	}
+
 	// While the agent is working, the configured send mode decides the
 	// default: steer injects the message into the ongoing stream so the
 	// agent picks it up mid-turn without breaking the stream (issue #3547);
@@ -992,8 +1011,10 @@ func (p *chatPage) enqueueMessage(msg msgtypes.SendMsg) tea.Cmd {
 // queue; steerFailedMsg carries the message back for local queueing when
 // steering was rejected (e.g. steer queue full).
 type (
-	steerSentMsg   struct{}
-	steerFailedMsg struct{ original msgtypes.SendMsg }
+	steerSentMsg      struct{}
+	steerFailedMsg    struct{ original msgtypes.SendMsg }
+	followUpSentMsg   struct{}
+	followUpFailedMsg struct{ original msgtypes.SendMsg }
 )
 
 // steerMessage injects the message into the ongoing stream via the runtime's
@@ -1010,6 +1031,18 @@ func (p *chatPage) steerMessage(msg msgtypes.SendMsg) tea.Cmd {
 			return steerFailedMsg{original: msg}
 		}
 		return steerSentMsg{}
+	}
+}
+
+func (p *chatPage) followUpMessage(msg msgtypes.SendMsg) tea.Cmd {
+	ctx := p.ctx()
+	return func() tea.Msg {
+		content := p.app.ResolveInput(ctx, msg.Content)
+		if err := p.app.FollowUpMessage(ctx, content, msg.Attachments); err != nil {
+			slog.Warn("Failed to enqueue follow-up; falling back to local queue", "error", err)
+			return followUpFailedMsg{original: msg}
+		}
+		return followUpSentMsg{}
 	}
 }
 

--- a/pkg/tui/page/chat/queue_test.go
+++ b/pkg/tui/page/chat/queue_test.go
@@ -560,9 +560,10 @@ func TestReadOnly_RejectsBypassQueueCommands(t *testing.T) {
 type steerRecordingRuntime struct {
 	queueTestRuntime
 
-	mu       sync.Mutex
-	steerErr error
-	steers   []runtime.QueuedMessage
+	mu        sync.Mutex
+	steerErr  error
+	steers    []runtime.QueuedMessage
+	followUps []runtime.QueuedMessage
 }
 
 func (r *steerRecordingRuntime) Steer(_ context.Context, msg runtime.QueuedMessage) error {
@@ -575,10 +576,42 @@ func (r *steerRecordingRuntime) Steer(_ context.Context, msg runtime.QueuedMessa
 	return nil
 }
 
+func (r *steerRecordingRuntime) FollowUp(_ context.Context, msg runtime.QueuedMessage) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.followUps = append(r.followUps, msg)
+	return nil
+}
+
+func (r *steerRecordingRuntime) followedUp() []runtime.QueuedMessage {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return append([]runtime.QueuedMessage(nil), r.followUps...)
+}
+
 func (r *steerRecordingRuntime) steered() []runtime.QueuedMessage {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	return append([]runtime.QueuedMessage(nil), r.steers...)
+}
+
+func TestFollowUpFlow_BusyAgent_UsesRuntimeFollowUpQueue(t *testing.T) {
+	t.Parallel()
+
+	rt := &steerRecordingRuntime{}
+	sess := session.New()
+	p := New(animation.NewRuntime(), t.Context(), app.New(t.Context(), rt, sess), service.NewSessionState(sess)).(*chatPage)
+	p.working = true
+
+	_, cmd := p.handleSendMsg(messages.SendMsg{Content: "do this next", FollowUp: true})
+
+	require.NotNil(t, cmd)
+	assert.IsType(t, followUpSentMsg{}, cmd())
+	assert.Empty(t, p.messageQueue)
+	assert.Empty(t, rt.steered())
+	if assert.Len(t, rt.followedUp(), 1) {
+		assert.Equal(t, "do this next", rt.followedUp()[0].Content)
+	}
 }
 
 // TestSteerFlow_BusyAgent_SteersMessage pins the issue #3547 contract: a


### PR DESCRIPTION
## Summary

- submit runtime follow-up messages with Alt+Enter in the full TUI
- add the same follow-up mode to the lean TUI while keeping Enter as steering
- preserve attachments in full-TUI follow-ups and display pending lean-TUI follow-ups
- document the shortcuts and cover both modes with tests

## Validation

- `task build`
- `task lint`
- `go test ./pkg/tui/components/editor ./pkg/tui/page/chat ./pkg/leantui ./pkg/app`
- `task test` (all packages passed except the existing live Moonshot API test, which returned HTTP 404 for `kimi-k2-0905-preview`)
