### PR TITLE
feat: include cost in session summaries

### DIFF
--- a/pkg/session/session_race_test.go
+++ b/pkg/session/session_race_test.go
@@ -294,11 +294,10 @@ func TestInMemoryStoreGranularUpdatesConcurrent(t *testing.T) {
 }
 
 // TestInMemoryStoreGetSessionSummariesConcurrent pins the read-side of the
-// same fix: GetSessionSummaries reads each live session's Title, so it must
-// go through the locked accessor (TitleSnapshot) to stay safe against
-// concurrent SetTitle/granular store updates on the shared pointer. Run
-// with -race; with a direct value.Title read the detector flags the
-// concurrent SetTitle write.
+// same fix: GetSessionSummaries reads each live session's Title and Cost, so
+// it must use locked accessors to stay safe against concurrent metadata
+// updates on the shared pointer. Run with -race; direct field reads make the
+// detector flag the concurrent writes.
 func TestInMemoryStoreGetSessionSummariesConcurrent(t *testing.T) {
 	t.Parallel()
 
@@ -342,5 +341,9 @@ func TestInMemoryStoreGetSessionSummariesConcurrent(t *testing.T) {
 	}
 	if got := summaries[0].Title; got != "concurrent title" && got != "direct title" {
 		t.Errorf("unexpected title %q", got)
+	}
+	_, _, wantCost := sess.TokensAndCost()
+	if got := summaries[0].Cost; got != wantCost {
+		t.Errorf("expected cost %v, got %v", wantCost, got)
 	}
 }

--- a/pkg/session/store.go
+++ b/pkg/session/store.go
@@ -82,6 +82,7 @@ type Summary struct {
 	CreatedAt   time.Time
 	Starred     bool
 	NumMessages int
+	Cost        float64
 	WorkingDir  string
 	Attributes  map[string]string
 }
@@ -180,12 +181,14 @@ func (s *InMemorySessionStore) GetSessionSummaries(_ context.Context) ([]Summary
 		if value.ParentID != "" {
 			return true
 		}
+		_, _, cost := value.TokensAndCost()
 		summaries = append(summaries, Summary{
 			ID:          value.ID,
 			Title:       value.TitleSnapshot(),
 			CreatedAt:   value.CreatedAt,
 			Starred:     value.Starred,
 			NumMessages: value.MessageCount(),
+			Cost:        cost,
 			WorkingDir:  value.WorkingDir,
 			Attributes:  value.AttributesSnapshot(),
 		})
@@ -843,7 +846,7 @@ func (s *SQLiteSessionStore) GetSessions(ctx context.Context) ([]*Session, error
 // This is much faster than GetSessions as it doesn't load message content.
 func (s *SQLiteSessionStore) GetSessionSummaries(ctx context.Context) ([]Summary, error) {
 	rows, err := s.db.QueryContext(ctx,
-		`SELECT s.id, s.title, s.created_at, s.starred, s.working_dir, s.attributes,
+		`SELECT s.id, s.title, s.created_at, s.starred, s.cost, s.working_dir, s.attributes,
 		        (SELECT COUNT(*) FROM session_items si WHERE si.session_id = s.id AND si.item_type = 'message')
 		 FROM sessions s
 		 WHERE s.parent_id IS NULL OR s.parent_id = ''
@@ -861,7 +864,7 @@ func (s *SQLiteSessionStore) GetSessionSummaries(ctx context.Context) ([]Summary
 			workingDir     sql.NullString
 			attributesJSON sql.NullString
 		)
-		if err := rows.Scan(&summary.ID, &summary.Title, &createdAtStr, &summary.Starred, &workingDir, &attributesJSON, &summary.NumMessages); err != nil {
+		if err := rows.Scan(&summary.ID, &summary.Title, &createdAtStr, &summary.Starred, &summary.Cost, &workingDir, &attributesJSON, &summary.NumMessages); err != nil {
 			return nil, err
 		}
 		summary.CreatedAt = parseCreatedAt(createdAtStr)

--- a/pkg/session/store_test.go
+++ b/pkg/session/store_test.go
@@ -193,6 +193,7 @@ func TestGetSessionSummaries(t *testing.T) {
 			})),
 		},
 		CreatedAt:  session1Time,
+		Cost:       0.25,
 		WorkingDir: "/work/project",
 	}
 
@@ -206,6 +207,7 @@ func TestGetSessionSummaries(t *testing.T) {
 			})),
 		},
 		CreatedAt: session2Time,
+		Cost:      0.50,
 	}
 
 	// Store the sessions
@@ -224,12 +226,14 @@ func TestGetSessionSummaries(t *testing.T) {
 	assert.Equal(t, "Second Session", summaries[0].Title)
 	assert.Equal(t, session2Time, summaries[0].CreatedAt)
 	assert.Equal(t, 1, summaries[0].NumMessages)
+	assert.InDelta(t, 0.50, summaries[0].Cost, 1e-9)
 	assert.Empty(t, summaries[0].WorkingDir)
 
 	assert.Equal(t, "session-1", summaries[1].ID)
 	assert.Equal(t, "First Session", summaries[1].Title)
 	assert.Equal(t, session1Time, summaries[1].CreatedAt)
 	assert.Equal(t, 1, summaries[1].NumMessages)
+	assert.InDelta(t, 0.25, summaries[1].Cost, 1e-9)
 	assert.Equal(t, "/work/project", summaries[1].WorkingDir)
 }
 
@@ -275,6 +279,7 @@ func TestGetSessionSummaries_InMemory_WorkingDir(t *testing.T) {
 		ID:         "session-1",
 		Title:      "First Session",
 		CreatedAt:  time.Now(),
+		Cost:       0.75,
 		WorkingDir: "/work/project",
 	})
 	require.NoError(t, err)
@@ -282,6 +287,7 @@ func TestGetSessionSummaries_InMemory_WorkingDir(t *testing.T) {
 	summaries, err := store.GetSessionSummaries(t.Context())
 	require.NoError(t, err)
 	require.Len(t, summaries, 1)
+	assert.InDelta(t, 0.75, summaries[0].Cost, 1e-9)
 	assert.Equal(t, "/work/project", summaries[0].WorkingDir)
 }
 


### PR DESCRIPTION
## Summary
- add session cost to `session.Summary`
- populate summary cost from in-memory and SQLite stores
- cover persisted, in-memory, and concurrent cost reads

## Testing
- `task build`
- `task lint`
- `MOONSHOT_API_KEY= task test`
- `go test -race ./pkg/session`