### PR TITLE
ci: migrate Hub logins to OIDC

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -199,7 +199,7 @@ jobs:
         id: docker_oidc
         uses: docker/oidc-action@b048fb089ace3e15a5fbdd784f4784d284ce5e8d # v1.1.0
         with:
-          connection-id: fc5234a6-aee3-4f2b-ae8a-75a1c690c1b2
+          connection-id: ${{ vars.DOCKERHUB_OIDC_CONNECTION_ID }}
           expires-in: 3600
 
       - name: Hub login
@@ -300,7 +300,7 @@ jobs:
         id: docker_oidc
         uses: docker/oidc-action@b048fb089ace3e15a5fbdd784f4784d284ce5e8d # v1.1.0
         with:
-          connection-id: fc5234a6-aee3-4f2b-ae8a-75a1c690c1b2
+          connection-id: ${{ vars.DOCKERHUB_OIDC_CONNECTION_ID }}
           expires-in: 3600
 
       - name: Hub login
@@ -355,7 +355,7 @@ jobs:
         id: docker_oidc
         uses: docker/oidc-action@b048fb089ace3e15a5fbdd784f4784d284ce5e8d # v1.1.0
         with:
-          connection-id: fc5234a6-aee3-4f2b-ae8a-75a1c690c1b2
+          connection-id: ${{ vars.DOCKERHUB_OIDC_CONNECTION_ID }}
           expires-in: 3600
 
       - name: Hub login

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -172,6 +172,9 @@ jobs:
   build-and-push-image:
     if: github.event_name != 'pull_request' && !github.event.repository.fork
     needs: [ lint, build-and-test, windows-tests, license-check ]
+    permissions:
+      contents: read
+      id-token: write
     # Build each platform on its own native runner in parallel, push by digest,
     # then assemble the multi-arch manifest in the merge job below.
     strategy:
@@ -192,11 +195,18 @@ jobs:
         env:
           platform: ${{ matrix.platform }}
 
+      - name: Get Docker Hub OIDC token
+        id: docker_oidc
+        uses: docker/oidc-action@b048fb089ace3e15a5fbdd784f4784d284ce5e8d # v1.1.0
+        with:
+          connection-id: fc5234a6-aee3-4f2b-ae8a-75a1c690c1b2
+          expires-in: 3600
+
       - name: Hub login
         uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
-          username: ${{ vars.DOCKERPUBLICBOT_USERNAME }}
-          password: ${{ secrets.DOCKERPUBLICBOT_WRITE_PAT }}
+          username: docker
+          password: ${{ steps.docker_oidc.outputs.token }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
@@ -274,6 +284,9 @@ jobs:
   merge-and-push-image:
     if: github.event_name != 'pull_request' && !github.event.repository.fork
     needs: [ build-and-push-image ]
+    permissions:
+      contents: read
+      id-token: write
     runs-on: ubuntu-latest
     steps:
       - name: Download digests
@@ -283,11 +296,18 @@ jobs:
           pattern: digests-*
           merge-multiple: true
 
+      - name: Get Docker Hub OIDC token
+        id: docker_oidc
+        uses: docker/oidc-action@b048fb089ace3e15a5fbdd784f4784d284ce5e8d # v1.1.0
+        with:
+          connection-id: fc5234a6-aee3-4f2b-ae8a-75a1c690c1b2
+          expires-in: 3600
+
       - name: Hub login
         uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
-          username: ${{ vars.DOCKERPUBLICBOT_USERNAME }}
-          password: ${{ secrets.DOCKERPUBLICBOT_WRITE_PAT }}
+          username: docker
+          password: ${{ steps.docker_oidc.outputs.token }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
@@ -319,6 +339,9 @@ jobs:
   merge-and-push-template:
     if: github.event_name != 'pull_request' && !github.event.repository.fork
     needs: [ build-and-push-image ]
+    permissions:
+      contents: read
+      id-token: write
     runs-on: ubuntu-latest
     steps:
       - name: Download template digests
@@ -328,11 +351,18 @@ jobs:
           pattern: template-digests-*
           merge-multiple: true
 
+      - name: Get Docker Hub OIDC token
+        id: docker_oidc
+        uses: docker/oidc-action@b048fb089ace3e15a5fbdd784f4784d284ce5e8d # v1.1.0
+        with:
+          connection-id: fc5234a6-aee3-4f2b-ae8a-75a1c690c1b2
+          expires-in: 3600
+
       - name: Hub login
         uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
-          username: ${{ vars.DOCKERPUBLICBOT_USERNAME }}
-          password: ${{ secrets.DOCKERPUBLICBOT_WRITE_PAT }}
+          username: docker
+          password: ${{ steps.docker_oidc.outputs.token }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0


### PR DESCRIPTION
## Summary

Migrates the three Hub push jobs in ci.yml from PAT-based login (DOCKERPUBLICBOT) to short-lived OIDC tokens, using the OIDC connection pattern already established in other Docker org repositories.

| Job | Change |
|---|---|
| build-and-push-image | job-level id-token: write, OIDC token exchange, login as docker with the exchanged token |
| merge-and-push-image | same |
| merge-and-push-template | same |

## Details

- Uses docker/oidc-action@b048fb0 (v1.1.0) with the current connection-id input (the connection_id form is deprecated in v1.x).
- The connection ID is read from the repository variable DOCKERHUB_OIDC_CONNECTION_ID, so the connection can be rotated without a code change.
- expires-in: 3600 (the maximum): the multi-arch digest builds with SBOM and provenance can outlive the 300 s default token TTL.
- The connection is scoped to pull and push on docker/docker-agent and docker/docker-agent-sbx-templates only, with subject claims restricted to this repository's main branch and v* tags.
- The job-level permissions blocks override the top-level contents: read for the three push jobs only. Artifact upload/download between jobs uses the runtime token and needs no extra permission.
- vars.DOCKERPUBLICBOT_USERNAME and secrets.DOCKERPUBLICBOT_WRITE_PAT are no longer referenced by this workflow.

## Validation

- scripts/workflow-lint.sh passes (SHA pinning check covers the new action reference).
- The push jobs are gated on non-PR events, so PR CI exercises only the linters; the first push to main (edge tag) is the end-to-end proof. A workflow_dispatch from a branch other than main will fail the token exchange by design (no matching subject claim).
- Merge prerequisite: the DOCKERHUB_OIDC_CONNECTION_ID repository variable must exist before this lands, otherwise the token exchange fails on the next main push.