### PR TITLE
fix: frontend-agnostic context overflow message, export recorded errors for recovery

### DIFF
--- a/pkg/modelerrors/modelerrors.go
+++ b/pkg/modelerrors/modelerrors.go
@@ -635,9 +635,14 @@ func FormatError(err error) string {
 	case OverflowKindMedia:
 		return "An image or file in this conversation is too large for the AI provider. " +
 			"Try a smaller file or remove it from context."
+	// Frontend-agnostic by design too: this error reaches every consumer of
+	// the runtime event stream, and not all of them expose a /compact
+	// command, so name the action ("compact") rather than a command. It also
+	// avoids claiming compaction "is not enabled": this path is reached both
+	// when compaction is disabled and when its retries are exhausted.
 	case OverflowKindTokens:
-		return "The conversation has exceeded the model's context window and automatic compaction is not enabled. " +
-			"Try running /compact to reduce the conversation size, or start a new session."
+		return "The conversation has exceeded the model's context window. " +
+			"Compact the conversation to reduce its size, or start a new session."
 	}
 
 	if IsStreamTruncationError(err) {

--- a/pkg/modelerrors/modelerrors_test.go
+++ b/pkg/modelerrors/modelerrors_test.go
@@ -389,12 +389,14 @@ func TestFormatError_OverflowKinds(t *testing.T) {
 		assert.NotContains(t, msg, "/compact")
 	})
 
-	t.Run("token overflow keeps the /compact hint", func(t *testing.T) {
+	t.Run("token overflow suggests compacting without naming a command", func(t *testing.T) {
 		t.Parallel()
 		err := errors.New(`prompt is too long: 200000 tokens > 128000 maximum`)
 		msg := FormatError(err)
 		assert.Contains(t, msg, "context window")
-		assert.Contains(t, msg, "/compact")
+		assert.Contains(t, msg, "Compact the conversation")
+		// Not every frontend exposes a /compact command.
+		assert.NotContains(t, msg, "/compact")
 	})
 }
 
@@ -529,7 +531,7 @@ func TestFormatError(t *testing.T) {
 		err := NewContextOverflowError(errors.New("prompt is too long"))
 		msg := FormatError(err)
 		assert.Contains(t, msg, "context window")
-		assert.Contains(t, msg, "/compact")
+		assert.Contains(t, msg, "Compact the conversation")
 		assert.NotContains(t, msg, "prompt is too long")
 	})
 
@@ -538,7 +540,7 @@ func TestFormatError(t *testing.T) {
 		err := fmt.Errorf("outer: %w", NewContextOverflowError(errors.New("prompt is too long")))
 		msg := FormatError(err)
 		assert.Contains(t, msg, "context window")
-		assert.Contains(t, msg, "/compact")
+		assert.Contains(t, msg, "Compact the conversation")
 	})
 
 	t.Run("generic error preserves message", func(t *testing.T) {
@@ -553,7 +555,7 @@ func TestFormatError(t *testing.T) {
 		wrapped := NewContextOverflowError(&StatusError{StatusCode: 400, Err: underlying})
 		msg := FormatError(wrapped)
 		assert.Contains(t, msg, "context window")
-		assert.Contains(t, msg, "/compact")
+		assert.Contains(t, msg, "Compact the conversation")
 	})
 }
 

--- a/pkg/server/session_manager.go
+++ b/pkg/server/session_manager.go
@@ -2058,7 +2058,7 @@ func (sm *SessionManager) ExportSessionForRecovery(ctx context.Context, sessionI
 	}
 
 	inputTokens, outputTokens := sess.Usage()
-	return map[string]any{
+	export := map[string]any{
 		"id":             sess.ID,
 		"title":          sess.TitleSnapshot(),
 		"created_at":     sess.CreatedAt,
@@ -2068,5 +2068,13 @@ func (sm *SessionManager) ExportSessionForRecovery(ctx context.Context, sessionI
 		"working_dir":    sess.WorkingDir,
 		"tools_approved": sess.ToolsApproved,
 		"permissions":    sess.Permissions,
-	}, nil
+	}
+	// Recorded errors are session items, not messages, so GetAllMessages
+	// drops them. Export them separately: recovery exports feed diagnostics,
+	// and a run that died with e.g. a context overflow is invisible without
+	// the error that ended it.
+	if errs := sess.GetAllErrors(); len(errs) > 0 {
+		export["errors"] = errs
+	}
+	return export, nil
 }

--- a/pkg/server/session_manager_test.go
+++ b/pkg/server/session_manager_test.go
@@ -2252,3 +2252,52 @@ func TestApplyAgentSwitchCommands_RollsBackOnBatchFailure(t *testing.T) {
 	assert.Equal(t, "root", rt.currentAgent, "runtime must be restored to the pre-batch agent")
 	assert.Equal(t, []string{"planner", "nonexistent", "root"}, rt.setCalls)
 }
