### PR TITLE
fix(runtime): sanitize malformed tool call names before persisting to session

### DIFF
--- a/pkg/runtime/after_llm_call_test.go
+++ b/pkg/runtime/after_llm_call_test.go
@@ -302,6 +302,74 @@ func TestAfterLLMCallHook_HarnessUsageWithoutCostIsUnpriced(t *testing.T) {
 		"a harness that reports no cost must yield nil cost (unpriced), not 0 (free)")
 }
 
+// TestSanitizeToolCallName unit-tests the name sanitization function that
+// prevents malformed model-emitted tool call names from poisoning session
+// history and causing non-retriable ValidationExceptions on strict providers
+// (e.g. AWS Bedrock Converse).
+func TestSanitizeToolCallName(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"read_file", "read_file"},
+		{"my-tool_v2", "my-tool_v2"},
+		// Exact incident: attribute syntax leaked into name field
+		{`view_file" path="install/step4.php" startLine="27" endLine="60`, "view_file"},
+		// Colon and slash — common in MCP server-qualified names
+		{"server:tool", "server"},
+		{"server/tool", "server"},
+		// Dot — e.g. "server.tool"
+		{"server.tool", "server"},
+		// Space
+		{"my tool", "my"},
+		// Name starting with invalid char falls back to unknown_tool
+		{`" path="foo"`, "unknown_tool"},
+		{"", "unknown_tool"},
+		// Name longer than 64 chars is capped
+		{string(make([]byte, 80)), "unknown_tool"}, // all zero bytes are invalid
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, sanitizeToolCallName(tt.input))
+		})
+	}
+}
+
+// TestMalformedToolCallNameSanitizedBeforeStore is a regression test for the
+// incident where a model emitted `view_file" path="..."` as a tool call name.
+// The assistant message written to the session must carry the sanitized name
+// so that replay to strict providers (AWS Bedrock) does not fail.
+func TestMalformedToolCallNameSanitizedBeforeStore(t *testing.T) {
+	t.Parallel()
+
+	malformedName := `view_file" path="install/step4.php" startLine="27" endLine="60`
+
+	stream := newStreamBuilder().
+		AddToolCallName("tc-1", malformedName).
+		AddToolCallArguments("tc-1", `{}`).
+		AddToolCallStopWithUsage(10, 5).
+		Build()
+
+	sess := session.New(session.WithUserMessage("show me step4.php"))
+	events := runSession(t, sess, stream)
+
+	var assistantMsg *session.Message
+	for _, ev := range events {
+		if e, ok := ev.(*MessageAddedEvent); ok && e.Message != nil && e.Message.Message.Role == chat.MessageRoleAssistant {
+			assistantMsg = e.Message
+		}
+	}
+
+	require.NotNil(t, assistantMsg, "expected an assistant message to be persisted")
+	require.Len(t, assistantMsg.Message.ToolCalls, 1)
+	assert.Equal(t, "view_file", assistantMsg.Message.ToolCalls[0].Function.Name,
+		"malformed name must be truncated at the first invalid character before storage")
+}
+
 // TestComputeMessageCost unit-tests the single cost-arithmetic source
 // shared by the persisted message and the after_llm_call payload,
 // including every branch that yields nil (unpriced).

