### PR TITLE
fix(tui): retain interrupt confirmation setting

### DIFF
--- a/pkg/tui/handlers.go
+++ b/pkg/tui/handlers.go
@@ -921,9 +921,10 @@ func (m *appModel) handleApplySettings(msg messages.ApplySettingsMsg) (tea.Model
 	model, cmd := m.applyLayoutSettings(preferences.Layout)
 
 	m.sendMode = messages.ParseSendMode(string(preferences.SendMode))
+	m.interruptMode = messages.ParseInterruptMode(string(preferences.InterruptConfirmation))
 	for _, page := range m.chatPages {
 		page.SetSendMode(m.sendMode)
-		page.SetInterruptMode(preferences.InterruptConfirmation)
+		page.SetInterruptMode(m.interruptMode)
 	}
 	if m.sessionState.SplitDiffView() != preferences.SplitDiffView {
 		m.sessionState.SetSplitDiffView(preferences.SplitDiffView)

--- a/pkg/tui/interrupt_mode_test.go
+++ b/pkg/tui/interrupt_mode_test.go
@@ -1,0 +1,176 @@
+package tui
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/docker/docker-agent/pkg/app"
+	"github.com/docker/docker-agent/pkg/paths"
+	"github.com/docker/docker-agent/pkg/runtime"
+	"github.com/docker/docker-agent/pkg/session"
+	"github.com/docker/docker-agent/pkg/tui/animation"
+	"github.com/docker/docker-agent/pkg/tui/commands"
+	"github.com/docker/docker-agent/pkg/tui/components/tabbar"
+	"github.com/docker/docker-agent/pkg/tui/dialog"
+	"github.com/docker/docker-agent/pkg/tui/messages"
+	"github.com/docker/docker-agent/pkg/tui/page/chat"
+	"github.com/docker/docker-agent/pkg/tui/service"
+	"github.com/docker/docker-agent/pkg/userconfig"
+)
+
+// buildPageFromOpts constructs a real chat page the way initSessionComponents
+// does — from m.chatPageOpts() — and drives it into the working state so Esc
+// reaches the interrupt handling.
+func buildPageFromOpts(t *testing.T, m *appModel) chat.Page {
+	t.Helper()
+	sess := session.New()
+	page := chat.New(animation.NewRuntime(), t.Context(),
+		app.New(t.Context(), stubRuntime{}, sess), service.NewSessionState(sess), m.chatPageOpts()...)
+	_, _ = page.Update(runtime.StreamStarted(sess.ID, "root"))
+	t.Cleanup(func() { _, _ = page.Update(messages.StreamCancelledMsg{}) })
+	return page
+}
+
+// opensInterruptDialog reports whether Esc on a working page opens the
+// interrupt confirmation dialog — the "always" behavior. "double-tap" and
+// "none" never open it.
+func opensInterruptDialog(page chat.Page) bool {
+	_, cmd := page.Update(tea.KeyPressMsg{Code: tea.KeyEscape})
+	return hasMsg[dialog.OpenDialogMsg](collectMsgs(cmd))
+}
+
+// TestChatPageOpts_PassesRetainedInterruptMode covers the future-page
+// regression: pages built after startup (new tab, /clear, /fork, session
+// load, …) must inherit the retained interrupt mode instead of falling back
+// to the confirmation dialog.
+func TestChatPageOpts_PassesRetainedInterruptMode(t *testing.T) {
+	t.Parallel()
+
+	m, _ := newTestModel(t)
+	m.buildCommandCategories = func(context.Context, tea.Model) []commands.Category { return nil }
+
+	m.interruptMode = messages.InterruptModeNone
+	assert.False(t, opensInterruptDialog(buildPageFromOpts(t, m)),
+		`a page built from chatPageOpts must inherit the retained "none" mode`)
+
+	m.interruptMode = messages.InterruptModeAlways
+	assert.True(t, opensInterruptDialog(buildPageFromOpts(t, m)),
+		`the default "always" mode keeps the confirmation dialog`)
+}
+
+// newApplySettingsModel wires the minimal appModel state handleApplySettings
+// touches around the newTestModel mocks.
+func newApplySettingsModel(t *testing.T) *appModel {
+	t.Helper()
+	m, _ := newTestModel(t)
+	m.buildCommandCategories = func(context.Context, tea.Model) []commands.Category { return nil }
+	m.leanMode = true
+	m.tabBar = tabbar.New(animation.NewRuntime(), 0)
+	m.sessionState = service.NewSessionState(session.New())
+	return m
+}
+
+// defaultTestPreferences returns a Preferences with every value at its
+// default, so tests only vary the interrupt confirmation.
+func defaultTestPreferences() messages.Preferences {
+	return messages.Preferences{
+		Layout: messages.LayoutSettings{
+			SidebarPosition: messages.SidebarRight,
+			SectionSpacing:  messages.SpacingNormal,
+			SidebarInfoMode: messages.InfoModeCompact,
+		},
+		SendMode:              messages.SendModeSteer,
+		SplitDiffView:         true,
+		RenderImages:          true,
+		TabTitleMaxLength:     userconfig.DefaultTabTitleMaxLength,
+		SoundThreshold:        userconfig.DefaultSoundThreshold,
+		InterruptConfirmation: messages.InterruptModeAlways,
+	}
+}
+
+// TestHandleApplySettings_RetainsInterruptMode proves applying /settings
+// records the interrupt preference on the appModel and pushes it to every
+// existing page, so a page created afterwards receives it too.
+func TestHandleApplySettings_RetainsInterruptMode(t *testing.T) {
+	setupSettingsConfigTest(t)
+
+	m := newApplySettingsModel(t)
+	second := &mockChatPage{}
+	m.chatPages["second"] = second
+
+	prefs := defaultTestPreferences()
+	prefs.InterruptConfirmation = messages.InterruptModeNone
+	_, _ = m.handleApplySettings(messages.ApplySettingsMsg{Preferences: prefs})
+
+	assert.Equal(t, messages.InterruptModeNone, m.interruptMode,
+		"the preference is retained for future pages")
+	assert.Equal(t, messages.InterruptModeNone, m.chatPage.(*mockChatPage).interruptMode,
+		"the active page receives the new mode")
+	assert.Equal(t, messages.InterruptModeNone, second.interruptMode,
+		"background pages receive the new mode")
+	assert.False(t, opensInterruptDialog(buildPageFromOpts(t, m)),
+		"a page created after applying settings receives the new mode")
+}
+
+// TestHandleApplySettings_NormalizesInvalidInterruptMode proves an invalid
+// submitted value is normalized before being retained and applied, so the
+// default "always" behavior is preserved.
+func TestHandleApplySettings_NormalizesInvalidInterruptMode(t *testing.T) {
+	setupSettingsConfigTest(t)
+
+	m := newApplySettingsModel(t)
+
+	prefs := defaultTestPreferences()
+	prefs.InterruptConfirmation = messages.InterruptMode("bogus")
+	_, _ = m.handleApplySettings(messages.ApplySettingsMsg{Preferences: prefs})
+
+	assert.Equal(t, messages.InterruptModeAlways, m.interruptMode)
+	assert.Equal(t, messages.InterruptModeAlways, m.chatPage.(*mockChatPage).interruptMode,
+		"pages receive the normalized mode, not the raw value")
+}
+
+// TestNew_AppliesPersistedInterruptModeAtStartup covers the startup path:
+// the persisted interrupt confirmation setting must reach the appModel and
+// the initial chat page built through chatPageOpts. Not parallel: the
+// config/data dir overrides are process-global.
+func TestNew_AppliesPersistedInterruptModeAtStartup(t *testing.T) {
+	tests := []struct {
+		name      string
+		persisted string
+		want      messages.InterruptMode
+	}{
+		{name: "persisted double-tap applies", persisted: "double-tap", want: messages.InterruptModeDoubleTap},
+		{name: "invalid value falls back to always", persisted: "bogus", want: messages.InterruptModeAlways},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			paths.SetDataDir(filepath.Join(dir, "data"))
+			paths.SetConfigDir(filepath.Join(dir, "config"))
+			t.Cleanup(func() {
+				paths.SetDataDir("")
+				paths.SetConfigDir("")
+			})
+			require.NoError(t, userconfig.Update(func(cfg *userconfig.Config) error {
+				cfg.Settings = &userconfig.Settings{InterruptConfirmation: tt.persisted}
+				return nil
+			}))
+
+			sess := session.New()
+			m := New(t.Context(), nil, app.New(t.Context(), stubRuntime{}, sess), dir, func() {}).(*appModel)
+			t.Cleanup(m.cleanupManagedResources)
+
+			assert.Equal(t, tt.want, m.interruptMode)
+
+			_, _ = m.chatPage.Update(runtime.StreamStarted(sess.ID, "root"))
+			t.Cleanup(func() { _, _ = m.chatPage.Update(messages.StreamCancelledMsg{}) })
+			assert.Equal(t, tt.want == messages.InterruptModeAlways, opensInterruptDialog(m.chatPage),
+				"the initial page must honor the persisted mode")
+		})
+	}
+}

