### PR TITLE
docs: auto-update for merged PRs (2026-08-06)

### DIFF
--- a/docs/tools/filesystem/index.md
+++ b/docs/tools/filesystem/index.md
@@ -28,6 +28,15 @@ When a file is not found, error messages include the resolved absolute path to h
 > [!IMPORTANT]
 > Agents must use paths appropriate for the host OS. A Windows absolute path like `C:\file.txt` on a Unix system (or vice versa) is rejected with a clear error message.
 
+### Empty directory detection
+
+When `list_directory` encounters an empty directory or a directory where all entries are hidden by ignore patterns (e.g., only a `.git` folder when `ignore_vcs: true`), it explicitly reports the state:
+
+- **Empty directory**: "Directory is empty: /path/to/dir"
+- **All entries ignored**: "Directory has no visible entries (N hidden by ignore patterns): /path/to/dir"
+
+This helps agents distinguish between an empty directory and a tool failure, avoiding unnecessary retries with shell commands.
+
 ## Available Tools
 
 | Tool                   | Description                                                               |
@@ -36,7 +45,7 @@ When a file is not found, error messages include the resolved absolute path to h
 | `read_multiple_files`  | Read several files in one call (more efficient than multiple `read_file`) |
 | `write_file`           | Create or overwrite a file with new content                               |
 | `edit_file`            | Make line-based edits (find-and-replace) in an existing file              |
-| `list_directory`       | List files and directories at a given path                                |
+| `list_directory`       | List files and directories at a given path (explicitly reports empty directories) |
 | `directory_tree`       | Recursive tree view of a directory                                        |
 | `create_directory`     | Create a new directory (creates parent directories as needed)             |
 | `remove_directory`     | Remove an empty directory                                                 |

--- a/docs/tools/shell/index.md
+++ b/docs/tools/shell/index.md
@@ -15,6 +15,17 @@ The shell tool allows agents to execute arbitrary shell commands synchronously. 
 
 Commands have a default 30-second timeout and require user confirmation unless `--yolo` is used. For servers, watchers, and other long-running commands, add the [`background_jobs`](../background-jobs/index.md) toolset alongside `shell`.
 
+### Shell interpreter detection
+
+The shell tool automatically detects and names the resolved shell interpreter (e.g., `bash`, `zsh`, `powershell`, `pwsh`, `cmd`) in its description to the model, along with the operating system (Linux, macOS, Windows). This helps models use the correct shell syntax for the host environment.
+
+For example:
+
+- On Linux with bash: "Executes the given shell command with bash on Linux."
+- On Windows with PowerShell: "Executes the given shell command with powershell on Windows. Use Windows PowerShell 5.1 syntax: chain commands with ";" (not "&&"), and avoid POSIX commands/flags like "ls -la"."
+
+This reduces wasted turns where models assume POSIX syntax on Windows or vice versa.
+
 ## Configuration
 
 ```yaml


### PR DESCRIPTION
This PR updates documentation to reflect code changes merged into `main` in the last 36 hours.

## Documentation Changes

### Filesystem Tool (`/docs/tools/filesystem/index.md`)
- **PR #3912**: Added documentation for empty directory detection in `list_directory`
  - Now explicitly reports when a directory is empty
  - Distinguishes between truly empty directories and directories with all entries hidden by ignore patterns
  - Helps models avoid unnecessary shell command retries

### Shell Tool (`/docs/tools/shell/index.md`)
- **PR #3911**: Added documentation for shell interpreter detection
  - The shell tool now names the resolved interpreter (bash, zsh, powershell, etc.) in its description
  - Includes OS information (Linux, macOS, Windows) to help models use correct syntax
  - Provides shell-specific syntax hints (e.g., PowerShell vs POSIX)
  - Reduces wasted turns from incorrect shell syntax assumptions

## Source PRs

- [#3911](https://github.com/docker/docker-agent/pull/3911) - feat(shell): name the resolved interpreter in the shell tool description
- [#3912](https://github.com/docker/docker-agent/pull/3912) - feat(filesystem): say when list_directory finds an empty directory

## PRs Not Requiring Doc Changes

The following merged PRs did not require documentation updates:
- [#3915](https://github.com/docker/docker-agent/pull/3915) - docs: update CHANGELOG.md for v1.122.0 (CHANGELOG only)
- [#3914](https://github.com/docker/docker-agent/pull/3914) - fix(tui): preserve stream cancellation after compaction (internal TUI behavior)
- [#3913](https://github.com/docker/docker-agent/pull/3913) - fix(filesystem): repair malformed inner JSON in double-serialized edits (internal implementation)
- [#3910](https://github.com/docker/docker-agent/pull/3910) - docs: update CHANGELOG.md for v1.121.0 (CHANGELOG only)
- [#3909](https://github.com/docker/docker-agent/pull/3909) - docs: auto-update for merged PRs (2026-08-05) (previous docs update)
- [#3899](https://github.com/docker/docker-agent/pull/3899) - feat(tui): configurable interrupt confirmation for Esc key (already documented in #3909)
- [#3833](https://github.com/docker/docker-agent/pull/3833) - fix(backgroundjobs): resolve status race condition and subprocess pipe hang (internal implementation)
- [#3831](https://github.com/docker/docker-agent/pull/3831) - fix: agent security and linting improvements (internal changes)
- [#3795](https://github.com/docker/docker-agent/pull/3795) - fix(tui): resolve cross-platform root detection and fallback paths in pickers (internal TUI behavior)
- [#3792](https://github.com/docker/docker-agent/pull/3792) - fix: resolve POSIX path handling and test failures on Windows (docs updated in the PR itself)