--- a/pkg/runtime/loop.go
+++ b/pkg/runtime/loop.go
@@ -1261,7 +1261,7 @@ var validToolNameRe = regexp.MustCompile(`^[a-zA-Z0-9_-]{1,64}$`)
 // entire name is invalid.
 func sanitizeToolCallName(name string) string {
 	end := strings.IndexFunc(name, func(r rune) bool {
-		return !('a' <= r && r <= 'z' || 'A' <= r && r <= 'Z' || '0' <= r && r <= '9' || r == '_' || r == '-')
+		return (r < 'a' || r > 'z') && (r < 'A' || r > 'Z') && (r < '0' || r > '9') && r != '_' && r != '-'
 	})
 	if end >= 0 {
 		name = name[:end]

--- a/pkg/runtime/loop.go
+++ b/pkg/runtime/loop.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"path/filepath"
 	"reflect"
+	"regexp"
 	"slices"
 	"strings"
 	"time"
@@ -1161,14 +1162,32 @@ func (r *LocalRuntime) recordAssistantMessage(
 		return nil
 	}
 
+	// Sanitize tool call names before persisting. A model may hallucinate
+	// attribute-style syntax into the name field (e.g. `view_file" path="..."`);
+	// strict providers like AWS Bedrock reject names outside [a-zA-Z0-9_-]{1,64}
+	// with a non-retriable ValidationException when the poisoned name is replayed
+	// in conversation history.
+	calls := res.Calls
+	for i, tc := range calls {
+		if !validToolNameRe.MatchString(tc.Function.Name) {
+			safe := sanitizeToolCallName(tc.Function.Name)
+			slog.Warn("Sanitizing malformed tool call name",
+				"agent", a.Name(),
+				"original", tc.Function.Name,
+				"sanitized", safe,
+			)
+			calls[i].Function.Name = safe
+		}
+	}
+
 	// Resolve tool definitions for the tool calls.
 	var toolDefs []tools.Tool
-	if len(res.Calls) > 0 {
+	if len(calls) > 0 {
 		toolMap := make(map[string]tools.Tool, len(agentTools))
 		for _, t := range agentTools {
 			toolMap[t.Name] = t
 		}
-		for _, call := range res.Calls {
+		for _, call := range calls {
 			if def, ok := toolMap[call.Function.Name]; ok {
 				toolDefs = append(toolDefs, def)
 			}
@@ -1203,7 +1222,7 @@ func (r *LocalRuntime) recordAssistantMessage(
 		ReasoningContent:  res.ReasoningContent,
 		ThinkingSignature: res.ThinkingSignature,
 		ThoughtSignature:  res.ThoughtSignature,
-		ToolCalls:         res.Calls,
+		ToolCalls:         calls,
 		ToolDefinitions:   toolDefs,
 		CreatedAt:         r.now().Format(time.RFC3339),
 		Usage:             res.Usage,
@@ -1226,6 +1245,34 @@ func (r *LocalRuntime) recordAssistantMessage(
 		FinishReason: res.FinishReason,
 	}
 	return msgUsage
+}
+
+// validToolNameRe matches the subset of tool names providers like AWS Bedrock
+// accept (pattern [a-zA-Z0-9_-]+, 1–64 chars). Names that fall outside this
+// set are sanitized by sanitizeToolCallName before being persisted.
+var validToolNameRe = regexp.MustCompile(`^[a-zA-Z0-9_-]{1,64}$`)
+
+// sanitizeToolCallName returns a provider-safe version of a model-emitted tool
+// call name by keeping only the leading [a-zA-Z0-9_-]+ run and capping at 64
+// chars. A model may hallucinate attribute-style syntax into the name field
+// (e.g. `view_file" path="foo.php" ...`); truncating at the first illegal
+// character recovers the intended name and prevents the poisoned string from
+// being replayed to strict providers. Falls back to "unknown_tool" when the
+// entire name is invalid.
+func sanitizeToolCallName(name string) string {
+	end := strings.IndexFunc(name, func(r rune) bool {
+		return !('a' <= r && r <= 'z' || 'A' <= r && r <= 'Z' || '0' <= r && r <= '9' || r == '_' || r == '-')
+	})
+	if end >= 0 {
+		name = name[:end]
+	}
+	if len(name) > 64 {
+		name = name[:64]
+	}
+	if name == "" {
+		return "unknown_tool"
+	}
+	return name
 }
 
 // usageHasTokens reports whether any billable tokens were recorded for a turn.


### PR DESCRIPTION
## Summary

- A model may hallucinate attribute-style syntax into a tool call name (e.g. `view_file" path="install/step4.php" startLine="27" endLine="60"`) — confirmed via session `16127c9a-09d0-44ff-ab48-1bf32e206eec`
- AWS Bedrock rejects names outside `[a-zA-Z0-9_-]{1,64}` with a non-retriable 400 ValidationException when the name is replayed from conversation history
- `sanitizeToolCallName` truncates at the first illegal character, caps at 64 chars, falls back to `unknown_tool` — applied in `recordAssistantMessage` before writing to session, with a `Warn` log when a name is changed

## Test plan

- [ ] `TestSanitizeToolCallName` — 11 unit cases covering exact incident pattern, colons, slashes, dots, spaces, all-invalid prefix, empty, >64-char
- [ ] `TestMalformedToolCallNameSanitizedBeforeStore` — end-to-end: stream emits malformed name, assert persisted `MessageAddedEvent` carries truncated name
- [ ] `go test ./pkg/runtime/ -count=1`