### PR TITLE
docs: auto-update for merged PRs (2026-08-16)

### DIFF
--- a/docs/tools/filesystem/index.md
+++ b/docs/tools/filesystem/index.md
@@ -44,12 +44,23 @@ This helps agents distinguish between an empty directory and a tool failure, avo
 | `read_file`            | Read the contents of a file (whole file, or a line range of a text file)  |
 | `read_multiple_files`  | Read several files in one call (more efficient than multiple `read_file`) |
 | `write_file`           | Create or overwrite a file with new content                               |
-| `edit_file`            | Make line-based edits (find-and-replace) in an existing file              |
+| `edit_file`            | Make line-based edits (find-and-replace) in an existing file. Each edit must specify a non-empty `oldText` to match and replace; empty `oldText` values are rejected with an error. |
 | `list_directory`       | List files and directories at a given path (explicitly reports empty directories) |
 | `directory_tree`       | Recursive tree view of a directory                                        |
 | `create_directory`     | Create a new directory (creates parent directories as needed)             |
 | `remove_directory`     | Remove an empty directory                                                 |
 | `search_files_content` | Search for text or regex patterns across files                            |
+
+## edit_file Validation
+
+The `edit_file` tool applies a sequence of find-and-replace edits to a file in memory, then writes the result back atomically. Each edit must provide a non-empty `oldText` value:
+
+- **Valid**: `{"oldText": "line one", "newText": "LINE ONE"}`
+- **Invalid**: `{"oldText": "", "newText": "INJECTED"}` — rejected with error
+
+An empty `oldText` is never a meaningful edit: Go's `strings.Contains(s, "")` is always `true`, and `strings.Replace(s, "", new, 1)` silently inserts at offset 0. Without validation, this would prepend content to the file while still reporting success. The tool now returns an explicit error ("oldText must not be empty") when an edit has an empty `oldText`, and no changes are written to disk.
+
+When a sequence contains multiple edits and a later one is rejected, the entire operation fails and the file is left untouched — edits are applied in memory and only written once at the end, so partial application is not possible.
 
 ## Configuration
 


### PR DESCRIPTION
## Documentation Updates

This PR updates documentation to reflect code changes merged into `main` in the last 36 hours.

### Changes

#### Filesystem Tool Documentation

**Source:** PR #3926 - [fix(filesystem): refuse edit_file edits with an empty oldText](https://github.com/docker/docker-agent/pull/3926)

Updated `/docs/tools/filesystem/index.md` to document the new validation behavior for the `edit_file` tool:

- Added explicit mention in the tools table that `edit_file` requires non-empty `oldText` values
- Added new "edit_file Validation" section explaining:
  - The validation rule (empty `oldText` is rejected with an error)
  - The rationale (prevents silent file prepending)
  - The atomic behavior (entire edit sequence fails if any edit is invalid)

### PRs Reviewed

The following PRs were reviewed for documentation impact:

- ✅ **#3926** - fix(filesystem): refuse edit_file edits with an empty oldText — **docs updated**
- ⏭️ **#3980** - chore(deps): update reviewed Go dependencies — no doc impact (dependency updates only)
- ⏭️ **#3942** - fix(attachment): stop attachment content from closing its own envelope — no doc impact (internal security hardening)
- ⏭️ **#3928** - fix(cache): adopt the on-disk state read during Store — no doc impact (internal cache implementation)
- ⏭️ **#3923** - fix(fsx): test repository containment on a path boundary — no doc impact (internal bug fix)

---

**Automated documentation maintenance** — see workflow in `.github/workflows/docs-sync.yml`