### PR TITLE
fix(runtime): scope harness prompt-selection to fresh vs resume session

### DIFF
--- a/pkg/runtime/harness.go
+++ b/pkg/runtime/harness.go
@@ -48,7 +48,8 @@ func (r *LocalRuntime) runHarnessAgent(ctx context.Context, sess *session.Sessio
 
 	// Harnesses own their context; run lifecycle hooks but do not forward injected instructions.
 	r.executeTurnStartHooks(ctx, sess, a, events)
-	messages := harnessInputMessages(sess)
+	harnessSessionID := harnessSessionIDFor(sess, a)
+	messages := harnessInputMessages(sess, harnessSessionID)
 	stop, msg, rewritten := r.executeBeforeLLMCallHooks(ctx, sess, a, modelID, 1, messages)
 	if stop {
 		slog.WarnContext(ctx, "before_llm_call hook signalled run termination",
@@ -61,8 +62,6 @@ func (r *LocalRuntime) runHarnessAgent(ctx context.Context, sess *session.Sessio
 		messages = rewritten
 	}
 	messages = r.applyBeforeLLMCallTransforms(ctx, sess, a, modelID, messages)
-
-	harnessSessionID := harnessSessionIDFor(sess, a)
 	prompt := strings.TrimSpace(harnessPrompt(messages))
 	if prompt == "" {
 		msg := "cannot run external harness without a user prompt"
@@ -421,7 +420,22 @@ func (r *LocalRuntime) rememberHarnessSessionID(ctx context.Context, sess *sessi
 	}
 }
 
-func harnessInputMessages(sess *session.Session) []chat.Message {
+// harnessInputMessages selects the messages to use as the harness prompt.
+// On resume (harnessSessionID != "") only the latest non-implicit user turn is
+// sent; the harness already holds prior context from its own session.
+// On a fresh session (harnessSessionID == "") the full delegated context is
+// included — system/task message plus all user messages — because the harness
+// receives no system prompt of its own and the task can only arrive via prompt.
+func harnessInputMessages(sess *session.Session, harnessSessionID string) []chat.Message {
+	if harnessSessionID != "" {
+		return latestUserTurn(sess)
+	}
+	return freshHarnessMessages(sess)
+}
+
+// latestUserTurn returns the most recent non-implicit user message, used on
+// resume turns where the harness already holds the preceding context.
+func latestUserTurn(sess *session.Session) []chat.Message {
 	for _, item := range slices.Backward(sess.MessagesSnapshot()) {
 		if item.Message != nil && !item.Message.Implicit && item.Message.Message.Role == chat.MessageRoleUser {
 			return []chat.Message{item.Message.Message}
@@ -430,13 +444,46 @@ func harnessInputMessages(sess *session.Session) []chat.Message {
 	return nil
 }
 
-func harnessPrompt(messages []chat.Message) string {
-	for _, message := range slices.Backward(messages) {
-		if message.Role == chat.MessageRoleUser {
-			return harnessMessageContent(message)
+// freshHarnessMessages collects the full delegated context for a new harness
+// session: all system and user messages (including implicit ones) in order.
+// Returns nil when the session contains no meaningful content — i.e. only an
+// implicit filler with no system/task message and no real user text — so the
+// empty-prompt guard in runHarnessAgent can still catch that degenerate case.
+func freshHarnessMessages(sess *session.Session) []chat.Message {
+	var msgs []chat.Message
+	hasMeaningful := false
+	for _, item := range sess.MessagesSnapshot() {
+		if item.Message == nil {
+			continue
+		}
+		msg := item.Message.Message
+		switch msg.Role {
+		case chat.MessageRoleSystem:
+			msgs = append(msgs, msg)
+			hasMeaningful = true
+		case chat.MessageRoleUser:
+			msgs = append(msgs, msg)
+			if !item.Message.Implicit {
+				hasMeaningful = true
+			}
 		}
 	}
-	return ""
+	if !hasMeaningful {
+		return nil
+	}
+	return msgs
+}
+
+// harnessPrompt concatenates the content of all supplied messages (system and
+// user) to form the prompt string sent to the external harness binary.
+func harnessPrompt(messages []chat.Message) string {
+	var parts []string
+	for _, message := range messages {
+		if content := harnessMessageContent(message); content != "" {
+			parts = append(parts, content)
+		}
+	}
+	return strings.Join(parts, "\n\n")
 }
 
 func harnessMessageContent(msg chat.Message) string {

--- a/pkg/runtime/harness_test.go
+++ b/pkg/runtime/harness_test.go
@@ -165,6 +165,12 @@ func TestHarnessAgentResumesPersistedSession(t *testing.T) {
 	assert.Equal(t, "thread-123", harnessSessionIDFor(loaded, rt.CurrentAgent()))
 }
 
+// TestHarnessRejectsImplicitOrMissingUserPrompt checks the genuine empty-prompt
+// case: an implicit "Please proceed." with no task/system message is
+// meaningless to the harness, so the run must be rejected before launch.
+// Contrast with TestHarnessDelegatedTaskWithImplicitUserMessage below, which
+// verifies that a delegation carrying a real task (system message + implicit
+// user) succeeds.
 func TestHarnessRejectsImplicitOrMissingUserPrompt(t *testing.T) {
 	if stdruntime.GOOS == "windows" {
 		t.Skip("shell script shim test")
@@ -179,6 +185,41 @@ func TestHarnessRejectsImplicitOrMissingUserPrompt(t *testing.T) {
 	assert.True(t, hasEventType(t, events, &ErrorEvent{}))
 	_, err := os.Stat(filepath.Join(harnessBinDir, "codex.args"))
 	assert.ErrorIs(t, err, os.ErrNotExist)
+}
+
+// TestHarnessDelegatedTaskWithImplicitUserMessage is a regression test for
+// https://github.com/docker/docker-agent/issues/4011. A transfer_task
+// delegation builds a sub-session where the task text lives in the system
+// message and the only user message is the implicit "Please proceed."
+// filler injected by newSubSession. Before the fix this was rejected with
+// "cannot run external harness without a user prompt"; now the full
+// delegated context (system/task + implicit user) must be forwarded as the
+// harness prompt.
+func TestHarnessDelegatedTaskWithImplicitUserMessage(t *testing.T) {
+	if stdruntime.GOOS == "windows" {
+		t.Skip("shell script shim test")
+	}
+
+	useHarnessShim(t, "codex", `{"type":"item.completed","item":{"type":"agent_message","text":"delegation done"}}
+`)
+	rt := newHarnessRuntime(t, "codex")
+	// Mirror exactly what newSubSession builds for a transfer_task delegation:
+	// the task goes into a system message and the user message is implicit.
+	task := "implement the widget"
+	sess := session.New(
+		session.WithSystemMessage(buildTaskSystemMessage(task, "a working widget", nil)),
+		session.WithImplicitUserMessage("Please proceed."),
+	)
+	events := collectRuntimeEvents(t, rt, sess)
+
+	// Must launch without error.
+	assert.False(t, hasEventType(t, events, &ErrorEvent{}))
+	assert.Equal(t, "delegation done", sess.GetLastAssistantMessageContent())
+
+	// Harness args must carry the task text so the harness can act on it.
+	args := harnessShimArgs(t, "codex")
+	assert.Contains(t, args, task)
+	assert.Contains(t, args, "<task>")
 }
 
 func TestHarnessSubSessionIDSurvivesReconstruction(t *testing.T) {


### PR DESCRIPTION
> 🤖 **Automated implementer agent** — *this comment was posted by the implementer bot from Docker Agentic Platform, not by a human developer*

Fixes #4011.

PR #3989 changed `harnessInputMessages` to return only the latest non-implicit user turn for all sessions. This is correct for resume turns, but breaks `transfer_task` delegations where the task lives in the system message and the only user message is the implicit `"Please proceed."` filler — yielding an empty prompt and the error `cannot run external harness without a user prompt`.

**Fix:** gate prompt-building on whether a harness session already exists:

- **Fresh** (`harnessSessionID == ""`): `freshHarnessMessages` collects all system and user messages including implicit ones, so the task/system content reaches the harness. A bare implicit filler with no system/task still returns `nil`, keeping the empty-prompt guard for that degenerate case.
- **Resume** (`harnessSessionID != ""`): `latestUserTurn` sends only the latest non-implicit user turn. Preserves #3989's intent.

`harnessPrompt` is updated to concatenate content from all supplied messages (system + user) so task text from the system message is included in the prompt on fresh sessions.

**Testing:** all existing harness tests pass; added `TestHarnessDelegatedTaskWithImplicitUserMessage` as a regression test that mirrors what `newSubSession` builds for a `transfer_task` delegation.