### PR TITLE
test(cache): fix Windows flake in the torn-file concurrency test

### DIFF
--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -260,7 +260,11 @@ func TestFileCache_concurrentStoreNeverYieldsTornFile(t *testing.T) {
 	// half-written content and json.Unmarshal would error.
 	for range 100 {
 		data, err := os.ReadFile(path)
-		if errors.Is(err, os.ErrNotExist) {
+		// Tolerate transient open failures caused by the writer itself:
+		// the file may not exist yet, and on Windows the open can race a
+		// rename replacing it. Only successfully read bytes are asserted
+		// on — the torn-write check is about content, not availability.
+		if errors.Is(err, os.ErrNotExist) || isTransientSharingViolation(err) {
 			continue
 		}
 		require.NoError(t, err)

--- a/pkg/cache/sharing_violation_other_test.go
+++ b/pkg/cache/sharing_violation_other_test.go
@@ -1,0 +1,10 @@
+//go:build !windows
+
+package cache
+
+// isTransientSharingViolation only exists on Windows, where opening a file
+// can transiently fail while a concurrent rename replaces it. POSIX renames
+// never make the destination unopenable.
+func isTransientSharingViolation(error) bool {
+	return false
+}

--- a/pkg/cache/sharing_violation_windows_test.go
+++ b/pkg/cache/sharing_violation_windows_test.go
@@ -1,0 +1,18 @@
+//go:build windows
+
+package cache
+
+import (
+	"errors"
+
+	"golang.org/x/sys/windows"
+)
+
+// isTransientSharingViolation reports whether a file open failed because a
+// concurrent rename-over-existing briefly held the destination. During
+// MoveFileEx(MOVEFILE_REPLACE_EXISTING) the target can be transiently
+// unopenable, so a reader racing Store's temp-file+rename publish sees
+// ERROR_SHARING_VIOLATION; that is not a torn write.
+func isTransientSharingViolation(err error) bool {
+	return errors.Is(err, windows.ERROR_SHARING_VIOLATION)
+}


### PR DESCRIPTION
### What this PR does

Fixes a Windows-only CI flake in `TestFileCache_concurrentStoreNeverYieldsTornFile` (seen e.g. in [this run](https://github.com/docker/docker-agent/actions/runs/31082255105/job/92553513516)):

```
open C:\...\cache.json: The process cannot access the file because it is being used by another process.
```

The test races a reader loop (`os.ReadFile`) against `Store`'s temp-file+rename publishes to prove readers never observe a torn write. On POSIX that's a clean race: rename is atomic and the destination stays openable. On Windows, `MoveFileEx(MOVEFILE_REPLACE_EXISTING)` can make the destination transiently unopenable, so the reader occasionally gets `ERROR_SHARING_VIOLATION` — a timing artifact of the writer itself, not a torn write.

The reader loop already tolerated `os.ErrNotExist` (file not published yet); it now also tolerates the Windows sharing violation, via a build-tagged test helper following the existing `isLockUnavailable` pattern (`pkg/tools/builtin/plan/lock_windows.go`). The test's actual assertion — successfully read bytes always parse as valid JSON — is unchanged.
