### PR TITLE
fix(tools): prevent slow startup from blocking turns

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"math/rand"
@@ -561,47 +562,33 @@ func (a *Agent) ToolSets() []tools.ToolSet {
 	return toolSets
 }
 
-// toolsetStartTimeout bounds a toolset start initiated on the turn path
-// when the turn context carries no deadline of its own. It mirrors the
-// runtime's startup-probe timeout (defaultToolStartTimeout) so both paths
-// give up on a wedged toolset after the same grace period; the abandoned
-// attempt keeps running in the background under the toolset's single-flight
-// lock and its outcome is picked up on a later turn.
-const toolsetStartTimeout = 30 * time.Second
-
 // tryStartToolSet starts one toolset without ever letting it stall the turn
-// (#4001):
+// (#4001). It runs the toolset's bounded, non-blocking TryStartWithTimeout
+// with the shared tools.DefaultStartTimeout budget — the same grace period
+// as the runtime's startup probe — and translates the outcome:
 //
 //   - A Start already in flight (e.g. a startup probe that timed out upstream
 //     but kept going) is skipped silently — TryStart never joins an in-flight
 //     attempt — so the turn proceeds with the toolsets that are ready.
-//   - A start initiated here runs in its own goroutine raced against the
-//     context/timeout, because a wedged toolset can ignore cancellation (the
-//     MCP connector detaches the context it is handed). On timeout the attempt
-//     is abandoned to finish in the background and the toolset is skipped for
-//     this turn — silently, since the failure reporters share the toolset's
-//     single-flight lock and consulting them would block on the very start we
-//     just abandoned.
+//   - A start initiated here that outlives the budget (a wedged toolset can
+//     ignore cancellation) is abandoned to finish in the background and the
+//     toolset is skipped for this turn — silently, since the failure
+//     reporters share the toolset's single-flight lock and consulting them
+//     would block on the very start we just abandoned. Its outcome is picked
+//     up on a later turn.
 func (a *Agent) tryStartToolSet(ctx context.Context, toolSet *tools.StartableToolSet) error {
-	startCtx, cancel := context.WithTimeout(ctx, toolsetStartTimeout)
-	defer cancel()
-
-	done := make(chan error, 1) // buffered so a late send never blocks
-	go func() {
-		started, err := toolSet.TryStart(startCtx)
-		if !started && err == nil {
-			slog.DebugContext(ctx, "Toolset start already in flight; skipping for this turn", "agent", a.Name(), "toolset", tools.DescribeToolSet(toolSet))
+	started, err := toolSet.TryStartWithTimeout(ctx, tools.DefaultStartTimeout)
+	if err != nil {
+		if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
+			slog.DebugContext(ctx, "Toolset start still running; skipping for this turn", "agent", a.Name(), "toolset", tools.DescribeToolSet(toolSet), "cause", err)
+			return nil
 		}
-		done <- err
-	}()
-
-	select {
-	case <-startCtx.Done():
-		slog.DebugContext(ctx, "Toolset start still running; skipping for this turn", "agent", a.Name(), "toolset", tools.DescribeToolSet(toolSet), "cause", context.Cause(startCtx))
-		return nil
-	case err := <-done:
 		return err
 	}
+	if !started {
+		slog.DebugContext(ctx, "Toolset start already in flight; skipping for this turn", "agent", a.Name(), "toolset", tools.DescribeToolSet(toolSet))
+	}
+	return nil
 }
 
 // ensureToolSetsAreStarted starts every toolset, surfacing the first
@@ -690,16 +677,20 @@ func (a *Agent) DrainWarnings() []string {
 }
 
 func (a *Agent) StopToolSets(ctx context.Context) error {
+	var errs []error
 	for _, toolSet := range a.toolsets {
 		// StopIfStarted checks-and-stops atomically under the toolset's
 		// lifecycle lock, so a toolset that was never started is left
 		// untouched, an in-flight Start that settles in time is stopped
 		// rather than leaked, and a Start wedged past ctx's deadline
 		// surfaces ctx.Err() instead of blocking shutdown forever (#4001).
+		// One failed stop must not abandon the rest: later toolsets are
+		// still stopped (an expired ctx still stops responsive ones) and
+		// the failures surface together.
 		if err := toolSet.StopIfStarted(ctx); err != nil {
-			return fmt.Errorf("failed to stop toolset: %w", err)
+			errs = append(errs, fmt.Errorf("failed to stop toolset %s: %w", tools.DescribeToolSet(toolSet), err))
 		}
 	}
 
-	return nil
+	return errors.Join(errs...)
 }

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -472,7 +472,10 @@ func (a *Agent) collectTools(ctx context.Context) ([]tools.Tool, error) {
 		started bool
 	}
 	results := concurrent.MapSlice(a.toolsets, func(toolSet *tools.StartableToolSet) listResult {
-		if !toolSet.IsStarted() {
+		// TryIsStarted: a toolset whose lifecycle operation is still in
+		// flight (e.g. a wedged Start abandoned by tryStartToolSet) is
+		// skipped for this turn instead of blocking the listing (#4001).
+		if !toolSet.TryIsStarted() {
 			return listResult{}
 		}
 		ts, err := toolSet.Tools(ctx)
@@ -558,6 +561,49 @@ func (a *Agent) ToolSets() []tools.ToolSet {
 	return toolSets
 }
 
+// toolsetStartTimeout bounds a toolset start initiated on the turn path
+// when the turn context carries no deadline of its own. It mirrors the
+// runtime's startup-probe timeout (defaultToolStartTimeout) so both paths
+// give up on a wedged toolset after the same grace period; the abandoned
+// attempt keeps running in the background under the toolset's single-flight
+// lock and its outcome is picked up on a later turn.
+const toolsetStartTimeout = 30 * time.Second
+
+// tryStartToolSet starts one toolset without ever letting it stall the turn
+// (#4001):
+//
+//   - A Start already in flight (e.g. a startup probe that timed out upstream
+//     but kept going) is skipped silently — TryStart never joins an in-flight
+//     attempt — so the turn proceeds with the toolsets that are ready.
+//   - A start initiated here runs in its own goroutine raced against the
+//     context/timeout, because a wedged toolset can ignore cancellation (the
+//     MCP connector detaches the context it is handed). On timeout the attempt
+//     is abandoned to finish in the background and the toolset is skipped for
+//     this turn — silently, since the failure reporters share the toolset's
+//     single-flight lock and consulting them would block on the very start we
+//     just abandoned.
+func (a *Agent) tryStartToolSet(ctx context.Context, toolSet *tools.StartableToolSet) error {
+	startCtx, cancel := context.WithTimeout(ctx, toolsetStartTimeout)
+	defer cancel()
+
+	done := make(chan error, 1) // buffered so a late send never blocks
+	go func() {
+		started, err := toolSet.TryStart(startCtx)
+		if !started && err == nil {
+			slog.DebugContext(ctx, "Toolset start already in flight; skipping for this turn", "agent", a.Name(), "toolset", tools.DescribeToolSet(toolSet))
+		}
+		done <- err
+	}()
+
+	select {
+	case <-startCtx.Done():
+		slog.DebugContext(ctx, "Toolset start still running; skipping for this turn", "agent", a.Name(), "toolset", tools.DescribeToolSet(toolSet), "cause", context.Cause(startCtx))
+		return nil
+	case err := <-done:
+		return err
+	}
+}
+
 // ensureToolSetsAreStarted starts every toolset, surfacing the first
 // failure of each streak as a user-visible warning and silently retrying
 // on every subsequent turn. A successful Start() automatically resets the
@@ -568,11 +614,13 @@ func (a *Agent) ToolSets() []tools.ToolSet {
 // obvious; a follow-up notification just reads as a spurious warning).
 //
 // Starts run concurrently so one slow toolset (e.g. an MCP server
-// handshake) doesn't delay the others; Start() is single-flight per
-// toolset and warnings are recorded in configuration order afterwards.
-// Peer-dependent toolsets (e.g. the deferred aggregator, whose Start
-// lists its source toolsets' tools) start in a second wave, after the
-// toolsets they depend on have settled.
+// handshake) doesn't delay the others; each start is non-blocking and
+// bounded via tryStartToolSet, so neither a start already in flight nor a
+// wedged start initiated here can stall the turn, and warnings are
+// recorded in configuration order afterwards. Peer-dependent toolsets
+// (e.g. the deferred aggregator, whose Start lists its source toolsets'
+// tools) start in a second wave, after the toolsets they depend on have
+// settled.
 func (a *Agent) ensureToolSetsAreStarted(ctx context.Context) {
 	var independent, dependent []int
 	for i, toolSet := range a.toolsets {
@@ -586,7 +634,7 @@ func (a *Agent) ensureToolSetsAreStarted(ctx context.Context) {
 	errs := make([]error, len(a.toolsets))
 	for _, wave := range [][]int{independent, dependent} {
 		concurrent.ForEach(wave, func(i int) {
-			errs[i] = a.toolsets[i].Start(ctx)
+			errs[i] = a.tryStartToolSet(ctx, a.toolsets[i])
 		})
 	}
 
@@ -643,12 +691,12 @@ func (a *Agent) DrainWarnings() []string {
 
 func (a *Agent) StopToolSets(ctx context.Context) error {
 	for _, toolSet := range a.toolsets {
-		// Only stop toolsets that were successfully started
-		if !toolSet.IsStarted() {
-			continue
-		}
-
-		if err := toolSet.Stop(ctx); err != nil {
+		// StopIfStarted checks-and-stops atomically under the toolset's
+		// lifecycle lock, so a toolset that was never started is left
+		// untouched, an in-flight Start that settles in time is stopped
+		// rather than leaked, and a Start wedged past ctx's deadline
+		// surfaces ctx.Err() instead of blocking shutdown forever (#4001).
+		if err := toolSet.StopIfStarted(ctx); err != nil {
 			return fmt.Errorf("failed to stop toolset: %w", err)
 		}
 	}

--- a/pkg/agent/agent_test.go
+++ b/pkg/agent/agent_test.go
@@ -861,7 +861,7 @@ func TestAgentToolsSkipsStartAlreadyInFlight(t *testing.T) {
 
 // TestAgentToolsBoundsTurnInitiatedStart verifies the other half of #4001:
 // when the turn itself initiates a Start and the toolset wedges (ignoring
-// cancellation), the turn is bounded by toolsetStartTimeout instead of
+// cancellation), the turn is bounded by tools.DefaultStartTimeout instead of
 // hanging. The abandoned attempt stays silent and finishes in the
 // background, so the next turn sees the toolset started.
 func TestAgentToolsBoundsTurnInitiatedStart(t *testing.T) {
@@ -878,7 +878,7 @@ func TestAgentToolsBoundsTurnInitiatedStart(t *testing.T) {
 		begin := time.Now()
 		got, err := a.Tools(t.Context())
 		require.NoError(t, err)
-		assert.Equal(t, toolsetStartTimeout, time.Since(begin), "the turn must give up exactly at the bound (fake time)")
+		assert.Equal(t, tools.DefaultStartTimeout, time.Since(begin), "the turn must give up exactly at the bound (fake time)")
 		assert.Equal(t, []string{"static_tool"}, toolNames(got))
 		assert.Empty(t, a.DrainWarnings(), "a start abandoned on timeout must be skipped silently")
 
@@ -970,5 +970,87 @@ func TestAgentStopToolSetsHonorsContextWhileStartInFlight(t *testing.T) {
 		releaseHung()
 		require.NoError(t, <-startDone)
 		assert.EqualValues(t, 1, hung.stops.Load(), "a start that settles after the abandoned shutdown must still be stopped")
+	})
+}
+
+// stopRecordingToolSet starts immediately and records Stop calls; stopErr,
+// when set, is returned from every Stop.
+type stopRecordingToolSet struct {
+	stubToolSet
+
+	stopErr error
+	stops   atomic.Int32
+}
+
+func (s *stopRecordingToolSet) Stop(context.Context) error {
+	s.stops.Add(1)
+	return s.stopErr
+}
+
+// TestAgentStopToolSetsContinuesPastStopFailure pins the aggregation
+// contract of StopToolSets: a toolset whose Stop fails must not abandon
+// stopping the later toolsets, and every failure surfaces in the joined
+// error.
+func TestAgentStopToolSetsContinuesPastStopFailure(t *testing.T) {
+	t.Parallel()
+
+	errFirst := errors.New("first boom")
+	errSecond := errors.New("second boom")
+	failingFirst := &stopRecordingToolSet{stopErr: errFirst}
+	failingSecond := &stopRecordingToolSet{stopErr: errSecond}
+	healthy := &stopRecordingToolSet{}
+	a := New("root", "test", WithToolSets(failingFirst, failingSecond, healthy))
+	for _, ts := range a.toolsets {
+		require.NoError(t, ts.Start(t.Context()))
+	}
+
+	err := a.StopToolSets(t.Context())
+	require.ErrorIs(t, err, errFirst)
+	require.ErrorIs(t, err, errSecond)
+	assert.EqualValues(t, 1, failingFirst.stops.Load())
+	assert.EqualValues(t, 1, failingSecond.stops.Load(), "an earlier failed stop must not abandon the next toolset")
+	assert.EqualValues(t, 1, healthy.stops.Load(), "a failed stop must not abandon the later toolsets")
+}
+
+// TestAgentStopToolSetsStopsLaterToolsetsPastDeadline pins the other half of
+// the aggregation contract: a toolset wedged past the shutdown deadline
+// surfaces ctx.Err() but must not abandon the later toolsets — a responsive
+// started toolset is still stopped even though the deadline has already
+// expired by the time its StopIfStarted runs, via the uncontended fast path
+// in the lifecycle lock's LockContext.
+func TestAgentStopToolSetsStopsLaterToolsetsPastDeadline(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		wedged := &hungStartToolSet{
+			entered: make(chan struct{}),
+			release: make(chan struct{}),
+		}
+		responsive := &hungStartToolSet{
+			entered: make(chan struct{}),
+			release: make(chan struct{}),
+		}
+		close(responsive.release) // starts and stops without blocking
+		a := New("root", "test", WithToolSets(wedged, responsive))
+
+		// Always unblock the wedged Start so no goroutine outlives the test.
+		releaseWedged := sync.OnceFunc(func() { close(wedged.release) })
+		t.Cleanup(releaseWedged)
+
+		startDone := make(chan error, 1)
+		go func() { startDone <- a.toolsets[0].Start(t.Context()) }()
+		<-wedged.entered
+		require.NoError(t, a.toolsets[1].Start(t.Context()))
+
+		ctx, cancel := context.WithTimeout(t.Context(), time.Second)
+		defer cancel()
+		err := a.StopToolSets(ctx)
+		require.ErrorIs(t, err, context.DeadlineExceeded)
+		assert.EqualValues(t, 0, wedged.stops.Load(), "the underlying Stop must not run while Start is wedged")
+		assert.EqualValues(t, 1, responsive.stops.Load(), "a wedged earlier toolset must not abandon stopping the later ones")
+
+		// The wedged Start settles; the stop request abandoned at the
+		// deadline still reaps it.
+		releaseWedged()
+		require.NoError(t, <-startDone)
+		assert.EqualValues(t, 1, wedged.stops.Load(), "a start that settles after the abandoned shutdown must still be stopped")
 	})
 }

--- a/pkg/agent/agent_test.go
+++ b/pkg/agent/agent_test.go
@@ -765,3 +765,210 @@ func TestAgentToolsRecoversWhenUnderlyingToolsetDies(t *testing.T) {
 	assert.Equal(t, 1, stub.startCalls)
 	assert.Equal(t, 1, stub.restartCalls)
 }
+
+// hungStartToolSet blocks in Start until release is closed; entered is
+// closed on the first call so tests can line up with the in-flight attempt.
+type hungStartToolSet struct {
+	stubToolSet
+
+	entered chan struct{}
+	release chan struct{}
+	calls   atomic.Int32
+	stops   atomic.Int32
+}
+
+func (h *hungStartToolSet) Start(context.Context) error {
+	if h.calls.Add(1) == 1 {
+		close(h.entered)
+	}
+	<-h.release
+	return nil
+}
+
+func (h *hungStartToolSet) Stop(context.Context) error {
+	h.stops.Add(1)
+	return nil
+}
+
+func toolNames(ts []tools.Tool) []string {
+	names := make([]string, len(ts))
+	for i, tool := range ts {
+		names[i] = tool.Name
+	}
+	return names
+}
+
+// TestAgentToolsSkipsStartAlreadyInFlight reproduces #4001: the runtime's
+// startup probe initiates Start, times out and abandons the goroutine, which
+// keeps holding the toolset's single-flight lock. The next turn must not
+// block behind that lock: Tools() returns promptly with the static tools and
+// the toolsets that are ready, emits no warning, and does not pile a second
+// underlying Start onto the wedged toolset.
+func TestAgentToolsSkipsStartAlreadyInFlight(t *testing.T) {
+	t.Parallel()
+
+	hung := &hungStartToolSet{
+		stubToolSet: stubToolSet{tools: []tools.Tool{{Name: "hung_tool", Parameters: map[string]any{}}}},
+		entered:     make(chan struct{}),
+		release:     make(chan struct{}),
+	}
+	ready := newStubToolSet(nil, []tools.Tool{{Name: "ready_tool", Parameters: map[string]any{}}}, nil)
+	a := New("root", "test",
+		WithToolSets(hung, ready),
+		WithTools(tools.Tool{Name: "static_tool", Parameters: map[string]any{}}))
+
+	// Always unblock the wedged Start so no goroutine outlives the test.
+	releaseHung := sync.OnceFunc(func() { close(hung.release) })
+	t.Cleanup(releaseHung)
+
+	// Simulate the startup probe: Start is initiated and hangs, holding the
+	// single-flight lock past the probe's deadline.
+	probeDone := make(chan error, 1)
+	go func() { probeDone <- a.toolsets[0].Start(t.Context()) }()
+	<-hung.entered
+
+	type toolsResult struct {
+		tools []tools.Tool
+		err   error
+	}
+	turnDone := make(chan toolsResult, 1)
+	go func() {
+		got, err := a.Tools(t.Context())
+		turnDone <- toolsResult{tools: got, err: err}
+	}()
+
+	select {
+	case res := <-turnDone:
+		require.NoError(t, res.err)
+		assert.ElementsMatch(t, []string{"ready_tool", "static_tool"}, toolNames(res.tools))
+	case <-time.After(5 * time.Second):
+		t.Fatal("Agent.Tools blocked behind an in-flight toolset Start")
+	}
+
+	assert.Empty(t, a.DrainWarnings(), "a start already in flight must not surface a warning")
+	assert.EqualValues(t, 1, hung.calls.Load(), "the turn must not run a second underlying Start")
+
+	// Once the wedged start completes, the next turn picks the toolset up
+	// without another underlying Start.
+	releaseHung()
+	require.NoError(t, <-probeDone)
+
+	got, err := a.Tools(t.Context())
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{"hung_tool", "ready_tool", "static_tool"}, toolNames(got))
+	assert.EqualValues(t, 1, hung.calls.Load())
+}
+
+// TestAgentToolsBoundsTurnInitiatedStart verifies the other half of #4001:
+// when the turn itself initiates a Start and the toolset wedges (ignoring
+// cancellation), the turn is bounded by toolsetStartTimeout instead of
+// hanging. The abandoned attempt stays silent and finishes in the
+// background, so the next turn sees the toolset started.
+func TestAgentToolsBoundsTurnInitiatedStart(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		hung := &hungStartToolSet{
+			stubToolSet: stubToolSet{tools: []tools.Tool{{Name: "hung_tool", Parameters: map[string]any{}}}},
+			entered:     make(chan struct{}),
+			release:     make(chan struct{}),
+		}
+		a := New("root", "test",
+			WithToolSets(hung),
+			WithTools(tools.Tool{Name: "static_tool", Parameters: map[string]any{}}))
+
+		begin := time.Now()
+		got, err := a.Tools(t.Context())
+		require.NoError(t, err)
+		assert.Equal(t, toolsetStartTimeout, time.Since(begin), "the turn must give up exactly at the bound (fake time)")
+		assert.Equal(t, []string{"static_tool"}, toolNames(got))
+		assert.Empty(t, a.DrainWarnings(), "a start abandoned on timeout must be skipped silently")
+
+		// Let the abandoned attempt finish; it completes the start in the
+		// background under the single-flight lock.
+		close(hung.release)
+		synctest.Wait()
+
+		got, err = a.Tools(t.Context())
+		require.NoError(t, err)
+		assert.ElementsMatch(t, []string{"hung_tool", "static_tool"}, toolNames(got))
+		assert.EqualValues(t, 1, hung.calls.Load(), "the abandoned attempt is the only underlying Start")
+	})
+}
+
+// TestAgentStopToolSetsWaitsForInFlightStart pins the shutdown half of the
+// lifecycle contract: StopToolSets must not skip a toolset whose Start is
+// still in flight. It waits for the attempt to settle, so a start abandoned
+// by the turn path that eventually succeeds is still stopped instead of
+// leaking.
+func TestAgentStopToolSetsWaitsForInFlightStart(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		hung := &hungStartToolSet{
+			entered: make(chan struct{}),
+			release: make(chan struct{}),
+		}
+		a := New("root", "test", WithToolSets(hung))
+
+		// Always unblock the wedged Start so no goroutine outlives the test.
+		releaseHung := sync.OnceFunc(func() { close(hung.release) })
+		t.Cleanup(releaseHung)
+
+		startDone := make(chan error, 1)
+		go func() { startDone <- a.toolsets[0].Start(t.Context()) }()
+		<-hung.entered
+
+		stopDone := make(chan error, 1)
+		go func() { stopDone <- a.StopToolSets(t.Context()) }()
+
+		// StopToolSets must wait for the in-flight Start to settle, not decide
+		// early that the toolset is unstarted. Once every goroutine is durably
+		// blocked, the stop must still be parked behind the wedged Start.
+		synctest.Wait()
+		select {
+		case err := <-stopDone:
+			t.Fatalf("StopToolSets returned (err=%v) while Start was still in flight", err)
+		default:
+		}
+
+		releaseHung()
+		require.NoError(t, <-startDone)
+		require.NoError(t, <-stopDone)
+		assert.EqualValues(t, 1, hung.stops.Load(), "the toolset that finished starting must be stopped, not leaked")
+	})
+}
+
+// TestAgentStopToolSetsHonorsContextWhileStartInFlight pins the other
+// shutdown half of the contract: when an in-flight Start ignores
+// cancellation and never settles, StopToolSets gives up with ctx.Err() at
+// the deadline instead of blocking shutdown forever, without running the
+// underlying Stop behind the wedged attempt. Once that attempt eventually
+// settles, the abandoned stop request still reaps the toolset.
+func TestAgentStopToolSetsHonorsContextWhileStartInFlight(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		hung := &hungStartToolSet{
+			entered: make(chan struct{}),
+			release: make(chan struct{}),
+		}
+		a := New("root", "test", WithToolSets(hung))
+
+		// Always unblock the wedged Start so no goroutine outlives the test.
+		releaseHung := sync.OnceFunc(func() { close(hung.release) })
+		t.Cleanup(releaseHung)
+
+		startDone := make(chan error, 1)
+		go func() { startDone <- a.toolsets[0].Start(t.Context()) }()
+		<-hung.entered
+
+		ctx, cancel := context.WithTimeout(t.Context(), time.Second)
+		defer cancel()
+		begin := time.Now()
+		err := a.StopToolSets(ctx)
+		require.ErrorIs(t, err, context.DeadlineExceeded)
+		assert.Equal(t, time.Second, time.Since(begin), "StopToolSets must give up exactly at the deadline (fake time)")
+		assert.EqualValues(t, 0, hung.stops.Load(), "the underlying Stop must not run while Start is still wedged")
+
+		// The wedged Start eventually settles; the stop request abandoned at
+		// the deadline must reap the fresh start so it doesn't leak.
+		releaseHung()
+		require.NoError(t, <-startDone)
+		assert.EqualValues(t, 1, hung.stops.Load(), "a start that settles after the abandoned shutdown must still be stopped")
+	})
+}

--- a/pkg/runtime/defaults.go
+++ b/pkg/runtime/defaults.go
@@ -1,6 +1,10 @@
 package runtime
 
-import "time"
+import (
+	"time"
+
+	"github.com/docker/docker-agent/pkg/tools"
+)
 
 // defaultEventChannelCapacity is the buffer size used for every Event
 // channel the runtime hands back to a caller. Sized large enough that a
@@ -62,7 +66,9 @@ const defaultToolListTimeout = 10 * time.Second
 // ToolsetInfo{Loading:false} event is never emitted and the sidebar animates
 // "tools available…" forever. A timed-out toolset is skipped for this startup
 // pass only — the original start attempt keeps running and the toolset is
-// picked up once it completes. It is longer than defaultToolListTimeout
+// picked up once it completes. It aliases the shared bounded-start default so
+// this startup probe and the agent's turn path give up on a wedged toolset
+// after the same grace period; it is longer than defaultToolListTimeout
 // because a cold start can legitimately include an image pull. Tests override
 // it via WithToolStartTimeout.
-const defaultToolStartTimeout = 30 * time.Second
+const defaultToolStartTimeout = tools.DefaultStartTimeout

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -1747,12 +1747,18 @@ func (r *LocalRuntime) emitToolsProgressively(ctx context.Context, a *agent.Agen
 	// Start every toolset concurrently so one slow start (e.g. an MCP server
 	// pulling an image) doesn't delay the others; the context is already
 	// non-interactive here so no start can block on a user-driven flow. Each
-	// start keeps its own bounded timeout, and outcomes are consumed in
-	// configuration order below so an early fast toolset is listed (and
-	// counted) without waiting for a slow later one. Peer-dependent toolsets
-	// (e.g. the deferred aggregator, whose Start lists its source toolsets'
-	// tools) start in a second wave, after the others have settled.
-	starts := make([]chan error, totalToolsets)
+	// start is non-blocking and bounded (tools.TryStartWithTimeout): a start
+	// already in flight is skipped rather than joined, a wedged start is
+	// abandoned at the timeout, and outcomes are consumed in configuration
+	// order below so an early fast toolset is listed (and counted) without
+	// waiting for a slow later one. Peer-dependent toolsets (e.g. the
+	// deferred aggregator, whose Start lists its source toolsets' tools)
+	// start in a second wave, after the others have settled.
+	type startOutcome struct {
+		started bool
+		err     error
+	}
+	starts := make([]chan startOutcome, totalToolsets)
 	var independents sync.WaitGroup
 	var dependents []int
 	for i, toolset := range toolsets {
@@ -1760,20 +1766,22 @@ func (r *LocalRuntime) emitToolsProgressively(ctx context.Context, a *agent.Agen
 		if !ok {
 			continue
 		}
-		starts[i] = make(chan error, 1)
+		starts[i] = make(chan startOutcome, 1)
 		if _, ok := tools.As[tools.PeerDependent](startable); ok {
 			dependents = append(dependents, i)
 			continue
 		}
 		independents.Go(func() {
-			starts[i] <- startToolsetWithTimeout(ctx, startable, r.toolStartTimeout)
+			started, err := startable.TryStartWithTimeout(ctx, r.toolStartTimeout)
+			starts[i] <- startOutcome{started: started, err: err}
 		})
 	}
 	for _, i := range dependents {
 		startable := toolsets[i].(*tools.StartableToolSet)
 		go func() {
 			independents.Wait()
-			starts[i] <- startToolsetWithTimeout(ctx, startable, r.toolStartTimeout)
+			started, err := startable.TryStartWithTimeout(ctx, r.toolStartTimeout)
+			starts[i] <- startOutcome{started: started, err: err}
 		}()
 	}
 
@@ -1789,21 +1797,43 @@ func (r *LocalRuntime) emitToolsProgressively(ctx context.Context, a *agent.Agen
 
 		// Handle the start outcome, including recovery: a previously-started
 		// toolset whose inner connection died (e.g. background invalid_token)
-		// had its recovery Start() called above so ShouldReportRecoveryFailure
-		// can fire the targeted re-auth notice. Start() is a no-op when the
-		// toolset is already healthy, so calling it unconditionally is safe.
+		// had its recovery start attempted above so ShouldReportRecoveryFailure
+		// can fire the targeted re-auth notice. The attempt is a no-op when the
+		// toolset is already healthy, so starting it unconditionally is safe.
 		if startable, ok := toolset.(*tools.StartableToolSet); ok {
-			if err := <-starts[i]; err != nil {
+			outcome := <-starts[i]
+			if err := outcome.err; err != nil {
 				desc := tools.DescribeToolSet(startable.ToolSet)
-				// A start that outlived its deadline (e.g. an MCP container
-				// stuck behind a wedged Docker daemon) is reported directly:
-				// the abandoned Start goroutine has not returned, so the
-				// once-per-streak guard below has recorded nothing and would
-				// silently swallow the warning.
-				if errors.Is(err, context.DeadlineExceeded) && ctx.Err() == nil {
-					slog.WarnContext(ctx, "Toolset start timed out; skipping",
-						"agent", a.Name(), "toolset", desc, "timeout", r.toolStartTimeout)
-					a.AddToolWarning(fmt.Sprintf("%s is taking too long to start (>%s) — it keeps starting in the background and its tools appear once it is ready", desc, r.toolStartTimeout))
+				// A cancellation-family error means the bounded attempt may
+				// have abandoned a wedged Start that keeps running in the
+				// background holding the toolset's single-flight lock. The
+				// failure reporters below share that lock, so consulting them
+				// here would block on the very attempt just abandoned — never
+				// touch them for these errors.
+				if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
+					// Outer context done — possibly canceled after the
+					// top-of-loop check: the startup pass is being torn down,
+					// so return without a warning.
+					if ctx.Err() != nil {
+						return
+					}
+					if errors.Is(err, context.DeadlineExceeded) {
+						// A start that outlived its per-toolset deadline (e.g.
+						// an MCP container stuck behind a wedged Docker daemon)
+						// is reported directly: the abandoned Start goroutine
+						// has not returned, so the once-per-streak guard below
+						// has recorded nothing and would silently swallow the
+						// warning.
+						slog.WarnContext(ctx, "Toolset start timed out; skipping",
+							"agent", a.Name(), "toolset", desc, "timeout", r.toolStartTimeout)
+						a.AddToolWarning(fmt.Sprintf("%s is taking too long to start (>%s) — it keeps starting in the background and its tools appear once it is ready", desc, r.toolStartTimeout))
+						continue
+					}
+					// A Canceled error while the outer context is still live can
+					// only come from within the toolset's own Start; skip it for
+					// this pass like the agent's turn path does.
+					slog.DebugContext(ctx, "Toolset start canceled; skipping",
+						"agent", a.Name(), "toolset", desc, "cause", err)
 					continue
 				}
 				// IsAuthorizationRequired must be checked BEFORE
@@ -1844,6 +1874,17 @@ func (r *LocalRuntime) emitToolsProgressively(ctx context.Context, a *agent.Agen
 				}
 				slog.WarnContext(ctx, "Toolset start failed; skipping", "agent", a.Name(), "toolset", desc, "error", err)
 				a.AddToolWarning(fmt.Sprintf("%s start failed: %v", desc, err))
+				continue
+			}
+			if !outcome.started {
+				// Another lifecycle operation holds the toolset's single-flight
+				// lock (e.g. a start abandoned by an earlier bounded attempt):
+				// skip the toolset for this startup pass — silently, because
+				// the failure reporters share that lock and consulting them
+				// would block on the very attempt being skipped. It is picked
+				// up once the attempt settles.
+				slog.DebugContext(ctx, "Toolset start already in flight; skipping",
+					"agent", a.Name(), "toolset", tools.DescribeToolSet(startable.ToolSet))
 				continue
 			}
 		}
@@ -1907,40 +1948,6 @@ func listToolsWithTimeout(ctx context.Context, toolset tools.ToolSet, timeout ti
 		return nil, toolCtx.Err()
 	case res := <-done:
 		return res.tools, res.err
-	}
-}
-
-// startToolsetWithTimeout starts a toolset under a bounded deadline, mirroring
-// listToolsWithTimeout. The deadline must be enforced by racing the call
-// against the timeout (not only via the context): the MCP connector detaches
-// the context it is handed with context.WithoutCancel, so a wedged initialize
-// handshake (e.g. Docker failing to start the server container) would ignore a
-// ctx deadline and block startup forever. On timeout it returns the context
-// error; the orphaned goroutine sends into a buffered channel and exits if the
-// call ever returns.
-//
-// The abandoned goroutine keeps holding the StartableToolSet's single-flight
-// lock, so later Start/Stop calls on the same toolset wait for the original
-// attempt rather than racing it — if it eventually completes, the toolset
-// becomes usable on the next turn; if it never does, the TUI shutdown safety
-// net still bounds the exit path.
-func startToolsetWithTimeout(ctx context.Context, toolset *tools.StartableToolSet, timeout time.Duration) error {
-	if timeout <= 0 {
-		timeout = defaultToolStartTimeout
-	}
-	startCtx, cancel := context.WithTimeout(ctx, timeout)
-	defer cancel()
-
-	done := make(chan error, 1) // buffered so a late send never blocks
-	go func() {
-		done <- toolset.Start(startCtx)
-	}()
-
-	select {
-	case <-startCtx.Done():
-		return startCtx.Err()
-	case err := <-done:
-		return err
 	}
 }
 

--- a/pkg/runtime/runtime_test.go
+++ b/pkg/runtime/runtime_test.go
@@ -8,7 +8,9 @@ import (
 	"slices"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
@@ -96,6 +98,31 @@ func (b *blockingStartToolSet) Start(context.Context) error {
 }
 func (b *blockingStartToolSet) Stop(context.Context) error                  { return nil }
 func (b *blockingStartToolSet) Tools(context.Context) ([]tools.Tool, error) { return nil, nil }
+
+// inFlightStartToolSet is a blockingStartToolSet variant that signals when a
+// Start attempt is in flight (entered closes on the first call) and counts
+// underlying Start calls, so tests can wedge an attempt before exercising
+// the code under test.
+type inFlightStartToolSet struct {
+	entered   chan struct{}
+	release   <-chan struct{}
+	enterOnce sync.Once
+	starts    atomic.Int32
+}
+
+var (
+	_ tools.ToolSet   = (*inFlightStartToolSet)(nil)
+	_ tools.Startable = (*inFlightStartToolSet)(nil)
+)
+
+func (b *inFlightStartToolSet) Start(context.Context) error {
+	b.starts.Add(1)
+	b.enterOnce.Do(func() { close(b.entered) })
+	<-b.release
+	return nil
+}
+func (b *inFlightStartToolSet) Stop(context.Context) error                  { return nil }
+func (b *inFlightStartToolSet) Tools(context.Context) ([]tools.Tool, error) { return nil, nil }
 
 type mockStream struct {
 	responses []chat.MessageStreamResponse
@@ -1422,6 +1449,157 @@ func TestEmitStartupInfo_SkipsToolsetWhoseStartHangs(t *testing.T) {
 
 	require.NotNil(t, warning, "a start timeout must surface a user-visible warning")
 	assert.Contains(t, warning.Message, "taking too long to start")
+}
+
+// TestEmitStartupInfo_SkipsToolsetWhoseStartIsAlreadyInFlight pins the
+// skip-in-flight half of the bounded-start contract (tools.TryStartWithTimeout):
+// a toolset whose Start is already running — e.g. abandoned by an earlier
+// bounded attempt and still holding the single-flight lock — is skipped
+// immediately instead of joined, so startup neither burns the start budget
+// again nor emits a duplicate "taking too long" warning, and the fast
+// toolset is still counted.
+func TestEmitStartupInfo_SkipsToolsetWhoseStartIsAlreadyInFlight(t *testing.T) {
+	t.Parallel()
+
+	prov := &mockProvider{id: "test/startup-model", stream: &mockStream{}}
+
+	release := make(chan struct{})
+	releaseWedged := sync.OnceFunc(func() { close(release) })
+	t.Cleanup(releaseWedged)
+
+	inFlight := &inFlightStartToolSet{entered: make(chan struct{}), release: release}
+	fast := newStubToolSet(nil, []tools.Tool{{Name: "ready"}}, nil)
+
+	root := agent.New("root", "agent",
+		agent.WithModel(prov),
+		agent.WithToolSets(inFlight, fast),
+	)
+	tm := team.New(team.WithAgents(root))
+
+	rt, err := NewLocalRuntime(t.Context(), tm,
+		WithCurrentAgent("root"),
+		WithModelStore(mockModelStore{}),
+		// Long enough that a regression to joining the in-flight attempt
+		// trips the prompt-return guard below instead of passing slowly.
+		WithToolStartTimeout(30*time.Second),
+	)
+	require.NoError(t, err)
+
+	// Wedge the toolset's Start before startup runs, as an earlier abandoned
+	// bounded attempt would: it keeps holding the single-flight lock.
+	startable, ok := root.ToolSets()[0].(*tools.StartableToolSet)
+	require.True(t, ok)
+	wedgedDone := make(chan error, 1)
+	go func() { wedgedDone <- startable.Start(t.Context()) }()
+	<-inFlight.entered
+
+	events := make(chan Event, 32)
+	done := make(chan struct{})
+	go func() {
+		rt.EmitStartupInfo(t.Context(), nil, NewChannelSink(events))
+		close(events)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("EmitStartupInfo did not return promptly: an in-flight toolset start was joined instead of skipped")
+	}
+
+	var toolsetInfos []*ToolsetInfoEvent
+	var warnings []*WarningEvent
+	for e := range events {
+		switch ev := e.(type) {
+		case *ToolsetInfoEvent:
+			toolsetInfos = append(toolsetInfos, ev)
+		case *WarningEvent:
+			warnings = append(warnings, ev)
+		}
+	}
+
+	require.NotEmpty(t, toolsetInfos, "expected at least one ToolsetInfo event")
+	last := toolsetInfos[len(toolsetInfos)-1]
+	assert.False(t, last.Loading, "final ToolsetInfo must report Loading=false so the sidebar resolves")
+	assert.Equal(t, 1, last.AvailableTools,
+		"the in-flight toolset is skipped; the fast toolset's single tool is still counted")
+	assert.Empty(t, warnings, "a skipped in-flight start must not surface a warning")
+	assert.EqualValues(t, 1, inFlight.starts.Load(), "the skip must not run a second underlying Start")
+
+	// Unblock the wedged attempt so its goroutine exits before the test ends.
+	releaseWedged()
+	require.NoError(t, <-wedgedDone)
+}
+
+// TestEmitStartupInfo_ReturnsOnCancelWhileStartIsWedged is the regression
+// test for the cancellation half of the bounded-start contract: when the
+// EmitStartupInfo context is canceled while TryStartWithTimeout has abandoned
+// a wedged Start that still holds the toolset's single-flight lock, the
+// startup pass must return instead of consulting the failure reporters,
+// which share that lock and would block on it forever. The bubble makes the
+// race deterministic: synctest.Wait parks the emit loop on the start outcome
+// — past its top-of-loop ctx check — before the cancel fires, and a
+// regression to the blocking reporters deadlocks the bubble.
+func TestEmitStartupInfo_ReturnsOnCancelWhileStartIsWedged(t *testing.T) {
+	t.Parallel()
+
+	synctest.Test(t, func(t *testing.T) {
+		prov := &mockProvider{id: "test/startup-model", stream: &mockStream{}}
+
+		// release is closed on cleanup so the wedged start goroutine (whose
+		// Start() ignores context cancellation) exits before the bubble is
+		// checked for leaked goroutines.
+		release := make(chan struct{})
+		t.Cleanup(func() { close(release) })
+
+		wedged := &inFlightStartToolSet{entered: make(chan struct{}), release: release}
+
+		root := agent.New("root", "agent",
+			agent.WithModel(prov),
+			agent.WithToolSets(wedged),
+		)
+		tm := team.New(team.WithAgents(root))
+
+		rt, err := NewLocalRuntime(t.Context(), tm,
+			WithCurrentAgent("root"),
+			WithModelStore(mockModelStore{}),
+			// Long enough (in the bubble's fake time) that the per-toolset
+			// deadline cannot fire; only the cancel unblocks the attempt.
+			WithToolStartTimeout(time.Hour),
+		)
+		require.NoError(t, err)
+
+		ctx, cancel := context.WithCancel(t.Context())
+		events := make(chan Event, 32)
+		done := make(chan struct{})
+		go func() {
+			rt.EmitStartupInfo(ctx, nil, NewChannelSink(events))
+			close(done)
+		}()
+
+		// The startup pass's own bounded attempt has entered the wedged
+		// Start — it now holds the single-flight lock. Park every other
+		// goroutine (the emit loop is blocked on the start outcome, past its
+		// top-of-loop ctx check) before canceling, so the cancellation
+		// deterministically loses that check's race.
+		<-wedged.entered
+		synctest.Wait()
+		cancel()
+
+		// EmitStartupInfo must return while the underlying Start is still
+		// wedged: release is closed only by the cleanup above, after this
+		// receive. Before the fix, the emit loop hung on the failure
+		// reporters' lock here and the bubble deadlocked.
+		<-done
+
+		close(events)
+		for e := range events {
+			if w, ok := e.(*WarningEvent); ok {
+				t.Fatalf("cancellation during a wedged start must not surface a warning; got %q", w.Message)
+			}
+		}
+		assert.EqualValues(t, 1, wedged.starts.Load(), "exactly one underlying Start ran and stayed wedged")
+	})
 }
 
 // TestEmitStartupInfo_EmitsProgressWhileSlowToolsetStarts guards the

--- a/pkg/team/team.go
+++ b/pkg/team/team.go
@@ -156,13 +156,16 @@ func (t *Team) Size() int {
 }
 
 func (t *Team) StopToolSets(ctx context.Context) error {
+	var errs []error
 	for _, agent := range t.agents {
+		// One agent failing to stop (e.g. a wedged toolset) must not leave
+		// later agents' toolsets running: keep stopping and aggregate.
 		if err := agent.StopToolSets(ctx); err != nil {
-			return fmt.Errorf("failed to stop tool sets: %w", err)
+			errs = append(errs, fmt.Errorf("failed to stop tool sets of agent %s: %w", agent.Name(), err))
 		}
 	}
 
-	return nil
+	return errors.Join(errs...)
 }
 
 // AgentConfig returns the raw resolved config for the named agent and true

--- a/pkg/team/team_test.go
+++ b/pkg/team/team_test.go
@@ -1,6 +1,9 @@
 package team
 
 import (
+	"context"
+	"errors"
+	"sync/atomic"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -8,10 +11,62 @@ import (
 
 	"github.com/docker/docker-agent/pkg/agent"
 	"github.com/docker/docker-agent/pkg/config/latest"
+	"github.com/docker/docker-agent/pkg/tools"
 )
 
 func newAgent(name string) *agent.Agent {
 	return agent.New(name, "")
+}
+
+// stopRecordingToolSet is a Startable ToolSet whose Stop records calls and
+// returns stopErr.
+type stopRecordingToolSet struct {
+	stopErr error
+	stops   atomic.Int32
+}
+
+func (s *stopRecordingToolSet) Tools(context.Context) ([]tools.Tool, error) { return nil, nil }
+func (s *stopRecordingToolSet) Start(context.Context) error                 { return nil }
+func (s *stopRecordingToolSet) Stop(context.Context) error {
+	s.stops.Add(1)
+	return s.stopErr
+}
+
+// TestStopToolSetsContinuesAcrossAgents pins the team-level aggregation
+// contract: an agent whose toolsets fail to stop must not abandon stopping
+// the later agents' toolsets, and every failure surfaces in the joined
+// error together with the owning agent's name.
+func TestStopToolSetsContinuesAcrossAgents(t *testing.T) {
+	t.Parallel()
+
+	errFirst := errors.New("first boom")
+	errSecond := errors.New("second boom")
+	tsFirst := &stopRecordingToolSet{stopErr: errFirst}
+	tsSecond := &stopRecordingToolSet{stopErr: errSecond}
+	tsHealthy := &stopRecordingToolSet{}
+
+	first := agent.New("first", "", agent.WithToolSets(tsFirst))
+	second := agent.New("second", "", agent.WithToolSets(tsSecond))
+	third := agent.New("third", "", agent.WithToolSets(tsHealthy))
+	tm := New(WithAgents(first, second, third))
+
+	// Start every toolset so StopToolSets has something to stop.
+	for _, a := range []*agent.Agent{first, second, third} {
+		for _, ts := range a.ToolSets() {
+			startable, ok := ts.(*tools.StartableToolSet)
+			require.True(t, ok)
+			require.NoError(t, startable.Start(t.Context()))
+		}
+	}
+
+	err := tm.StopToolSets(t.Context())
+	require.ErrorIs(t, err, errFirst)
+	require.ErrorIs(t, err, errSecond)
+	assert.Contains(t, err.Error(), "first")
+	assert.Contains(t, err.Error(), "second")
+	assert.EqualValues(t, 1, tsFirst.stops.Load())
+	assert.EqualValues(t, 1, tsSecond.stops.Load(), "an earlier failing agent must not abandon the next agent's toolsets")
+	assert.EqualValues(t, 1, tsHealthy.stops.Load(), "a failing earlier agent must not abandon stopping later agents' toolsets")
 }
 
 // RuntimeSafety returns the config-wide default set via WithRuntimeSafety,

--- a/pkg/tools/builtin/rag/rag.go
+++ b/pkg/tools/builtin/rag/rag.go
@@ -87,9 +87,12 @@ func (t *ToolSet) Start(ctx context.Context) error {
 		return nil
 	}
 
-	// We create a child context so we can explicitly cancel the watcher and event goroutines
-	// when Stop() is called, preventing goroutine leaks if the parent context outlives this toolset.
-	watchCtx, cancel := context.WithCancel(ctx)
+	// The watcher and event forwarder are long-lived and owned by Stop() via
+	// cancelWatcher: detach them from the caller's cancellation — Start may
+	// run under a short-lived startup-probe context — while keeping its values
+	// (logging, tracing). Initialize below still uses the caller's ctx so a
+	// canceled startup aborts indexing.
+	watchCtx, cancel := context.WithCancel(context.WithoutCancel(ctx))
 	t.cancelWatcher = cancel
 
 	// Forward RAG manager events if a callback is set.

--- a/pkg/tools/builtin/rag/rag_test.go
+++ b/pkg/tools/builtin/rag/rag_test.go
@@ -187,3 +187,64 @@ func TestStopAfterFailedStart(t *testing.T) {
 		t.Fatal("Stop() deadlocked after a failed Start()")
 	}
 }
+
+// watcherCapturingStrategy hands the context its file watcher receives to the
+// test so it can assert on the watcher's lifetime. Initialize is immediate
+// (inherited from mockStrategy) and StartFileWatcher returns as soon as the
+// watcher is "installed", mirroring the real strategies.
+type watcherCapturingStrategy struct {
+	mockStrategy
+
+	watchCtx chan context.Context
+}
+
+func (m *watcherCapturingStrategy) StartFileWatcher(ctx context.Context, _ []string, _ strategy.ChunkingConfig) error {
+	m.watchCtx <- ctx
+	return nil
+}
+
+type watcherCtxKey struct{}
+
+// TestStartDetachesWatcherFromCallerContext covers #4001: Start may run under
+// a short-lived context (e.g. the runtime's bounded startup probe), and the
+// long-lived file watcher must not die with it. The watcher context keeps the
+// caller's values, but only Stop() owns its cancellation.
+func TestStartDetachesWatcherFromCallerContext(t *testing.T) {
+	t.Parallel()
+
+	strategyMock := &watcherCapturingStrategy{watchCtx: make(chan context.Context, 1)}
+	cfg := rag.Config{
+		StrategyConfigs: []strategy.Config{
+			{Name: "capturing", Strategy: strategyMock},
+		},
+	}
+
+	mgr, err := rag.New(t.Context(), "watched-rag", cfg, nil)
+	require.NoError(t, err)
+
+	tool := &ToolSet{
+		manager:  mgr,
+		toolName: "watched-rag",
+	}
+
+	startCtx, cancelStart := context.WithCancel(context.WithValue(t.Context(), watcherCtxKey{}, "kept"))
+	defer cancelStart()
+	require.NoError(t, tool.Start(startCtx))
+
+	var watchCtx context.Context
+	select {
+	case watchCtx = <-strategyMock.watchCtx:
+	case <-time.After(5 * time.Second):
+		t.Fatal("file watcher was never started")
+	}
+	assert.Equal(t, "kept", watchCtx.Value(watcherCtxKey{}), "watcher context must keep the caller's values")
+
+	// Cancelling the Start context (probe timeout) must not kill the watcher.
+	// Cancellation propagates synchronously, so this check is deterministic.
+	cancelStart()
+	require.NoError(t, watchCtx.Err(), "watcher must outlive the context passed to Start")
+
+	// Stop owns the watcher's cancellation.
+	require.NoError(t, tool.Stop(t.Context()))
+	assert.ErrorIs(t, watchCtx.Err(), context.Canceled, "Stop must cancel the watcher")
+}

--- a/pkg/tools/export_test.go
+++ b/pkg/tools/export_test.go
@@ -1,0 +1,14 @@
+package tools
+
+import "context"
+
+// ExportedPublishStopRequest exposes the request-publication half of
+// StopIfStarted for tests in the _test package: it leaves a pending stop
+// request behind exactly as a requester that lost the lifecycle-lock race
+// (e.g. to a concurrent TryIsStarted) with an already-done context would.
+func (s *StartableToolSet) ExportedPublishStopRequest(ctx context.Context) {
+	s.stopRequestMu.Lock()
+	defer s.stopRequestMu.Unlock()
+	s.stopRequested = true
+	s.stopRequestCtx = ctx
+}

--- a/pkg/tools/startable.go
+++ b/pkg/tools/startable.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log/slog"
 	"sync"
+	"time"
 
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
@@ -187,7 +188,9 @@ func NewStartable(ts ToolSet) *StartableToolSet {
 // For toolsets that don't implement Startable, this always returns true.
 // It waits for any in-flight lifecycle operation (Start/Stop) to settle,
 // so callers deciding whether a Stop is needed observe the final state;
-// use TryIsStarted on paths that must never block.
+// use TryIsStarted on paths that must never block. Releasing the lifecycle
+// lock on return can settle a pending StopIfStarted request, so a call may
+// invoke — and block on — the underlying Stop.
 func (s *StartableToolSet) IsStarted() bool {
 	s.mu.Lock()
 	defer s.unlock()
@@ -205,8 +208,14 @@ func (s *StartableToolSet) TryIsStarted() bool {
 	if !s.mu.TryLock() {
 		return false
 	}
-	defer s.unlock()
-	return s.started
+	started := s.started
+	// The release handshake may consume a pending StopIfStarted request and
+	// stop the toolset this probe just observed started: report a reaped
+	// start as not-ready rather than as started.
+	if s.unlock() {
+		return false
+	}
+	return started
 }
 
 // Start starts the toolset with single-flight semantics.
@@ -245,6 +254,52 @@ func (s *StartableToolSet) TryStart(ctx context.Context) (started bool, err erro
 		return false, err
 	}
 	return s.started, nil
+}
+
+// DefaultStartTimeout bounds a toolset start when the caller supplies no
+// budget of its own. It is shared by the agent's turn path and the runtime's
+// startup probe so both give up on a wedged toolset after the same grace
+// period; it is deliberately generous because a cold start can legitimately
+// include an image pull.
+const DefaultStartTimeout = 30 * time.Second
+
+// TryStartWithTimeout runs TryStart bounded by timeout (DefaultStartTimeout
+// when non-positive). The attempt runs in its own goroutine raced against
+// the bound — not only under the derived context — because a wedged toolset
+// can ignore cancellation (the MCP connector detaches the context it is
+// handed). Outcomes:
+//
+//   - (true, nil): the toolset is started (freshly, latched or recovered).
+//   - (false, nil): skipped — another lifecycle operation holds the
+//     single-flight lock, or a pending shutdown reaped the fresh start.
+//   - (false, ctx.Err() of the bound): the attempt outlived the budget and
+//     was abandoned. It keeps running in the background holding the
+//     single-flight lock, so later Start/Stop calls wait for it rather than
+//     race it; if it eventually completes, a later call picks the toolset up.
+//   - (false, err): the attempt ran and failed with err.
+func (s *StartableToolSet) TryStartWithTimeout(ctx context.Context, timeout time.Duration) (bool, error) {
+	if timeout <= 0 {
+		timeout = DefaultStartTimeout
+	}
+	startCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	type startResult struct {
+		started bool
+		err     error
+	}
+	done := make(chan startResult, 1) // buffered so a late send never blocks
+	go func() {
+		started, err := s.TryStart(startCtx)
+		done <- startResult{started: started, err: err}
+	}()
+
+	select {
+	case <-startCtx.Done():
+		return false, startCtx.Err()
+	case res := <-done:
+		return res.started, res.err
+	}
 }
 
 // startLocked implements the start sequence shared by Start and TryStart.
@@ -324,7 +379,9 @@ func (s *StartableToolSet) startLocked(ctx context.Context) (err error) {
 // Tools lists the underlying toolset's tools and tracks listing-failure
 // streaks so callers can de-duplicate warnings via ShouldReportListFailure().
 // A successful listing clears the streak so a future failure is reported as
-// fresh.
+// fresh. Releasing the lifecycle lock on return can settle a pending
+// StopIfStarted request, so a call may invoke — and block on — the
+// underlying Stop.
 func (s *StartableToolSet) Tools(ctx context.Context) ([]Tool, error) {
 	ta, err := s.ToolSet.Tools(ctx)
 
@@ -405,15 +462,19 @@ func (s *StartableToolSet) stopLocked(ctx context.Context) error {
 // Tools, a reporter or Stop: while still holding mu it consumes the request
 // and, when the toolset is started, stops it. The requester may have timed
 // out and returned long ago, so the stop runs under context.WithoutCancel
-// of the request ctx and a failure can only be logged.
+// of the request ctx and a failure can only be logged. It reports whether
+// any request was settled, so non-blocking probes (TryIsStarted) can avoid
+// reporting a started toolset this very release just reaped.
 //
 // Each round settles one request; the lock is released by the round that
 // finds none. Re-checking after a stop keeps stopRequestMu holds brief
 // (never across stopLocked) while still consuming a request published
 // during that stop, whose publisher may have timed out behind it.
-func (s *StartableToolSet) unlock() {
+func (s *StartableToolSet) unlock() (settled bool) {
 	for !s.settleStopRequestAndRelease() {
+		settled = true
 	}
+	return settled
 }
 
 // settleStopRequestAndRelease performs one round of the unlock handshake:

--- a/pkg/tools/startable.go
+++ b/pkg/tools/startable.go
@@ -3,6 +3,7 @@ package tools
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"sync"
 
 	"go.opentelemetry.io/otel"
@@ -71,6 +72,66 @@ func (f *failureStreak) shouldReport() bool {
 	return true
 }
 
+// lifecycleMutex is a mutex built on a 1-buffered channel: the lock is held
+// while the buffer is full. Unlike sync.Mutex, acquisition can be bounded by
+// a context, which the shutdown path needs when an in-flight Start ignores
+// cancellation and never releases the lock (#4001). The zero value is ready
+// to use; like sync.Mutex, a lifecycleMutex must not be copied after first
+// use.
+type lifecycleMutex struct {
+	once sync.Once
+	ch   chan struct{}
+}
+
+// init makes the zero value usable; every method calls it before touching ch.
+func (m *lifecycleMutex) init() {
+	m.once.Do(func() { m.ch = make(chan struct{}, 1) })
+}
+
+func (m *lifecycleMutex) Lock() {
+	m.init()
+	m.ch <- struct{}{}
+}
+
+// LockContext acquires the lock unless ctx ends first, in which case it
+// returns ctx.Err() without acquiring. An uncontended lock is always
+// acquired, even when ctx is already done, so a shutdown arriving with an
+// expired deadline still stops responsive toolsets.
+func (m *lifecycleMutex) LockContext(ctx context.Context) error {
+	m.init()
+	select {
+	case m.ch <- struct{}{}:
+		return nil
+	default:
+	}
+	select {
+	case m.ch <- struct{}{}:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+// TryLock acquires the lock only when it is immediately available.
+func (m *lifecycleMutex) TryLock() bool {
+	m.init()
+	select {
+	case m.ch <- struct{}{}:
+		return true
+	default:
+		return false
+	}
+}
+
+func (m *lifecycleMutex) Unlock() {
+	m.init()
+	select {
+	case <-m.ch:
+	default:
+		panic("tools: Unlock of an unlocked lifecycleMutex")
+	}
+}
+
 // StartableToolSet wraps a ToolSet with lazy, single-flight start semantics.
 // This is the canonical way to manage toolset lifecycle.
 //
@@ -85,8 +146,28 @@ func (f *failureStreak) shouldReport() bool {
 type StartableToolSet struct {
 	ToolSet
 
-	mu          sync.Mutex
-	started     bool
+	// mu serializes lifecycle operations (Start/Stop) and guards started
+	// and the failure streaks. TryStart and TryIsStarted use TryLock to
+	// detect an in-flight lifecycle operation without blocking (#4001);
+	// StopIfStarted uses LockContext so shutdown deadlines are honored even
+	// when an in-flight Start ignores cancellation and keeps the lock past
+	// them. Every holder must release through unlock — never mu.Unlock
+	// directly — so a stop request abandoned by a timed-out StopIfStarted
+	// is consumed by whichever holder releases the lock next.
+	mu      lifecycleMutex
+	started bool
+
+	// stopRequestMu guards the stop request that StopIfStarted publishes
+	// before waiting for mu. A requester that times out waiting leaves the
+	// request behind for the current holder's unlock handshake, so it can
+	// neither go stale (leaking a started toolset) nor linger to reap a
+	// start a later caller deliberately performs. Lock order: mu may be
+	// held when taking stopRequestMu; stopRequestMu is never held while
+	// acquiring mu.
+	stopRequestMu  sync.Mutex
+	stopRequested  bool
+	stopRequestCtx context.Context //nolint:containedctx // carries the requester's values into a late stop; set iff stopRequested
+
 	startStreak failureStreak // Start() failures
 	listStreak  failureStreak // Tools() listing failures
 	// recoveryStreak tracks once-per-streak notices specifically for
@@ -104,9 +185,27 @@ func NewStartable(ts ToolSet) *StartableToolSet {
 
 // IsStarted returns whether the toolset has been successfully started.
 // For toolsets that don't implement Startable, this always returns true.
+// It waits for any in-flight lifecycle operation (Start/Stop) to settle,
+// so callers deciding whether a Stop is needed observe the final state;
+// use TryIsStarted on paths that must never block.
 func (s *StartableToolSet) IsStarted() bool {
 	s.mu.Lock()
-	defer s.mu.Unlock()
+	defer s.unlock()
+	return s.started
+}
+
+// TryIsStarted is the non-blocking variant of IsStarted: when another
+// lifecycle operation (Start/Stop) holds the single-flight lock it returns
+// false immediately instead of waiting for it to settle. false therefore
+// means "unstarted, or a lifecycle operation is in flight". It exists for
+// callers that must skip a toolset that isn't immediately ready (e.g.
+// collecting tools for a turn) rather than stall behind a wedged Start
+// (#4001); callers that need the settled state must use IsStarted.
+func (s *StartableToolSet) TryIsStarted() bool {
+	if !s.mu.TryLock() {
+		return false
+	}
+	defer s.unlock()
 	return s.started
 }
 
@@ -114,10 +213,43 @@ func (s *StartableToolSet) IsStarted() bool {
 // Concurrent callers block until the start attempt completes.
 // If start fails, a future call will retry.
 // If the underlying toolset doesn't implement Startable, this is a no-op.
-func (s *StartableToolSet) Start(ctx context.Context) (err error) {
+func (s *StartableToolSet) Start(ctx context.Context) error {
 	s.mu.Lock()
-	defer s.mu.Unlock()
+	defer s.unlock()
+	return s.startLocked(ctx)
+}
 
+// TryStart is the non-blocking variant of Start for turn-critical callers:
+// it never joins an in-flight lifecycle operation. When another Start or
+// Stop holds the single-flight lock it returns (false, nil) immediately —
+// start already in progress, not ready yet — without recording a failure
+// streak. Otherwise it runs exactly the same start logic as Start:
+// (true, nil) when the toolset is started (freshly or already latched),
+// (false, err) when the attempt ran and failed, and (false, nil) also when
+// a pending shutdown (StopIfStarted) reaped the toolset within the attempt.
+func (s *StartableToolSet) TryStart(ctx context.Context) (started bool, err error) {
+	if !s.mu.TryLock() {
+		return false, nil
+	}
+	// Return values are computed before deferred calls run, and the release
+	// handshake in unlock may consume a pending shutdown request and stop
+	// the toolset this attempt just started: re-check after the release so
+	// a reaped start is reported as (false, nil), not as started.
+	defer func() {
+		s.unlock()
+		if started {
+			started = s.TryIsStarted()
+		}
+	}()
+	if err := s.startLocked(ctx); err != nil {
+		return false, err
+	}
+	return s.started, nil
+}
+
+// startLocked implements the start sequence shared by Start and TryStart.
+// s.mu must be held.
+func (s *StartableToolSet) startLocked(ctx context.Context) (err error) {
 	recovering := false
 	if s.started {
 		if reporter, ok := As[startReporter](s.ToolSet); !ok || reporter.IsStarted() {
@@ -197,7 +329,7 @@ func (s *StartableToolSet) Tools(ctx context.Context) ([]Tool, error) {
 	ta, err := s.ToolSet.Tools(ctx)
 
 	s.mu.Lock()
-	defer s.mu.Unlock()
+	defer s.unlock()
 	if err != nil {
 		s.listStreak.fail()
 		return nil, err
@@ -211,8 +343,53 @@ func (s *StartableToolSet) Tools(ctx context.Context) ([]Tool, error) {
 // the started flag so that a subsequent Start will re-initialize.
 func (s *StartableToolSet) Stop(ctx context.Context) error {
 	s.mu.Lock()
-	defer s.mu.Unlock()
+	defer s.unlock()
+	return s.stopLocked(ctx)
+}
 
+// StopIfStarted stops the toolset only when it has been started, waiting —
+// bounded by ctx — for an in-flight lifecycle operation to settle first.
+// It is the shutdown-path variant of Stop:
+//
+//   - When an in-flight Start settles before ctx is done, check-then-stop
+//     runs atomically under the lifecycle lock: a start that completes in
+//     time is stopped, never leaked, and a never-started toolset is left
+//     untouched.
+//   - When ctx ends first (a wedged Start ignoring cancellation, #4001), it
+//     returns ctx.Err() without blocking further. The published request
+//     stays pending and is consumed by the current lock holder's release
+//     handshake (see unlock), which stops the toolset when that holder
+//     leaves it started — so a start that settles after the deadline is
+//     still reaped, and a later deliberate start is never affected.
+func (s *StartableToolSet) StopIfStarted(ctx context.Context) error {
+	// Publish the request before waiting so it cannot be lost to a holder
+	// that releases the lock only after the deadline below.
+	s.stopRequestMu.Lock()
+	s.stopRequested = true
+	s.stopRequestCtx = ctx
+	s.stopRequestMu.Unlock()
+
+	if err := s.mu.LockContext(ctx); err != nil {
+		return err
+	}
+	defer s.unlock()
+
+	// Claim the request — ours, or a concurrent caller's; one stop settles
+	// both — so it cannot linger past this shutdown.
+	s.stopRequestMu.Lock()
+	s.stopRequested = false
+	s.stopRequestCtx = nil
+	s.stopRequestMu.Unlock()
+
+	if !s.started {
+		return nil
+	}
+	return s.stopLocked(ctx)
+}
+
+// stopLocked implements the stop sequence shared by Stop, StopIfStarted and
+// the unlock release handshake; s.mu must be held.
+func (s *StartableToolSet) stopLocked(ctx context.Context) error {
 	s.started = false
 	s.startStreak.reset()
 	s.listStreak.reset()
@@ -223,13 +400,56 @@ func (s *StartableToolSet) Stop(ctx context.Context) error {
 	return nil
 }
 
+// unlock releases the lifecycle lock after a handshake that settles any
+// pending StopIfStarted request — no matter whether this holder was Start,
+// Tools, a reporter or Stop: while still holding mu it consumes the request
+// and, when the toolset is started, stops it. The requester may have timed
+// out and returned long ago, so the stop runs under context.WithoutCancel
+// of the request ctx and a failure can only be logged.
+//
+// Each round settles one request; the lock is released by the round that
+// finds none. Re-checking after a stop keeps stopRequestMu holds brief
+// (never across stopLocked) while still consuming a request published
+// during that stop, whose publisher may have timed out behind it.
+func (s *StartableToolSet) unlock() {
+	for !s.settleStopRequestAndRelease() {
+	}
+}
+
+// settleStopRequestAndRelease performs one round of the unlock handshake:
+// when no stop request is pending it releases the lifecycle lock and reports
+// true; otherwise it consumes the request, stops a started toolset on the
+// requester's behalf, and reports false so unlock checks again.
+func (s *StartableToolSet) settleStopRequestAndRelease() bool {
+	s.stopRequestMu.Lock()
+	if !s.stopRequested {
+		// Releasing mu before stopRequestMu closes the publish/consume
+		// race: a request published after this check finds mu free, so the
+		// requester's own LockContext — or the next holder's unlock —
+		// settles it.
+		s.mu.Unlock()
+		s.stopRequestMu.Unlock()
+		return true
+	}
+	s.stopRequested = false
+	ctx := context.WithoutCancel(s.stopRequestCtx)
+	s.stopRequestCtx = nil
+	s.stopRequestMu.Unlock()
+	if s.started {
+		if err := s.stopLocked(ctx); err != nil {
+			slog.WarnContext(ctx, "Failed to stop toolset for a pending shutdown request", "toolset", DescribeToolSet(s), "error", err)
+		}
+	}
+	return false
+}
+
 // ShouldReportFailure returns true exactly once per failure streak — after
 // the first failed Start() and before the streak ends (a successful
 // Start() or Stop()). Subsequent calls return false until a new streak
 // begins. Calling it when no failure is pending always returns false.
 func (s *StartableToolSet) ShouldReportFailure() bool {
 	s.mu.Lock()
-	defer s.mu.Unlock()
+	defer s.unlock()
 	return s.startStreak.shouldReport()
 }
 
@@ -239,7 +459,7 @@ func (s *StartableToolSet) ShouldReportFailure() bool {
 // streak begins. Calling it when no failure is pending always returns false.
 func (s *StartableToolSet) ShouldReportListFailure() bool {
 	s.mu.Lock()
-	defer s.mu.Unlock()
+	defer s.unlock()
 	return s.listStreak.shouldReport()
 }
 
@@ -255,7 +475,7 @@ func (s *StartableToolSet) ShouldReportListFailure() bool {
 // the first interactive turn).
 func (s *StartableToolSet) ShouldReportRecoveryFailure() bool {
 	s.mu.Lock()
-	defer s.mu.Unlock()
+	defer s.unlock()
 	return s.recoveryStreak.shouldReport()
 }
 

--- a/pkg/tools/startable_test.go
+++ b/pkg/tools/startable_test.go
@@ -3,6 +3,8 @@ package tools_test
 import (
 	"context"
 	"errors"
+	"sync"
+	"sync/atomic"
 	"testing"
 
 	"gotest.tools/v3/assert"
@@ -456,4 +458,343 @@ func TestStartableToolSet_ShouldReportRecoveryFailure_ResetsOnStop(t *testing.T)
 
 	assert.Check(t, s.Start(t.Context()) != nil)
 	assert.Check(t, is.Equal(s.ShouldReportRecoveryFailure(), true), "fresh recovery after Stop must report again")
+}
+
+// blockingToolSet blocks in Start until release is closed. entered is closed
+// on the first Start call so tests can line up with the in-flight attempt.
+type blockingToolSet struct {
+	entered  chan struct{}
+	release  chan struct{}
+	startErr error
+	calls    atomic.Int32
+	stops    atomic.Int32
+}
+
+func (b *blockingToolSet) Tools(context.Context) ([]tools.Tool, error) { return nil, nil }
+
+func (b *blockingToolSet) Start(context.Context) error {
+	if b.calls.Add(1) == 1 {
+		close(b.entered)
+	}
+	<-b.release
+	return b.startErr
+}
+
+func (b *blockingToolSet) Stop(context.Context) error {
+	b.stops.Add(1)
+	return nil
+}
+
+// TestStartableToolSet_TryStartSkipsInFlightStart pins the TryStart contract
+// for #4001: while another Start holds the single-flight lock, TryStart
+// returns (false, nil) immediately — no second underlying Start, no failure
+// streak — and TryIsStarted reports not-ready without blocking.
+func TestStartableToolSet_TryStartSkipsInFlightStart(t *testing.T) {
+	t.Parallel()
+
+	inner := &blockingToolSet{entered: make(chan struct{}), release: make(chan struct{})}
+	s := tools.NewStartable(inner)
+
+	assert.Check(t, is.Equal(s.TryIsStarted(), false), "TryIsStarted is false while unstarted")
+
+	// Always unblock the wedged Start so no goroutine outlives the test.
+	release := sync.OnceFunc(func() { close(inner.release) })
+	t.Cleanup(release)
+
+	startDone := make(chan error, 1)
+	go func() { startDone <- s.Start(t.Context()) }()
+	<-inner.entered
+
+	started, err := s.TryStart(t.Context())
+	assert.NilError(t, err, "an in-flight start must not surface as a failure")
+	assert.Check(t, !started, "TryStart must not join an in-flight start")
+	assert.Check(t, is.Equal(inner.calls.Load(), int32(1)), "TryStart must not run a second underlying Start")
+	assert.Check(t, is.Equal(s.TryIsStarted(), false), "TryIsStarted is false while a lifecycle operation is in flight")
+
+	release()
+	assert.NilError(t, <-startDone)
+
+	// The skipped TryStart must not have begun a failure streak.
+	assert.Check(t, is.Equal(s.ShouldReportFailure(), false), "skipped TryStart must not record a failure")
+	assert.Check(t, is.Equal(s.IsStarted(), true))
+	assert.Check(t, is.Equal(s.TryIsStarted(), true), "TryIsStarted reads the settled state once the lock is free")
+
+	// Latched: a later TryStart reports started without another underlying call.
+	started, err = s.TryStart(t.Context())
+	assert.NilError(t, err)
+	assert.Check(t, started)
+	assert.Check(t, is.Equal(inner.calls.Load(), int32(1)))
+}
+
+// TestStartableToolSet_TryStartRunsStartLogic verifies that when the lock is
+// free, TryStart behaves exactly like Start: a failure records the
+// once-per-streak warning and a subsequent success latches the started state.
+func TestStartableToolSet_TryStartRunsStartLogic(t *testing.T) {
+	t.Parallel()
+
+	errBoom := errors.New("boom")
+	f := &flappyToolSet{errs: []error{errBoom, nil}}
+	s := tools.NewStartable(f)
+
+	started, err := s.TryStart(t.Context())
+	assert.Check(t, errors.Is(err, errBoom), "TryStart must surface the underlying start error")
+	assert.Check(t, !started)
+	assert.Check(t, is.Equal(s.ShouldReportFailure(), true), "a failed TryStart attempt reports like Start")
+
+	started, err = s.TryStart(t.Context())
+	assert.NilError(t, err)
+	assert.Check(t, started)
+	assert.Check(t, is.Equal(s.IsStarted(), true))
+	assert.Check(t, is.Equal(f.startups, 1))
+}
+
+// TestStartableToolSet_StopIfStartedLeavesNeverStartedUntouched pins the
+// shutdown intent carried over from Agent.StopToolSets: a toolset that was
+// never started must not have its underlying Stop called.
+func TestStartableToolSet_StopIfStartedLeavesNeverStartedUntouched(t *testing.T) {
+	t.Parallel()
+
+	inner := &blockingToolSet{entered: make(chan struct{}), release: make(chan struct{})}
+	s := tools.NewStartable(inner)
+
+	assert.NilError(t, s.StopIfStarted(t.Context()))
+	assert.Check(t, is.Equal(inner.stops.Load(), int32(0)), "a toolset that was never started must not be stopped")
+}
+
+// TestStartableToolSet_StopIfStartedStopsStarted verifies the settled fast
+// path: a started toolset is stopped and unlatched.
+func TestStartableToolSet_StopIfStartedStopsStarted(t *testing.T) {
+	t.Parallel()
+
+	inner := &blockingToolSet{entered: make(chan struct{}), release: make(chan struct{})}
+	close(inner.release) // Start completes immediately
+	s := tools.NewStartable(inner)
+
+	assert.NilError(t, s.Start(t.Context()))
+	assert.NilError(t, s.StopIfStarted(t.Context()))
+	assert.Check(t, is.Equal(inner.stops.Load(), int32(1)))
+	assert.Check(t, is.Equal(s.IsStarted(), false))
+}
+
+// TestStartableToolSet_StopIfStartedHonorsContext pins the deadline half of
+// the shutdown contract: while a wedged Start holds the single-flight lock,
+// StopIfStarted gives up with ctx.Err() instead of blocking, leaves the
+// underlying Stop unrun, and leaves the request pending for the wedged
+// attempt — whose lock release reaps the toolset when the attempt settles
+// successfully. A consumed request must not affect a later deliberate start.
+func TestStartableToolSet_StopIfStartedHonorsContext(t *testing.T) {
+	t.Parallel()
+
+	inner := &blockingToolSet{entered: make(chan struct{}), release: make(chan struct{})}
+	s := tools.NewStartable(inner)
+
+	// Always unblock the wedged Start so no goroutine outlives the test.
+	release := sync.OnceFunc(func() { close(inner.release) })
+	t.Cleanup(release)
+
+	startDone := make(chan error, 1)
+	go func() { startDone <- s.Start(t.Context()) }()
+	<-inner.entered
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+	err := s.StopIfStarted(ctx)
+	assert.Check(t, errors.Is(err, context.Canceled), "StopIfStarted must give up when ctx ends while Start is wedged: %v", err)
+	assert.Check(t, is.Equal(inner.stops.Load(), int32(0)), "the underlying Stop must not run while Start is wedged")
+
+	// The wedged Start settles: the abandoned request reaps the toolset.
+	release()
+	assert.NilError(t, <-startDone)
+	assert.Check(t, is.Equal(inner.stops.Load(), int32(1)), "a start that settles after the abandoned request must be stopped")
+	assert.Check(t, is.Equal(s.IsStarted(), false))
+
+	// The request was consumed by the reap: a later deliberate start must
+	// stay up.
+	assert.NilError(t, s.Start(t.Context()))
+	assert.Check(t, is.Equal(s.IsStarted(), true))
+	assert.Check(t, is.Equal(inner.stops.Load(), int32(1)), "a later deliberate start must not be reaped")
+}
+
+// TestStartableToolSet_StopIfStartedRequestDiscardedOnFailedStart verifies
+// that when the wedged Start fails after the stop request was abandoned,
+// there is nothing to reap: the request is consumed on lock release without
+// stopping anything, rather than left to stop an instance a later caller
+// deliberately starts.
+func TestStartableToolSet_StopIfStartedRequestDiscardedOnFailedStart(t *testing.T) {
+	t.Parallel()
+
+	errBoom := errors.New("boom")
+	inner := &blockingToolSet{entered: make(chan struct{}), release: make(chan struct{}), startErr: errBoom}
+	s := tools.NewStartable(inner)
+
+	// Always unblock the wedged Start so no goroutine outlives the test.
+	release := sync.OnceFunc(func() { close(inner.release) })
+	t.Cleanup(release)
+
+	startDone := make(chan error, 1)
+	go func() { startDone <- s.Start(t.Context()) }()
+	<-inner.entered
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+	assert.Check(t, errors.Is(s.StopIfStarted(ctx), context.Canceled))
+
+	// The wedged Start fails: nothing started, nothing to stop.
+	release()
+	assert.Check(t, errors.Is(<-startDone, errBoom))
+	assert.Check(t, is.Equal(inner.stops.Load(), int32(0)))
+
+	inner.startErr = nil
+	assert.NilError(t, s.Start(t.Context()))
+	assert.Check(t, is.Equal(s.IsStarted(), true))
+	assert.Check(t, is.Equal(inner.stops.Load(), int32(0)), "the discarded request must not reap the fresh start")
+}
+
+// barrierReporterToolSet is a startable toolset whose IsStarted reporter can
+// be armed to block once. startLocked probes the reporter (while holding the
+// lifecycle lock) when the wrapper is already latched started, so the barrier
+// keeps a non-starting lock holder busy through public behavior alone — long
+// enough for a StopIfStarted deadline to expire behind it.
+type barrierReporterToolSet struct {
+	entered chan struct{} // closed when the armed probe begins blocking
+	release chan struct{} // closed by the test to let the probe return
+	armed   atomic.Bool
+	started atomic.Bool
+	stops   atomic.Int32
+}
+
+func newBarrierReporterToolSet() *barrierReporterToolSet {
+	return &barrierReporterToolSet{entered: make(chan struct{}), release: make(chan struct{})}
+}
+
+func (b *barrierReporterToolSet) Tools(context.Context) ([]tools.Tool, error) { return nil, nil }
+
+func (b *barrierReporterToolSet) Start(context.Context) error {
+	b.started.Store(true)
+	return nil
+}
+
+func (b *barrierReporterToolSet) Stop(context.Context) error {
+	b.stops.Add(1)
+	b.started.Store(false)
+	return nil
+}
+
+func (b *barrierReporterToolSet) IsStarted() bool {
+	if b.armed.CompareAndSwap(true, false) {
+		close(b.entered)
+		<-b.release
+	}
+	return b.started.Load()
+}
+
+// TestStartableToolSet_StopIfStartedRequestOutlivesLatchedStart pins the
+// removal of the stale-request compromise: a stop request that times out
+// while the lifecycle lock is held by a short, non-starting holder — here a
+// latched Start blocked in its reporter probe — must stop the still-started
+// toolset as soon as that holder releases the lock, and must not linger to
+// reap a later deliberate start.
+func TestStartableToolSet_StopIfStartedRequestOutlivesLatchedStart(t *testing.T) {
+	t.Parallel()
+
+	inner := newBarrierReporterToolSet()
+	s := tools.NewStartable(inner)
+	assert.NilError(t, s.Start(t.Context()))
+
+	// Wedge a latched Start inside the reporter probe: the lifecycle lock is
+	// held but nothing is being started.
+	inner.armed.Store(true)
+	releaseProbe := sync.OnceFunc(func() { close(inner.release) })
+	t.Cleanup(releaseProbe)
+	startDone := make(chan error, 1)
+	go func() { startDone <- s.Start(t.Context()) }()
+	<-inner.entered
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+	assert.Check(t, errors.Is(s.StopIfStarted(ctx), context.Canceled))
+	assert.Check(t, is.Equal(inner.stops.Load(), int32(0)), "the underlying Stop must not run while the probe holds the lock")
+
+	// The probe returns: the holder consumes the abandoned request on lock
+	// release and stops the still-started toolset before Start returns.
+	releaseProbe()
+	assert.NilError(t, <-startDone)
+	assert.Check(t, is.Equal(inner.stops.Load(), int32(1)), "the abandoned request must stop the toolset when the lock holder releases")
+	assert.Check(t, is.Equal(s.IsStarted(), false))
+
+	// The request was consumed: a later deliberate start stays up.
+	assert.NilError(t, s.Start(t.Context()))
+	assert.Check(t, is.Equal(s.IsStarted(), true))
+	assert.Check(t, is.Equal(inner.stops.Load(), int32(1)), "a later deliberate start must not be reaped")
+}
+
+// TestStartableToolSet_TryStartReportsReapedStart pins TryStart's return
+// value against the release handshake: when a shutdown request abandoned
+// during the attempt is consumed as TryStart releases the lock, the toolset
+// it just confirmed started is stopped again, and TryStart must report
+// (false, nil) rather than a started toolset that no longer is.
+func TestStartableToolSet_TryStartReportsReapedStart(t *testing.T) {
+	t.Parallel()
+
+	inner := newBarrierReporterToolSet()
+	s := tools.NewStartable(inner)
+	assert.NilError(t, s.Start(t.Context()))
+
+	inner.armed.Store(true)
+	releaseProbe := sync.OnceFunc(func() { close(inner.release) })
+	t.Cleanup(releaseProbe)
+
+	type result struct {
+		started bool
+		err     error
+	}
+	tryDone := make(chan result, 1)
+	go func() {
+		started, err := s.TryStart(t.Context())
+		tryDone <- result{started: started, err: err}
+	}()
+	<-inner.entered
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+	assert.Check(t, errors.Is(s.StopIfStarted(ctx), context.Canceled))
+
+	releaseProbe()
+	res := <-tryDone
+	assert.NilError(t, res.err)
+	assert.Check(t, !res.started, "TryStart must not report started after the pending request reaped the toolset")
+	assert.Check(t, is.Equal(inner.stops.Load(), int32(1)))
+	assert.Check(t, is.Equal(s.IsStarted(), false))
+}
+
+// TestStartableToolSet_ZeroValueIsUsable pins that a StartableToolSet
+// constructed without NewStartable — zero-value lock fields — does not
+// deadlock: the lifecycle mutex initializes lazily on first use, including
+// concurrent first use.
+func TestStartableToolSet_ZeroValueIsUsable(t *testing.T) {
+	t.Parallel()
+
+	s := &tools.StartableToolSet{ToolSet: &stubToolSet{}}
+
+	var wg sync.WaitGroup
+	for range 4 {
+		wg.Go(func() {
+			_ = s.IsStarted()
+		})
+	}
+	wg.Wait()
+
+	assert.NilError(t, s.Start(t.Context()))
+	assert.Check(t, is.Equal(s.IsStarted(), true))
+
+	started, err := s.TryStart(t.Context())
+	assert.NilError(t, err)
+	assert.Check(t, started)
+	assert.Check(t, is.Equal(s.TryIsStarted(), true))
+
+	_, err = s.Tools(t.Context())
+	assert.NilError(t, err)
+
+	assert.NilError(t, s.StopIfStarted(t.Context()))
+	assert.Check(t, is.Equal(s.IsStarted(), false))
 }

--- a/pkg/tools/startable_test.go
+++ b/pkg/tools/startable_test.go
@@ -6,6 +6,8 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
+	"testing/synctest"
+	"time"
 
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
@@ -548,6 +550,42 @@ func TestStartableToolSet_TryStartRunsStartLogic(t *testing.T) {
 	assert.Check(t, is.Equal(f.startups, 1))
 }
 
+// TestStartableToolSet_TryStartWithTimeoutAbandonsWedgedStart pins the shared
+// bounded-start helper used by the agent turn path and the runtime startup
+// probe: a wedged Start (one that ignores cancellation) is abandoned exactly
+// at the bound with the bound's context error, an attempt already in flight
+// is skipped rather than joined, and the abandoned attempt keeps running in
+// the background under the single-flight lock so a later call picks up its
+// outcome.
+func TestStartableToolSet_TryStartWithTimeoutAbandonsWedgedStart(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		inner := &blockingToolSet{entered: make(chan struct{}), release: make(chan struct{})}
+		s := tools.NewStartable(inner)
+
+		begin := time.Now()
+		started, err := s.TryStartWithTimeout(t.Context(), time.Second)
+		assert.Check(t, errors.Is(err, context.DeadlineExceeded), "a wedged attempt must be abandoned with the bound's error: %v", err)
+		assert.Check(t, !started)
+		assert.Check(t, is.Equal(time.Since(begin), time.Second), "the attempt must be abandoned exactly at the bound (fake time)")
+
+		// While the abandoned attempt holds the single-flight lock, a second
+		// bounded call skips it immediately instead of joining it.
+		started, err = s.TryStartWithTimeout(t.Context(), time.Second)
+		assert.NilError(t, err, "an in-flight start must not surface as a failure")
+		assert.Check(t, !started, "a bounded call must not join an in-flight start")
+		assert.Check(t, is.Equal(inner.calls.Load(), int32(1)), "the skip must not run a second underlying Start")
+
+		// The abandoned attempt settles in the background; a later call
+		// reports the latched start without another underlying Start.
+		close(inner.release)
+		synctest.Wait()
+		started, err = s.TryStartWithTimeout(t.Context(), time.Second)
+		assert.NilError(t, err)
+		assert.Check(t, started)
+		assert.Check(t, is.Equal(inner.calls.Load(), int32(1)))
+	})
+}
+
 // TestStartableToolSet_StopIfStartedLeavesNeverStartedUntouched pins the
 // shutdown intent carried over from Agent.StopToolSets: a toolset that was
 // never started must not have its underlying Stop called.
@@ -572,6 +610,26 @@ func TestStartableToolSet_StopIfStartedStopsStarted(t *testing.T) {
 
 	assert.NilError(t, s.Start(t.Context()))
 	assert.NilError(t, s.StopIfStarted(t.Context()))
+	assert.Check(t, is.Equal(inner.stops.Load(), int32(1)))
+	assert.Check(t, is.Equal(s.IsStarted(), false))
+}
+
+// TestStartableToolSet_StopIfStartedExpiredContextStopsResponsiveToolset pins
+// the deliberate fast path in lifecycleMutex.LockContext: an uncontended lock
+// is acquired even when ctx is already done, so a shutdown arriving with an
+// expired deadline still stops a responsive started toolset instead of
+// leaking it.
+func TestStartableToolSet_StopIfStartedExpiredContextStopsResponsiveToolset(t *testing.T) {
+	t.Parallel()
+
+	inner := &blockingToolSet{entered: make(chan struct{}), release: make(chan struct{})}
+	close(inner.release) // Start completes immediately, Stop never blocks
+	s := tools.NewStartable(inner)
+	assert.NilError(t, s.Start(t.Context()))
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+	assert.NilError(t, s.StopIfStarted(ctx), "an already-canceled ctx must still stop an uncontended started toolset")
 	assert.Check(t, is.Equal(inner.stops.Load(), int32(1)))
 	assert.Check(t, is.Equal(s.IsStarted(), false))
 }
@@ -764,6 +822,30 @@ func TestStartableToolSet_TryStartReportsReapedStart(t *testing.T) {
 	assert.NilError(t, res.err)
 	assert.Check(t, !res.started, "TryStart must not report started after the pending request reaped the toolset")
 	assert.Check(t, is.Equal(inner.stops.Load(), int32(1)))
+	assert.Check(t, is.Equal(s.IsStarted(), false))
+}
+
+// TestStartableToolSet_TryIsStartedReportsReapedStart is the TryIsStarted
+// analogue of the TryStart test above: when a pending shutdown request is
+// consumed as TryIsStarted releases the lock, the toolset it just observed
+// started is stopped again, and TryIsStarted must report false rather than
+// a started toolset that no longer is. The pending request is planted
+// directly because the window it models — a StopIfStarted that published its
+// request but lost the lifecycle-lock race to TryIsStarted before giving up
+// on its already-done context — cannot be sequenced deterministically through
+// the public API.
+func TestStartableToolSet_TryIsStartedReportsReapedStart(t *testing.T) {
+	t.Parallel()
+
+	inner := &blockingToolSet{entered: make(chan struct{}), release: make(chan struct{})}
+	close(inner.release) // Start completes immediately
+	s := tools.NewStartable(inner)
+	assert.NilError(t, s.Start(t.Context()))
+
+	s.ExportedPublishStopRequest(t.Context())
+
+	assert.Check(t, is.Equal(s.TryIsStarted(), false), "TryIsStarted must not report started after its own release reaped the toolset")
+	assert.Check(t, is.Equal(inner.stops.Load(), int32(1)), "the pending request must stop the toolset on release")
 	assert.Check(t, is.Equal(s.IsStarted(), false))
 }
 


### PR DESCRIPTION
## Summary

- keep conversation turns responsive when a toolset start is already in progress or exceeds the start budget
- make toolset shutdown context-aware while still reaping starts that finish after shutdown times out
- detach the long-lived RAG watcher from the short-lived startup context and keep `Stop` responsible for cancellation

## Issue expectations

| Expectation from #4001 | Implementation |
| --- | --- |
| Bound `Start()` on the turn-critical path | `Agent` races turn-initiated starts against a 30-second timeout |
| Do not wait behind the startup probe's abandoned `Start()` | non-blocking `TryStart` skips an in-flight lifecycle operation |
| Continue with tools that are already available | non-blocking readiness checks omit only toolsets that are not immediately ready |
| Preserve bounded shutdown | context-aware `StopIfStarted` honors shutdown deadlines and reaps a late successful start |
| Keep the RAG watcher alive after the startup probe returns | watcher context uses `context.WithoutCancel` while preserving context values |
| Stop long-lived RAG work during lifecycle cleanup | `ToolSet.Stop` remains the owner of watcher cancellation and waits for managed goroutines |

## Validation

- `go test -race -count=1 ./pkg/tools ./pkg/agent ./pkg/runtime ./pkg/tools/builtin/rag ./pkg/tools/mcp ./pkg/tools/builtin/mcpcatalog ./pkg/team ./pkg/a2a ./pkg/acp ./pkg/chatserver ./pkg/mcp ./pkg/server`
- lifecycle and timeout regression tests repeated 100 times under the race detector with `GOMAXPROCS=1` and `GOMAXPROCS=8`
- end-to-end runtime probe timeout validation repeated 50 times under the race detector
- RAG watcher cancellation validation repeated 50 times under the race detector, including a mutation check that fails when `context.WithoutCancel` is removed
- `go test ./...` with local HTTP proxy variables removed
- `golangci-lint run ./pkg/tools/... ./pkg/agent/... ./pkg/runtime/...`
- `go vet` on directly impacted packages and consumers
- `go run ./lint .`
- `go mod tidy --diff`
- `./scripts/build.sh`

The repository-wide race run also reports existing races in `pkg/evaluation` and `pkg/tui`; both reproduce on an unchanged `main` checkout and are unrelated to this change.

Closes #4001