+
+// TestExportSessionForRecovery_IncludesErrors verifies that recorded error
+// items reach the recovery export. GetAllMessages filters them out, so
+// without a dedicated "errors" key a run that died with e.g. a context
+// overflow would look like it just stopped mid-conversation.
+func TestExportSessionForRecovery_IncludesErrors(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	store := session.NewInMemorySessionStore()
+	sess := session.New(session.WithUserMessage("hi"))
+	require.NoError(t, store.AddSession(ctx, sess))
+	require.NoError(t, store.AddError(ctx, sess.ID, &session.Error{
+		Message:   "the conversation has exceeded the model's context window",
+		Code:      "context_exceeded",
+		AgentName: "root",
+	}))
+
+	sm := NewSessionManager(ctx, config.Sources{}, store, 0, &config.RuntimeConfig{})
+	export, err := sm.ExportSessionForRecovery(ctx, sess.ID)
+	require.NoError(t, err)
+
+	errs, ok := export["errors"].([]session.Error)
+	require.True(t, ok, "export must carry recorded errors")
+	require.Len(t, errs, 1)
+	assert.Equal(t, "context_exceeded", errs[0].Code)
+
+	messages, ok := export["messages"].([]session.Message)
+	require.True(t, ok)
+	require.Len(t, messages, 1, "error items must not leak into messages")
+}
+
+// TestExportSessionForRecovery_OmitsErrorsKeyWhenNone verifies the export
+// shape is unchanged for sessions without recorded errors.
+func TestExportSessionForRecovery_OmitsErrorsKeyWhenNone(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	store := session.NewInMemorySessionStore()
+	sess := session.New(session.WithUserMessage("hi"))
+	require.NoError(t, store.AddSession(ctx, sess))
+
+	sm := NewSessionManager(ctx, config.Sources{}, store, 0, &config.RuntimeConfig{})
+	export, err := sm.ExportSessionForRecovery(ctx, sess.ID)
+	require.NoError(t, err)
+
+	_, present := export["errors"]
+	assert.False(t, present)
+}

--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -1114,6 +1114,24 @@ func (s *Session) GetAllMessages() []Message {
 	return messages
 }
 
+// GetAllErrors extracts all recorded errors from the session, including from
+// sub-sessions, in item order. Recorded errors live alongside messages as
+// session items but are not part of the conversation, so exports that build
+// on GetAllMessages need this to surface failures for diagnostics.
+func (s *Session) GetAllErrors() []Error {
+	items := s.snapshotItems()
+
+	var errs []Error
+	for _, item := range items {
+		if item.IsError() {
+			errs = append(errs, *item.Error)
+		} else if item.IsSubSession() {
+			errs = append(errs, item.SubSession.GetAllErrors()...)
+		}
+	}
+	return errs
+}
+
 // OwnMessages extracts this session's direct messages, excluding system
 // messages and WITHOUT recursing into sub-sessions. This is the set of
 // messages that actually enters this session's prompt (GetMessages skips

--- a/pkg/session/session_test.go
+++ b/pkg/session/session_test.go
@@ -1029,3 +1029,29 @@ func TestEmbeddedSubSessionCost(t *testing.T) {
 	assert.InDelta(t, 0.10, sess.OwnCost(), 1e-9)
 	assert.InDelta(t, 0.18, sess.TotalCost(), 1e-9, "TotalCost counts embedded and live sub-sessions")
 }
+
+// TestGetAllErrors verifies recorded errors are collected in item order,
+// including from sub-sessions, and that GetAllMessages keeps excluding them.
+func TestGetAllErrors(t *testing.T) {
+	t.Parallel()
+
+	sess := New(WithUserMessage("hi"))
+	sess.AddError(&Error{Message: "first failure", Code: "model_error", AgentName: "root"})
+
+	sub := New(WithParentID(sess.ID))
+	sub.AddError(&Error{Message: "sub failure", Code: "tool_failed", AgentName: "child"})
+	sess.AddSubSession(sub)
+
+	sess.AddError(&Error{Message: "second failure", Code: "context_exceeded", AgentName: "root"})
+
+	errs := sess.GetAllErrors()
+	require.Len(t, errs, 3)
+	assert.Equal(t, "first failure", errs[0].Message)
+	assert.Equal(t, "sub failure", errs[1].Message)
+	assert.Equal(t, "second failure", errs[2].Message)
+	assert.Equal(t, "context_exceeded", errs[2].Code)
+
+	for _, msg := range sess.GetAllMessages() {
+		assert.NotContains(t, msg.Message.Content, "failure", "errors must not leak into messages")
+	}
+}


### PR DESCRIPTION
### What this PR does

Two fixes motivated by a diagnostics report where a run died with a fatal context overflow:

1. **Make the token-overflow message frontend-agnostic.** The fatal overflow error told users to "Try running /compact", but this error travels on the runtime event stream and reaches every consumer (API/serve clients, embedding hosts), not all of which expose a `/compact` command. It also claimed "automatic compaction is not enabled" even when compaction *was* enabled but its overflow-retry budget was exhausted. The message now names the action ("Compact the conversation…") instead of a command and drops the wrong claim.

2. **Include recorded errors in the session recovery export.** Recorded error items (persisted since v1.100.0) are filtered out by `GetAllMessages()`, so `ExportSessionForRecovery` produced a transcript that just stops mid-conversation with no trace of the failure that ended it. Diagnosing the report above required manually reproducing which error the user saw. The export now carries a separate `errors` key (omitted when the session has no recorded errors, so the shape is unchanged for the common case).
