### PR TITLE
fix: migrate Nebius alias to Token Factory

### DIFF
--- a/docs/providers/nebius/index.md
+++ b/docs/providers/nebius/index.md
@@ -1,20 +1,22 @@
 ---
-title: "Nebius"
-description: "Use Nebius AI models with Docker Agent."
-keywords: docker agent, ai agents, model providers, llm, nebius
+title: "Nebius Token Factory"
+description: "Use Nebius Token Factory models with Docker Agent."
+keywords: docker agent, ai agents, model providers, llm, nebius, token factory
 weight: 190
 canonical: https://docs.docker.com/ai/docker-agent/providers/nebius/
 ---
 
-_Use Nebius AI models with Docker Agent._
+_Use Nebius Token Factory models with Docker Agent._
 
 ## Overview
 
-Nebius provides AI models through an OpenAI-compatible API. Docker Agent includes built-in support for Nebius as an alias provider.
+[Nebius Token Factory](https://tokenfactory.nebius.com/) provides hosted AI
+models through an OpenAI-compatible API. Docker Agent includes built-in support
+for Token Factory as the `nebius` alias provider.
 
 ## Setup
 
-1. Get an API key from [Nebius AI](https://nebius.ai/)
+1. Create a project API key in [Nebius Token Factory](https://tokenfactory.nebius.com/).
 2. Set the environment variable:
 
    ```bash
@@ -30,8 +32,8 @@ The simplest way to use Nebius:
 ```yaml
 agents:
   root:
-    model: nebius/deepseek-ai/DeepSeek-V3
-    description: Assistant using Nebius
+    model: nebius/openai/gpt-oss-120b
+    description: Assistant using Nebius Token Factory
     instruction: You are a helpful assistant.
 ```
 
@@ -43,33 +45,36 @@ For more control over parameters:
 models:
   nebius_model:
     provider: nebius
-    model: deepseek-ai/DeepSeek-V3
+    model: openai/gpt-oss-120b
     temperature: 0.7
     max_tokens: 8192
 
 agents:
   root:
     model: nebius_model
-    description: Assistant using Nebius
+    description: Assistant using Nebius Token Factory
     instruction: You are a helpful assistant.
 ```
 
 ## Available Models
 
-Nebius hosts various open models. Check the [Nebius documentation](https://nebius.ai/docs) for the current model catalog.
+Token Factory's catalog changes as models launch and retire. With your API key
+configured, list the models currently available to your project:
 
-| Model                               | Description                     |
-| ----------------------------------- | ------------------------------- |
-| `deepseek-ai/DeepSeek-V3`           | DeepSeek V3 model               |
-| `Qwen/Qwen2.5-72B-Instruct`         | Qwen 2.5 72B instruction-tuned  |
-| `meta-llama/Llama-3.3-70B-Instruct` | Llama 3.3 70B instruction-tuned |
+```console
+$ docker agent models --provider nebius
+```
+
+You can also browse models in the [Token Factory
+console](https://tokenfactory.nebius.com/models). Model IDs are case-sensitive;
+copy the full ID shown by the CLI or console.
 
 ## How It Works
 
 Nebius is implemented as a built-in alias in Docker Agent:
 
 - **API Type:** OpenAI-compatible (`openai_chatcompletions`)
-- **Base URL:** `https://api.studio.nebius.com/v1`
+- **Base URL:** `https://api.tokenfactory.nebius.com/v1`
 - **Token Variable:** `NEBIUS_API_KEY`
 
 ## Example: Code Assistant
@@ -77,10 +82,10 @@ Nebius is implemented as a built-in alias in Docker Agent:
 ```yaml
 agents:
   coder:
-    model: nebius/deepseek-ai/DeepSeek-V3
-    description: Code assistant using DeepSeek
+    model: nebius/openai/gpt-oss-120b
+    description: Code assistant using Nebius Token Factory
     instruction: |
-      You are an expert programmer using DeepSeek V3.
+      You are an expert programmer.
       Write clean, well-documented code.
       Follow best practices for the language being used.
     toolsets:

--- a/examples/nebius.yaml
+++ b/examples/nebius.yaml
@@ -1,15 +1,14 @@
 agents:
   root:
-    model: grok-model
-    description: A helpful AI assistant powered by Nebius
+    model: token-factory-model
+    description: A helpful AI assistant powered by Nebius Token Factory
     instruction: |
-      You are a LLM model, a helpful and maximally truthful AI built by Moonshotai.
+      You are a helpful and maximally truthful AI assistant.
       Be helpful, accurate, and concise in your responses.
-      You are not based on any other companies and their models.
 
 models:
-  grok-model:
+  token-factory-model:
     provider: nebius
-    model: moonshotai/Kimi-K2.5
-    max_tokens: 110000
+    model: openai/gpt-oss-120b
+    max_tokens: 8192
     temperature: 0.7

--- a/pkg/model/provider/aliases.go
+++ b/pkg/model/provider/aliases.go
@@ -51,7 +51,7 @@ var Aliases = map[string]Alias{
 	},
 	"nebius": {
 		APIType:     "openai",
-		BaseURL:     "https://api.studio.nebius.com/v1",
+		BaseURL:     "https://api.tokenfactory.nebius.com/v1",
 		TokenEnvVar: "NEBIUS_API_KEY",
 	},
 	"nvidia": {

--- a/pkg/model/provider/aliases_test.go
+++ b/pkg/model/provider/aliases_test.go
@@ -63,6 +63,18 @@ func TestCatalogAliases(t *testing.T) {
 	}
 }
 
+func TestNebiusAliasUsesTokenFactoryEndpoint(t *testing.T) {
+	t.Parallel()
+
+	alias, ok := LookupAlias("nebius")
+	require.True(t, ok)
+	assert.Equal(t, Alias{
+		APIType:     "openai",
+		BaseURL:     "https://api.tokenfactory.nebius.com/v1",
+		TokenEnvVar: "NEBIUS_API_KEY",
+	}, alias)
+}
+
 // TestCloudflareAliases asserts the two Cloudflare aliases resolve to their
 // account/gateway-scoped, env-templated base URLs. Unlike the static aliases
 // above, their BaseURL carries ${...} references that are expanded at


### PR DESCRIPTION
## What changed

- point the existing `nebius` alias at the Nebius Token Factory inference endpoint
- add a regression test that locks the alias to the Token Factory URL and existing API-key variable
- refresh the provider guide and example with Token Factory branding and a current model ID
- replace the static model table with Docker Agent's live catalog command and the Token Factory console

## Why

Nebius AI Studio evolved into Nebius Token Factory. The old `api.studio.nebius.com` endpoint and the provider page's sample catalog were left behind, so the built-in alias sent new users to a legacy endpoint and the example referenced a retired model.

This repairs the existing alias; it does not add another provider or generated model catalog. The provider remains on Docker Agent's OpenAI-compatible Chat Completions path.

Nebius migration reference: https://docs.tokenfactory.nebius.com/other-capabilities/migration-guide

## Impact

Configurations using `provider: nebius` now target `https://api.tokenfactory.nebius.com/v1` while keeping the same `NEBIUS_API_KEY` contract. Users get current setup guidance and can discover the catalog without another hard-coded model list becoming stale.

## Validation

- `go test ./pkg/model/provider -run 'Test(LookupAlias|CatalogAliases|NebiusAliasUsesTokenFactoryEndpoint)$' -count=1`
- `go test ./...`
- `./scripts/build.sh`
- `go run ./lint .` (1,793 files, no offenses)
- `go mod tidy -diff`
- `npx --yes markdownlint-cli2@0.22.1 providers/nebius/index.md` (118 files, 0 errors)
- `docker-agent models --all --provider nebius --format json` (includes `openai/gpt-oss-120b`)
- `git diff --check`

Live inference was not run because no Token Factory API key was available in the test environment.
