### PR TITLE
docs: auto-update for merged PRs (2026-08-13)

### DIFF
--- a/docs/concepts/distribution/index.md
+++ b/docs/concepts/distribution/index.md
@@ -108,11 +108,11 @@ $ docker agent run docker.io/myorg/private-agent:latest
 ```
 
 > [!NOTE]
-> **Docker Desktop credentials**
+> **Docker authentication**
 >
-> When pulling or running an agent from a `docker.com` or `*.docker.com` HTTPS URL (e.g. `desktop.docker.com`), Docker Agent automatically forwards your Docker Desktop JWT for authentication — no explicit login required when Docker Desktop is running and signed in.
+> When pulling or running an agent from a `docker.com` or `*.docker.com` HTTPS URL (e.g. `desktop.docker.com`), Docker Agent automatically forwards a Docker token for authentication. If Docker Desktop is running and signed in, its token is used; otherwise, Docker Agent exchanges the access token stored by `docker login` for a fresh Docker token. Either way, no explicit login step is required beyond `docker login` (or being signed into Docker Desktop).
 >
-> Note: `docker.io` (the standard Docker Hub registry domain) is a separate domain and is **not** covered by automatic JWT forwarding. Agents pulled from `docker.io` or `registry-1.docker.io` still require `docker login docker.io` for private repositories.
+> Note: `docker.io` (the standard Docker Hub registry domain) is a separate domain and is **not** covered by automatic token forwarding. Agents pulled from `docker.io` or `registry-1.docker.io` still require `docker login docker.io` for private repositories.
 
 > [!NOTE]
 > **Troubleshooting**


### PR DESCRIPTION
This PR updates documentation to reflect code changes merged into `main` in the last 36 hours.

## Documentation Changes

### PR #3935: Docker token exchange feature

**Updated:** `/docs/concepts/distribution/index.md`

- Changed "Docker Desktop credentials" section to "Docker authentication"
- Updated text to reflect that `docker login` is now sufficient for authenticating Docker-domain registry pulls, even without Docker Desktop running
- Explained that Docker Agent can exchange the access token stored by `docker login` for a fresh Docker token when Docker Desktop is not available

This completes the documentation updates for the token exchange mechanism introduced in PR #3935. The PR already included updates to:
- `/docs/configuration/overview/index.md` (new environment variables)
- `/docs/features/cli/index.md` (updated `debug auth` command description)
- `/docs/guides/secrets/index.md` (new "Docker Authentication" section)

The distribution docs were the only remaining documentation that still implied Docker Desktop was required for Docker-domain registry authentication.

---

**Source PR:** https://github.com/docker/docker-agent/pull/3935