### PR TITLE
test(e2e): extend Windows streaming TUI timeouts

### DIFF
--- a/e2e/tui/steering_test.go
+++ b/e2e/tui/steering_test.go
@@ -10,6 +10,7 @@ package tui_test
 
 import (
 	"os"
+	"runtime"
 	"testing"
 	"time"
 
@@ -33,13 +34,26 @@ func steeringProxyOptions() *fake.ProxyOptions {
 	}
 }
 
+// newStreamingTUI builds the steering harness and, on Windows only, raises
+// the WaitFor deadline to 30s: the simulated stream replays slower there
+// (issue #3983). Applied after construction because newTUIWithProxyOptions
+// does not forward tuitest options; it is safe before any interaction.
+func newStreamingTUI(t *testing.T) *tuitest.Driver {
+	t.Helper()
+	d := newTUIWithProxyOptions(t, "testdata/basic.yaml", 120, 40, steeringProxyOptions())
+	if runtime.GOOS == "windows" {
+		tuitest.WithTimeout(30 * time.Second)(d)
+	}
+	return d
+}
+
 // TestChat_SteerWhileStreaming submits a second message while the agent is
 // still streaming its first answer. The message must be steered into the
 // ongoing stream: the steering toast appears, no queue toast is shown, and
 // once the runtime drains the message the transcript shows the injected user
 // bubble followed by the agent's answer to it.
 func TestChat_SteerWhileStreaming(t *testing.T) {
-	d := newTUIWithProxyOptions(t, "testdata/basic.yaml", 120, 40, steeringProxyOptions())
+	d := newStreamingTUI(t)
 
 	// Draft the follow-up as a single paste so it costs one Update instead of
 	// one per keystroke (keystrokes are expensive under -race and would eat
@@ -71,7 +85,7 @@ func TestChat_SteerWhileStreaming(t *testing.T) {
 // producing a second turn with its own answer. The switch must also be
 // persisted to the user config.
 func TestChat_QueueSendModeWhileStreaming(t *testing.T) {
-	d := newTUIWithProxyOptions(t, "testdata/basic.yaml", 120, 40, steeringProxyOptions())
+	d := newStreamingTUI(t)
 
 	// Flip the send mode on the Behavior tab of /settings: open the dialog,
 	// switch tab, cycle Steer → Queue, apply.


### PR DESCRIPTION
## Summary

- apply a 30-second `tuitest` timeout to the two simulated-stream TUI scenarios on Windows
- retain the default timeout on other platforms and for all unrelated TUI tests
- preserve the existing streamed-output assertions and timeout diagnostics

## Issue expectations

| Expectation | Implementation |
|---|---|
| Use `tuitest.WithTimeout(30*time.Second)` for affected Windows tests | Applied by the shared streaming-test constructor when `runtime.GOOS == "windows"` |
| Keep the increase narrowly scoped | Constructor is used only by `TestChat_SteerWhileStreaming` and `TestChat_QueueSendModeWhileStreaming` |
| Preserve output assertions and diagnostics | Assertions and `tuitest` timeout reporting are unchanged |
| Avoid a global timeout increase | `defaultWaitTimeout` and unrelated tests are unchanged |
| Handle cache or parallelism changes separately | No CI cache or parallelism changes are included |

## Validation

- `task lint`
- `task build`
- `task test`
- targeted TUI tests with `-count=3` on macOS
- Windows amd64 cross-compilation with a clean Go build cache
- targeted Windows test binary under Wine 11.0: 5 repetitions per test, 10/10 passed with no timeout
- native GitHub Actions `windows-tests`: passed in runs [32345381401](https://github.com/docker/docker-agent/actions/runs/32345381401) and [32346112403](https://github.com/docker/docker-agent/actions/runs/32346112403)

The two workflow-dispatch runs report an overall failure only because post-validation image publication could not obtain a Docker Hub OIDC token on the branch. `lint`, `license-check`, `build-and-test`, and `windows-tests` passed in both runs, and no image was published.

Closes #3983
