### PR TITLE
docs: auto-update for merged PRs (2026-08-07)

### DIFF
--- a/docs/features/cli/index.md
+++ b/docs/features/cli/index.md
@@ -39,7 +39,7 @@ $ docker agent run [config] [message...] [flags]
 | `--dry-run`                             | Initialize the agent without executing anything (useful for validating a config)                                                          |
 | `--remote <addr>`                       | Use a remote runtime at the given address instead of running the agent locally. Mutually exclusive with `--sandbox`, `--worktree`, `--worktree-pr`, `--worktree-base`, `--session`, `--session-db`, `--record`, and `--fake` — a remote runtime owns its own session storage and execution environment, so these local-only concerns don't apply. |
 | `--listen <addr>`                       | Expose this run's control plane over HTTP so an external process can drive the running TUI (send follow-ups, stream events, read the title). Accepts `host:port` or `unix://`, `npipe://`, `fd://`. Hidden from `docker agent run --help` — like `debug`, it's a stable but advanced/automation-oriented flag rather than a day-to-day one. See the [API Server](../api-server/index.md#listen) guide for the full walkthrough. |
-| `--lean`                                | Use a simplified, non-alternate-screen TUI. Unlike the default full-screen TUI, this renders inline in the normal terminal buffer — useful in environments where an alternate screen is unwanted (e.g. inside tmux panes, CI with a tty, or log-friendly pipelines). Displays an ASCII art banner on startup. |
+| `--lean`                                | Use a simplified, non-alternate-screen TUI. Unlike the default full-screen TUI, this renders inline in the normal terminal buffer — useful in environments where an alternate screen is unwanted (e.g. inside tmux panes, CI with a tty, or log-friendly pipelines). Like the full TUI, displays an ASCII art banner on startup when the chat is empty. |
 | `--app-name <name>`                     | Override the application name label shown in the TUI (status bar, window title, "/exit" notifications).                                   |
 | `--sidebar`                             | Control sidebar visibility. Set to `--sidebar=false` to hide the sidebar and disable the Ctrl+B toggle (default: `true`).                 |
 | `--disable-commands <list>`             | Hide and disable specific slash commands in the TUI. Accepts a comma-separated list of command names (leading slash optional, case-insensitive). E.g. `--disable-commands="/cost,/eval,/model"`. |
@@ -104,7 +104,7 @@ $ docker agent run --agent-picker=myorg/coder,myorg/researcher
 > [!TIP]
 > **Lean, inline TUI**
 >
-> Pass `--lean` to get a lightweight TUI that renders inline in your terminal (no alternate screen). It displays an ASCII art banner on startup and supports the same slash commands and streaming output as the full TUI, making it handy inside tmux, scripts, or any context where a full-screen takeover is unwanted.
+> Pass `--lean` to get a lightweight TUI that renders inline in your terminal (no alternate screen). Like the full TUI, it displays an ASCII art banner on startup when the chat is empty, and supports the same slash commands and streaming output, making it handy inside tmux, scripts, or any context where a full-screen takeover is unwanted.
 
 > [!TIP]
 > **Isolate a run in a git worktree**

--- a/docs/features/tui/index.md
+++ b/docs/features/tui/index.md
@@ -13,6 +13,8 @@ _Docker Agent's default interface is a rich, interactive terminal UI with file a
 
 ## Launching the TUI
 
+Both the full TUI and the lean TUI display a centered ASCII art Docker Agent banner on startup when the chat is empty. The banner is automatically hidden once the agent starts responding or when a custom welcome message is configured.
+
 ```bash
 # Launch with a config
 $ docker agent run agent.yaml

--- a/docs/features/tui/index.md
+++ b/docs/features/tui/index.md
@@ -227,6 +227,24 @@ The TUI renders Mermaid diagram blocks inline rather than displaying raw syntax.
 
 Mermaid rendering works in both the full TUI and the lean TUI. Unsupported or syntactically invalid diagram blocks are displayed as ordinary fenced code blocks — no configuration is required and there is no way to disable it.
 
+### LaTeX Math Rendering
+
+The TUI renders LaTeX math expressions as terminal-friendly Unicode text. When an assistant message contains inline math (delimited by `$…$`) or display math (delimited by `$$…$$`), the TUI converts supported LaTeX commands to their Unicode equivalents and displays them directly in the conversation.
+
+Supported features include:
+
+- Greek letters (`\alpha`, `\beta`, `\gamma`, …)
+- Mathematical operators (`\times`, `\div`, `\pm`, `\oplus`, …)
+- Relations (`\le`, `\ge`, `\approx`, `\equiv`, …)
+- Set operators (`\cap`, `\cup`, `\subset`, `\in`, …)
+- Calculus symbols (`\int`, `\sum`, `\prod`, `\partial`, `\nabla`, …)
+- Arrows and logic (`\to`, `\implies`, `\forall`, `\exists`, …)
+- Superscripts and subscripts (e.g., `x^2`, `a_i`)
+- Fractions (`\frac{a}{b}`), square roots (`\sqrt{x}`), and matrices
+- Common functions (`\sin`, `\cos`, `\log`, `\lim`, …)
+
+Unsupported or syntactically invalid LaTeX expressions fall back to displaying the raw source. LaTeX rendering works in both the full TUI and the lean TUI, requires no configuration, and cannot be disabled.
+
 ### Markdown Images
 
 The TUI fetches and renders images referenced in agent responses using the Kitty graphics protocol. When an assistant message contains a standard Markdown image reference, the TUI downloads the image in the background and displays it inline at the point of the reference. While the image is loading a placeholder is shown; once loaded, the message re-renders with the image in place.


### PR DESCRIPTION
## Documentation Updates

This PR updates the  directory to reflect code changes merged into `main` in the last 36 hours.

### Changes

Two documentation updates covering recent feature additions to the TUI:

#### 1. LaTeX Math Rendering (PR #3950)
- **Source**: https://github.com/docker/docker-agent/pull/3950
- **What changed**: Added LaTeX math rendering support to the markdown renderer
- **Doc update**: Added a new "LaTeX Math Rendering" section to `docs/features/tui/index.md` documenting:
  - Inline and display math support (`$…$` and `$$…$$`)
  - Supported LaTeX features (Greek letters, operators, relations, calculus symbols, fractions, etc.)
  - Fallback behavior for unsupported syntax
  - Works in both full and lean TUI

#### 2. Startup Banner in Normal TUI (PR #3949)
- **Source**: https://github.com/docker/docker-agent/pull/3949
- **What changed**: Extended the ASCII art startup banner to the normal (full-screen) TUI
- **Doc update**: Updated `docs/features/tui/index.md` and `docs/features/cli/index.md` to clarify:
  - Both the full TUI and lean TUI now display the startup banner
  - Banner is shown when the chat is empty and hides automatically once the agent responds
  - Previously the banner was only documented for the lean TUI

---

**Commits**: 2 atomic commits, one per source PR
**No code changes**: Only `/docs` files were modified