--- a/pkg/tui/tui.go
+++ b/pkg/tui/tui.go
@@ -296,6 +296,11 @@ type appModel struct {
 	// Shared by every tab and managed via /settings.
 	sendMode messages.SendMode
 
+	// interruptMode is how Esc interrupts a running stream (confirmation
+	// dialog, double-tap, or immediate). Shared by every tab and managed
+	// via /settings.
+	interruptMode messages.InterruptMode
+
 	// buildCommandCategories is a function that returns the list of command categories.
 	buildCommandCategories func(context.Context, tea.Model) []commands.Category
 
@@ -529,6 +534,7 @@ func New(ctx context.Context, spawner SessionSpawner, initialApp *app.App, initi
 		editorLines:                   3,
 		layoutSettings:                layoutSettingsFromConfig(userSettings.GetLayout()),
 		sendMode:                      messages.ParseSendMode(userSettings.GetBusySendMode()),
+		interruptMode:                 messages.ParseInterruptMode(userSettings.GetInterruptConfirmation()),
 		keyboardEnhancementsSupported: termfeatures.SupportsModifiedEnter(os.Getenv),
 		dockerDesktop:                 os.Getenv("TERM_PROGRAM") == "docker_desktop",
 		appName:                       "docker agent",
@@ -658,6 +664,7 @@ func (m *appModel) chatPageOpts() []chat.PageOption {
 		chat.WithCommandParser(commands.NewParser(m.commandCategories()...)),
 		chat.WithLayoutSettings(m.layoutSettings),
 		chat.WithSendMode(m.sendMode),
+		chat.WithInterruptMode(m.interruptMode),
 	}
 
 	if m.leanMode {

--- a/pkg/tui/tui_exit_test.go
+++ b/pkg/tui/tui_exit_test.go
@@ -33,6 +33,9 @@ import (
 // mockChatPage implements chat.Page for testing.
 type mockChatPage struct {
 	compactCalls []string // AdditionalPrompt of each CompactSession call
+
+	// interruptMode records the last SetInterruptMode value.
+	interruptMode messages.InterruptMode
 }
 
 func (m *mockChatPage) Init() tea.Cmd                          { return nil }
@@ -58,13 +61,15 @@ func (m *mockChatPage) SetSidebarSettings(chat.SidebarSettings)  {}
 func (m *mockChatPage) SetLayoutSettings(messages.LayoutSettings) tea.Cmd {
 	return nil
 }
-func (m *mockChatPage) SetSendMode(messages.SendMode)           {}
-func (m *mockChatPage) SetInterruptMode(messages.InterruptMode) {}
-func (m *mockChatPage) SetRoutingID(string)                     {}
-func (m *mockChatPage) TakeRoutedTimers() tea.Cmd               { return nil }
-func (m *mockChatPage) VisualGeneration() uint64                { return 0 }
-func (m *mockChatPage) Bindings() []key.Binding                 { return nil }
-func (m *mockChatPage) Help() help.KeyMap                       { return nil }
+func (m *mockChatPage) SetSendMode(messages.SendMode) {}
+func (m *mockChatPage) SetInterruptMode(mode messages.InterruptMode) {
+	m.interruptMode = mode
+}
+func (m *mockChatPage) SetRoutingID(string)       {}
+func (m *mockChatPage) TakeRoutedTimers() tea.Cmd { return nil }
+func (m *mockChatPage) VisualGeneration() uint64  { return 0 }
+func (m *mockChatPage) Bindings() []key.Binding   { return nil }
+func (m *mockChatPage) Help() help.KeyMap         { return nil }
 
 type countingChatPage struct {
 	mockChatPage


### PR DESCRIPTION
## Summary

- retain the parsed interrupt confirmation mode in the top-level TUI model
- pass the retained mode to initial, new, restored, and rebuilt chat pages
- normalize and propagate settings changes to existing and future pages
- add regression coverage for persisted startup state, settings application, and page recreation

## Issue expectations

| Expectation | Implementation |
| --- | --- |
| `none` and `double-tap` survive restart | Startup parses `settings.interrupt_confirmation` into `appModel.interruptMode` |
| New and rebuilt pages preserve the mode | `chatPageOpts()` passes `chat.WithInterruptMode(m.interruptMode)` |
| Settings changes affect open and future tabs | `handleApplySettings()` retains the normalized mode and updates every live chat page |
| Invalid values keep the safe default | Values are normalized through `ParseInterruptMode`, falling back to `always` |
| Prevent regression | Tests cover startup, existing-page propagation, future pages, and invalid values |

## Validation

- `task build`
- `task test`
- `task lint`

Closes #3993
