### PR TITLE
docs: add missing built-in tools to concepts overview

### DIFF
--- a/docs/concepts/tools/index.md
+++ b/docs/concepts/tools/index.md
@@ -49,6 +49,12 @@ Docker Agent ships with several built-in tools that require no external dependen
 | [Handoff](../../tools/handoff/index.md) | Hand the conversation off to another local agent in the same config (auto-enabled with `handoffs:`) |
 | [A2A](../../tools/a2a/index.md) | Connect to remote agents via the Agent-to-Agent protocol |
 | [MCP Catalog](../../tools/mcp-catalog/index.md) | Discover and activate remote MCP servers from the Docker MCP Catalog on demand |
+| [Git](../../tools/git/index.md) | Read-only git repository inspection |
+| [Scheduler](../../tools/scheduler/index.md) | Schedule instructions to run at a fixed time or recurring interval |
+| [Webhook](../../tools/webhook/index.md) | Outbound notifications to Slack, Discord, Telegram, and more |
+| [Plan](../../tools/plan/index.md) | Shared persistent scratchpad for multi-agent collaboration |
+| [Session Plan](../../tools/session_plan/index.md) | Per-session plan tracker for the draft/review/execute workflow |
+| [Session Context](../../tools/session_context/index.md) | Reference a previous session as context |
 
 ## MCP Tools
 

--- a/docs/concepts/tools/index.md
+++ b/docs/concepts/tools/index.md
@@ -50,8 +50,8 @@ Docker Agent ships with several built-in tools that require no external dependen
 | [A2A](../../tools/a2a/index.md) | Connect to remote agents via the Agent-to-Agent protocol |
 | [MCP Catalog](../../tools/mcp-catalog/index.md) | Discover and activate remote MCP servers from the Docker MCP Catalog on demand |
 | [Git](../../tools/git/index.md) | Read-only git repository inspection |
-| [Scheduler](../../tools/scheduler/index.md) | Schedule instructions to run at a fixed time or recurring interval |
-| [Webhook](../../tools/webhook/index.md) | Outbound notifications to Slack, Discord, Telegram, and more |
+| [Scheduler](../../tools/scheduler/index.md) | Schedule instructions to run at a time or on a recurring interval |
+| [Webhook](../../tools/webhook/index.md) | Outbound notifications to Slack, Discord, Telegram, IFTTT, and more |
 | [Plan](../../tools/plan/index.md) | Shared persistent scratchpad for multi-agent collaboration |
 | [Session Plan](../../tools/session_plan/index.md) | Per-session plan tracker for the draft/review/execute workflow |
 | [Session Context](../../tools/session_context/index.md) | Reference a previous session as context |


### PR DESCRIPTION
> 🤖 **Automated implementer agent** — *this comment was posted by the implementer bot from Docker Agentic Platform, not by a human developer*

Closes #3971.

Six built-in tools (Git, Scheduler, Webhook, Plan, Session Plan, Session Context) each have full documentation pages under `docs/tools/` but were absent from the Built-in Tools table in `docs/concepts/tools/index.md`. This made them undiscoverable from the main concepts overview.

Added all six rows ordered by their `weight:` frontmatter (125–210), appended after the existing MCP Catalog entry. Descriptions are taken verbatim from each tool's own frontmatter.

Docs-only change; no build or test impact.