### PR TITLE
feat(runtime): resume external harness sessions

### DIFF
--- a/pkg/runtime/harness.go
+++ b/pkg/runtime/harness.go
@@ -21,7 +21,7 @@ import (
 	"github.com/docker/docker-agent/pkg/tools"
 )
 
-func (r *LocalRuntime) runHarnessAgent(ctx context.Context, sess *session.Session, a *agent.Agent, baseExtra, baseLegacy []chat.Message, baseSources []session.InstructionSource, events EventSink) string {
+func (r *LocalRuntime) runHarnessAgent(ctx context.Context, sess *session.Session, a *agent.Agent, events EventSink) string {
 	ctx, span := r.startSpan(ctx, "runtime.harness", trace.WithAttributes(traceAttributesForHarness(sess, a)...))
 	defer span.End()
 
@@ -46,10 +46,9 @@ func (r *LocalRuntime) runHarnessAgent(ctx context.Context, sess *session.Sessio
 		r.executeTurnEndHooks(context.WithoutCancel(ctx), sess, a, endReason, events)
 	}()
 
-	turnStartMsgs := r.executeTurnStartHooks(ctx, sess, a, events)
-	legacyExtras := append(slices.Clone(baseLegacy), turnStartMsgs.legacyMessages()...)
-	messages := r.messagesWithDynamicContext(ctx, sess, a,
-		instructionSources(baseExtra, nil, turnStartMsgs, baseSources...), legacyExtras)
+	// Harnesses own their context; run lifecycle hooks but do not forward injected instructions.
+	r.executeTurnStartHooks(ctx, sess, a, events)
+	messages := harnessInputMessages(sess)
 	stop, msg, rewritten := r.executeBeforeLLMCallHooks(ctx, sess, a, modelID, 1, messages)
 	if stop {
 		slog.WarnContext(ctx, "before_llm_call hook signalled run termination",
@@ -63,7 +62,16 @@ func (r *LocalRuntime) runHarnessAgent(ctx context.Context, sess *session.Sessio
 	}
 	messages = r.applyBeforeLLMCallTransforms(ctx, sess, a, modelID, messages)
 
-	prompt := harnessPromptFromMessages(messages)
+	harnessSessionID := harnessSessionIDFor(sess, a)
+	prompt := strings.TrimSpace(harnessPrompt(messages))
+	if prompt == "" {
+		msg := "cannot run external harness without a user prompt"
+		events.Emit(ErrorWithCodeForSession(sess.ID, ErrorCodeModelError, msg))
+		r.notifyError(ctx, a, sess.ID, msg)
+		span.SetStatus(codes.Error, "harness prompt is empty")
+		endReason = turnEndReasonError
+		return endReason
+	}
 	var streamed strings.Builder
 	var finalResult string
 	var usage *chat.Usage
@@ -116,8 +124,11 @@ func (r *LocalRuntime) runHarnessAgent(ctx context.Context, sess *session.Sessio
 		}
 	}
 
-	err = baseharness.Run(ctx, provider, prompt, func(ev baseharness.Event) {
+	var reportedHarnessSessionID string
+	handleEvent := func(ev baseharness.Event) {
 		switch ev.Type {
+		case baseharness.EventSessionID:
+			reportedHarnessSessionID = strings.TrimSpace(ev.SessionID)
 		case baseharness.EventText:
 			if ev.Text == "" {
 				return
@@ -162,7 +173,12 @@ func (r *LocalRuntime) runHarnessAgent(ctx context.Context, sess *session.Sessio
 				cost = ev.Usage.TotalCostUSD
 			}
 		}
-	})
+	}
+	if harnessSessionID == "" {
+		err = baseharness.Run(ctx, provider, prompt, handleEvent)
+	} else {
+		err = baseharness.Resume(ctx, provider, harnessSessionID, prompt, handleEvent)
+	}
 	if err != nil {
 		if ctx.Err() != nil {
 			completeRemainingToolCalls(tools.ResultError("External harness was canceled."))
@@ -179,6 +195,9 @@ func (r *LocalRuntime) runHarnessAgent(ctx context.Context, sess *session.Sessio
 		span.SetStatus(codes.Error, "harness run error")
 		endReason = turnEndReasonError
 		return endReason
+	}
+	if reportedHarnessSessionID != "" && reportedHarnessSessionID != harnessSessionID {
+		r.rememberHarnessSessionID(ctx, sess, a, reportedHarnessSessionID)
 	}
 
 	completeRemainingToolCalls(harnessToolCompletedResult())
@@ -380,16 +399,44 @@ func (r *LocalRuntime) recordHarnessAssistantMessage(sess *session.Session, a *a
 	}
 }
 
-func harnessPromptFromMessages(messages []chat.Message) string {
-	var b strings.Builder
-	for _, msg := range messages {
-		content := harnessMessageContent(msg)
-		if strings.TrimSpace(content) == "" {
-			continue
-		}
-		fmt.Fprintf(&b, "<%s>\n%s\n</%s>\n\n", msg.Role, content, msg.Role)
+func harnessSessionAttributeKey(sess *session.Session, a *agent.Agent) string {
+	return fmt.Sprintf("docker-agent.harness.session.%s.%s.%s", sess.ID, a.Name(), codingharness.Label(a.Harness()))
+}
+
+func harnessSessionIDFor(sess *session.Session, a *agent.Agent) string {
+	return sess.AttributesSnapshot()[harnessSessionAttributeKey(sess, a)]
+}
+
+func (r *LocalRuntime) rememberHarnessSessionID(ctx context.Context, sess *session.Session, a *agent.Agent, harnessSessionID string) {
+	sess.SetAttribute(harnessSessionAttributeKey(sess, a), harnessSessionID)
+	if sess.IsSubSession() {
+		// SubSessionCompleted persists the full child after its stream drains.
+		return
 	}
-	return strings.TrimSpace(b.String())
+	if r.sessionStore == nil {
+		return
+	}
+	if err := r.sessionStore.UpdateSession(context.WithoutCancel(ctx), sess); err != nil {
+		slog.WarnContext(ctx, "Failed to persist harness session ID", "session_id", sess.ID, "agent", a.Name(), "error", err)
+	}
+}
+
+func harnessInputMessages(sess *session.Session) []chat.Message {
+	for _, item := range slices.Backward(sess.MessagesSnapshot()) {
+		if item.Message != nil && !item.Message.Implicit && item.Message.Message.Role == chat.MessageRoleUser {
+			return []chat.Message{item.Message.Message}
+		}
+	}
+	return nil
+}
+
+func harnessPrompt(messages []chat.Message) string {
+	for _, message := range slices.Backward(messages) {
+		if message.Role == chat.MessageRoleUser {
+			return harnessMessageContent(message)
+		}
+	}
+	return ""
 }
 
 func harnessMessageContent(msg chat.Message) string {

--- a/pkg/runtime/harness_test.go
+++ b/pkg/runtime/harness_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/docker/docker-agent/pkg/js"
 	"github.com/docker/docker-agent/pkg/paths"
 	"github.com/docker/docker-agent/pkg/session"
+	"github.com/docker/docker-agent/pkg/session/sqlitestore"
 	"github.com/docker/docker-agent/pkg/team"
 	"github.com/docker/docker-agent/pkg/tools"
 )
@@ -43,7 +44,9 @@ func TestMain(m *testing.M) {
 		panic(err)
 	}
 	for _, name := range []string{"codex", "claude"} {
-		script := fmt.Sprintf("#!/bin/sh\ncat %q\n", filepath.Join(dir, name+".out"))
+		script := fmt.Sprintf("#!/bin/sh\nprintf '%%s\\n' \"$@\" > %q\ncat %q\nif [ -f %q ]; then exit \"$(cat %q)\"; fi\n",
+			filepath.Join(dir, name+".args"), filepath.Join(dir, name+".out"),
+			filepath.Join(dir, name+".exit"), filepath.Join(dir, name+".exit"))
 		if err := os.WriteFile(filepath.Join(dir, name), []byte(script), 0o755); err != nil {
 			panic(err)
 		}
@@ -75,7 +78,22 @@ func TestMain(m *testing.M) {
 func useHarnessShim(t *testing.T, name, out string) {
 	t.Helper()
 	require.NoError(t, os.WriteFile(filepath.Join(harnessBinDir, name+".out"), []byte(out), 0o600))
+	require.NoError(t, os.RemoveAll(filepath.Join(harnessBinDir, name+".args")))
+	require.NoError(t, os.RemoveAll(filepath.Join(harnessBinDir, name+".exit")))
 	t.Setenv("PATH", harnessBinDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+}
+
+func useFailingHarnessShim(t *testing.T, name, out string) {
+	t.Helper()
+	useHarnessShim(t, name, out)
+	require.NoError(t, os.WriteFile(filepath.Join(harnessBinDir, name+".exit"), []byte("1"), 0o600))
+}
+
+func harnessShimArgs(t *testing.T, name string) string {
+	t.Helper()
+	args, err := os.ReadFile(filepath.Join(harnessBinDir, name+".args"))
+	require.NoError(t, err)
+	return string(args)
 }
 
 func TestHarnessAgentRunStream(t *testing.T) {
@@ -100,6 +118,91 @@ func TestHarnessAgentRunStream(t *testing.T) {
 		}
 	}
 	assert.True(t, sawHarnessModel, "expected AgentInfo event with codex harness label")
+
+	args := harnessShimArgs(t, "codex")
+	assert.Contains(t, args, "do the task")
+	assert.NotContains(t, args, "You are an external coder.")
+	assert.NotContains(t, args, "<user>")
+}
+
+func TestHarnessAgentResumesPersistedSession(t *testing.T) {
+	if stdruntime.GOOS == "windows" {
+		t.Skip("shell script shim test")
+	}
+
+	useHarnessShim(t, "codex", `{"type":"thread.started","thread_id":"thread-123"}
+{"type":"item.completed","item":{"type":"agent_message","text":"first answer"}}
+`)
+
+	store := session.NewInMemorySessionStore()
+	rt := newHarnessRuntimeWithStore(t, "codex", store)
+	sess := session.New(session.WithUserMessage("first question"))
+	collectRuntimeEvents(t, rt, sess)
+
+	loaded, err := store.GetSession(t.Context(), sess.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "thread-123", harnessSessionIDFor(loaded, rt.CurrentAgent()))
+
+	useHarnessShim(t, "codex", `{"type":"thread.started","thread_id":"thread-123"}
+{"type":"item.completed","item":{"type":"agent_message","text":"second answer"}}
+`)
+	loaded.AddMessage(session.UserMessage("follow up only"))
+	rt = newHarnessRuntimeWithStore(t, "codex", store)
+	collectRuntimeEvents(t, rt, loaded)
+
+	args := harnessShimArgs(t, "codex")
+	assert.Contains(t, args, "exec\nresume\nthread-123\n")
+	assert.Contains(t, args, "follow up only")
+	assert.NotContains(t, args, "first question")
+	assert.NotContains(t, args, "first answer")
+	assert.Equal(t, "second answer", loaded.GetLastAssistantMessageContent())
+
+	useFailingHarnessShim(t, "codex", `{"type":"thread.started","thread_id":"failed-thread"}
+`)
+	loaded.AddMessage(session.UserMessage("third question"))
+	events := collectRuntimeEvents(t, rt, loaded)
+	assert.True(t, hasEventType(t, events, &ErrorEvent{}))
+	assert.Equal(t, "thread-123", harnessSessionIDFor(loaded, rt.CurrentAgent()))
+}
+
+func TestHarnessRejectsImplicitOrMissingUserPrompt(t *testing.T) {
+	if stdruntime.GOOS == "windows" {
+		t.Skip("shell script shim test")
+	}
+
+	useHarnessShim(t, "codex", `{"type":"item.completed","item":{"type":"agent_message","text":"unexpected"}}
+`)
+	rt := newHarnessRuntime(t, "codex")
+	sess := session.New(session.WithImplicitUserMessage("Please proceed."))
+	events := collectRuntimeEvents(t, rt, sess)
+
+	assert.True(t, hasEventType(t, events, &ErrorEvent{}))
+	_, err := os.Stat(filepath.Join(harnessBinDir, "codex.args"))
+	assert.ErrorIs(t, err, os.ErrNotExist)
+}
+
+func TestHarnessSubSessionIDSurvivesReconstruction(t *testing.T) {
+	if stdruntime.GOOS == "windows" {
+		t.Skip("shell script shim test")
+	}
+
+	useHarnessShim(t, "codex", `{"type":"thread.started","thread_id":"child-thread"}
+{"type":"item.completed","item":{"type":"agent_message","text":"done"}}
+`)
+	store, err := sqlitestore.New(t.Context(), filepath.Join(t.TempDir(), "sessions.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, store.Close()) })
+	parent := session.New(session.WithID("parent"))
+	require.NoError(t, store.AddSession(t.Context(), parent))
+
+	rt := newHarnessRuntimeWithStore(t, "codex", store)
+	sess := session.New(session.WithParentID(parent.ID), session.WithUserMessage("child task"))
+	collectRuntimeEvents(t, rt, sess)
+	newPersistenceObserver(store).OnEvent(t.Context(), parent, SubSessionCompleted(parent.ID, sess, "root"))
+
+	reconstructed, err := store.GetSession(t.Context(), sess.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "child-thread", harnessSessionIDFor(reconstructed, rt.CurrentAgent()))
 }
 
 func TestHarnessToolCallCompletes(t *testing.T) {
@@ -216,8 +319,13 @@ func TestHarnessSuppressesReplayedClaudeCodeFinalText(t *testing.T) {
 
 func newHarnessRuntime(t *testing.T, harnessType string) *LocalRuntime {
 	t.Helper()
+	return newHarnessRuntimeWithStore(t, harnessType, session.NewInMemorySessionStore())
+}
+
+func newHarnessRuntimeWithStore(t *testing.T, harnessType string, store session.Store) *LocalRuntime {
+	t.Helper()
 	root := agent.New("root", "You are an external coder.", agent.WithHarness(&latest.HarnessConfig{Type: harnessType}))
-	rt, err := NewLocalRuntime(t.Context(), team.New(team.WithAgents(root)), WithSessionCompaction(false), WithModelStore(mockModelStore{}))
+	rt, err := NewLocalRuntime(t.Context(), team.New(team.WithAgents(root)), WithSessionCompaction(false), WithModelStore(mockModelStore{}), WithSessionStore(store))
 	require.NoError(t, err)
 	return rt
 }

--- a/pkg/runtime/loop.go
+++ b/pkg/runtime/loop.go
@@ -415,9 +415,7 @@ func (r *LocalRuntime) runStreamLoop(ctx context.Context, sess *session.Session,
 	sink.Emit(StreamStarted(sess.ID, a.Name()))
 
 	if a.HasHarness() {
-		streamReason = r.runHarnessAgent(ctx, sess, a,
-			slices.Concat(ls.sessionStartMsgs, ls.userPromptMsgs),
-			slices.Concat(ls.sessionStartLegacyMsgs, ls.userPromptMsgs), ls.sessionStartSources, sink)
+		streamReason = r.runHarnessAgent(ctx, sess, a, sink)
 		return
 	}
 


### PR DESCRIPTION
## Summary

- capture external harness session IDs and persist them with docker-agent sessions
- resume existing harness sessions on later turns instead of starting a new CLI session
- send only the current user request, without docker-agent system instructions or conversation history
- cover session persistence and resume command construction across runtime recreation

## Testing

- `task lint`
- `task build`
- `go test ./pkg/runtime -run 'TestHarness|TestAfterLLMCallHook_Harness' -count=10`

`task test` was also run; all relevant packages passed, but `pkg/teamloader`'s `TestLoadExamples` failed for the DMR examples because Docker Model Runner was not available at `127.0.0.1:12434`.
