### PR TITLE
docs: replace CAGENT_MODELS_GATEWAY with DOCKER_AGENT_MODELS_GATEWAY in docs and samples

### DIFF
--- a/agent-schema.json
+++ b/agent-schema.json
@@ -1595,7 +1595,7 @@
         },
         "bypass_models_gateway": {
           "type": "boolean",
-          "description": "When true, this model connects directly to its provider, ignoring any configured models gateway (--models-gateway / CAGENT_MODELS_GATEWAY). The model then authenticates with the provider's own credentials (e.g. OPENAI_API_KEY, ANTHROPIC_API_KEY, or token_key) instead of routing through the gateway. A custom base_url (set on the model or inherited from a custom provider definition) implies this bypass even when the flag is false."
+          "description": "When true, this model connects directly to its provider, ignoring any configured models gateway (--models-gateway / DOCKER_AGENT_MODELS_GATEWAY). The model then authenticates with the provider's own credentials (e.g. OPENAI_API_KEY, ANTHROPIC_API_KEY, or token_key) instead of routing through the gateway. A custom base_url (set on the model or inherited from a custom provider definition) implies this bypass even when the flag is false."
         },
         "provider_opts": {
           "type": "object",

--- a/docs/configuration/models/index.md
+++ b/docs/configuration/models/index.md
@@ -77,7 +77,7 @@ models:
 | `title_model`         | string     | ✗        | Model used for session-title generation. Can be a named model from the `models:` section or an inline `provider/model` string. When omitted, the agent's primary model generates titles. Cannot be combined with `first_available`. |
 | `compaction_model`    | string     | ✗        | Model used for session compaction (summary generation). Can be a named model or an inline `provider/model` string. The agent-level `compaction_model` takes precedence over this value, which in turn takes precedence over a provider-level default. When none is set, the primary model compacts. Cannot be combined with `first_available`. See the [Context & Compaction guide](../../guides/compaction/index.md). |
 | `compaction_threshold` | float     | ✗        | Fraction of the context window at which proactive auto-compaction triggers for agents running this model. Must be greater than `0` and at most `1`. Takes precedence over the agent-level `compaction_threshold`. Cannot be combined with `first_available`. Default: `0.9`. See the [Context & Compaction guide](../../guides/compaction/index.md). |
-| `bypass_models_gateway` | boolean  | ✗        | When `true`, this model connects directly to its provider even when a models gateway (`--models-gateway` / `CAGENT_MODELS_GATEWAY`) is configured. Implied by a custom `base_url`. See [Gateway Bypass](#gateway-bypass). |
+| `bypass_models_gateway` | boolean  | ✗        | When `true`, this model connects directly to its provider even when a models gateway (`--models-gateway` / `DOCKER_AGENT_MODELS_GATEWAY`) is configured. Implied by a custom `base_url`. See [Gateway Bypass](#gateway-bypass). |
 
 ## Attachment Capability Overrides
 
@@ -256,7 +256,7 @@ for complete examples.
 
 ## Gateway Bypass
 
-When a models gateway (`--models-gateway` / `CAGENT_MODELS_GATEWAY`) is configured,
+When a models gateway (`--models-gateway` / `DOCKER_AGENT_MODELS_GATEWAY`) is configured,
 models without a custom `base_url` route through it by default. Set
 `bypass_models_gateway: true` on a specific model to make it connect directly
 to its provider instead:

--- a/examples/bypass_models_gateway.yaml
+++ b/examples/bypass_models_gateway.yaml
@@ -1,6 +1,6 @@
 # Demonstrates `bypass_models_gateway`, which forces a specific model to
 # connect directly to its provider instead of routing through a models gateway
-# (configured via --models-gateway / CAGENT_MODELS_GATEWAY).
+# (configured via --models-gateway / DOCKER_AGENT_MODELS_GATEWAY).
 #
 # This is useful when most models should go through a central gateway (for
 # billing, auditing, or shared credentials) but one model must talk to its

--- a/pkg/config/latest/types.go
+++ b/pkg/config/latest/types.go
@@ -1083,7 +1083,7 @@ type ModelConfig struct {
 	TokenKey          string   `json:"token_key,omitempty"`
 	// BypassModelsGateway, when true, forces this model to connect directly to
 	// its provider, ignoring any configured models gateway (the --models-gateway
-	// flag / CAGENT_MODELS_GATEWAY env var). The model then authenticates with
+	// flag / DOCKER_AGENT_MODELS_GATEWAY env var). The model then authenticates with
 	// the provider's own credentials (e.g. OPENAI_API_KEY, ANTHROPIC_API_KEY, or
 	// token_key) instead of routing through the gateway.
 	//


### PR DESCRIPTION
> 🤖 **Automated implementer agent** — *this comment was posted by the implementer bot from Docker Agentic Platform, not by a human developer*

Replace stale CAGENT_MODELS_GATEWAY primary references with DOCKER_AGENT_MODELS_GATEWAY in docs, schema, YAML comment, and a code comment.

Changed files: agent-schema.json, examples/bypass_models_gateway.yaml, docs/configuration/models/index.md (x2), pkg/config/latest/types.go.

Not changed: runtime env-var code (backward compat), frozen config packages v11-v14, CAGENT_PPROF_ADDR/ASKPASS vars (no DA_ equivalent), CHANGELOG, existing legacy CAGENT_* parentheticals in cli/overview docs.

Testing: go build ./... and go test ./pkg/config/ pass.