### PR TITLE
docs: complete CLI reference for serve a2a safety flags

### DIFF
--- a/docs/features/cli/index.md
+++ b/docs/features/cli/index.md
@@ -349,6 +349,10 @@ $ docker agent serve a2a <config> [flags]
 | ---------------------- | ------------------ | ------------------------------------------------------------------------------------------ |
 | `-a, --agent <name>`   | (team default)     | Name of the agent to run. Defaults to the team's first agent if not specified.             |
 | `-l, --listen <addr>`  | `127.0.0.1:8082`   | Address to listen on.                                                                       |
+| `--auth-token <token>` | (none)             | Bearer token required for agent-card and invocation requests.                              |
+| `--cors-origin <origins>` | (none)          | Allowed browser origins, comma-separated; empty disables CORS.                             |
+| `--insecure-no-auth`   | `false`            | Allow an unauthenticated non-loopback listener (unsafe).                                   |
+| `--safety <policy>`    | `restricted`       | Tool safety policy; `autonomous` is permitted only through this explicit CLI flag.         |
 | `-s, --session-db <path>` | `<data-dir>/session.db` | Path to the SQLite session database.                                                 |
 
 All [runtime configuration flags](#runtime-configuration-flags) are also accepted.


### PR DESCRIPTION
## Documentation Update

This PR completes the documentation for the safety-related flags added to `docker agent serve a2a` in PR #4000.

### Changes

- Added `--auth-token`, `--cors-origin`, `--insecure-no-auth`, and `--safety` flags to the `serve a2a` section in `/docs/features/cli/index.md`

### Context

PR #4000 ("feat: harden served-agent safety controls") added authentication and safety controls to all served-agent modes (A2A, chat, and MCP). The documentation updates in that PR covered:
- ✅ `serve mcp` - flags added to CLI index
- ✅ `serve chat` - flags added to CLI index  
- ⚠️ `serve a2a` - flags documented in `/docs/features/a2a/index.md` but **not** in the CLI index

This PR fixes the omission in the CLI reference to maintain consistency with the other serve commands.

### Source PRs

- #4000 - feat: harden served-agent safety controls

---

**Related:** The complete flag documentation already exists in `/docs/features/a2a/index.md`. This PR ensures the CLI index is consistent with the other serve commands.