### PR TITLE
feat(tui): add a show/hide banner setting

### DIFF
--- a/cmd/root/run.go
+++ b/cmd/root/run.go
@@ -1131,6 +1131,7 @@ func (f *runExecFlags) runLeanTUI(ctx context.Context, rt runtime.Runtime, sess 
 		wd, _ = os.Getwd()
 	}
 	renderImages := userconfig.Get().GetRenderImages() && tuiimage.SupportsKittyGraphics(os.Stdin, os.Stdout)
+	showBanner := userconfig.Get().GetShowBanner()
 	return leantui.Run(ctx, leantui.Config{
 		App:                    a,
 		WorkingDir:             wd,
@@ -1141,6 +1142,7 @@ func (f *runExecFlags) runLeanTUI(ctx context.Context, rt runtime.Runtime, sess 
 		AppName:                f.appName,
 		DisabledCommands:       f.disabledCommands,
 		RenderImages:           &renderImages,
+		ShowBanner:             &showBanner,
 	})
 }
 

--- a/docs/configuration/user-settings/index.md
+++ b/docs/configuration/user-settings/index.md
@@ -40,6 +40,7 @@ You rarely need to hand-edit this file. Most fields are managed from the TUI's `
 | `expand_thinking` | boolean | `false` | Start new sessions with thinking/tool blocks expanded instead of collapsed. |
 | `split_diff_view` | boolean | `true` | Render file-edit diffs side-by-side instead of unified. |
 | `render_images` | boolean | `true` | Render images in the TUI using the Kitty graphics protocol. Applies to both tool-result images and Markdown images in agent responses. Automatically disabled when the terminal does not support Kitty. |
+| `show_banner` | boolean | `true` | Show the ASCII-art startup banner on an empty conversation. Applies to both the full TUI and the [lean TUI](../../features/tui/index.md#lean-tui). Managed from the **Appearance** tab of `/settings`. |
 | `theme` | string | `default` | Theme name, loaded from a built-in theme or `~/.cagent/themes/<name>.yaml`. The special value `auto` follows the terminal's light/dark background. See [Theming](../../features/tui/index.md#theming). |
 | `theme_dark` | string | `default` | Theme applied when `theme: auto` and the terminal background is dark. |
 | `theme_light` | string | `default-light` | Theme applied when `theme: auto` and the terminal background is light. |
@@ -95,6 +96,7 @@ settings:
   expand_thinking: false
   split_diff_view: true
   render_images: true
+  show_banner: true
   hide_tool_results: false
   sound: true
   sound_threshold: 10
@@ -131,4 +133,4 @@ User settings are a **low-priority** source: they establish defaults, and anythi
 - **Aliases sit between CLI flags and user settings.** An [alias](../../features/cli/index.md#docker-agent-alias) (`docker agent alias add ...`) can bundle its own `yolo`, `safety`, `model`, `hide_tool_results`, and `sandbox` defaults; those apply when the corresponding flag was not explicitly passed, the same way user settings do, but are resolved after user settings so an alias's own choices take priority over your global defaults.
 - **Permissions are merged, not overridden.** Global `settings.permissions` and an agent's own `permissions:` are combined into a single set of `deny` → `allow` → `ask` patterns before evaluation — a global deny always blocks, regardless of what the agent config allows. See [Merging Behavior](../permissions/index.md#merging-behavior).
 - **Hooks are additive, not overridden.** For a given lifecycle event, hooks from the agent config, `settings.hooks`, `hooks.d/` drop-ins, and `--hook-*` CLI flags **all** run, in that order. Global hooks cannot be suppressed by an individual agent.
-- **Everything else is a plain default.** Fields with no CLI or agent-config equivalent (`sound`, `sound_threshold`, `restore_tabs`, `tab_title_max_length`, `split_diff_view`, `render_images`, `cache_stable_prompts`, `warn_on_cache_miss`, `busy_send_mode`, `keybindings`, `layout`) only ever come from `settings:` (or the `/settings` dialog that writes it) — there is nothing to override them per run.
+- **Everything else is a plain default.** Fields with no CLI or agent-config equivalent (`sound`, `sound_threshold`, `restore_tabs`, `tab_title_max_length`, `split_diff_view`, `render_images`, `show_banner`, `cache_stable_prompts`, `warn_on_cache_miss`, `busy_send_mode`, `keybindings`, `layout`) only ever come from `settings:` (or the `/settings` dialog that writes it) — there is nothing to override them per run.

--- a/docs/features/tui/index.md
+++ b/docs/features/tui/index.md
@@ -448,7 +448,7 @@ The **Appearance** tab selects the theme and customizes the layout. Layout chang
 - **Section spacing**: `Compact`, `Normal` (default), or `Relaxed`, the number of blank lines between the sidebar sections (1, 2, or 3).
 - **Sidebar sections**: toggle the visibility of the **Session path** (the working directory line, including its git branch) and the **Token usage**, **Agents**, **Tools**, and **Todos** sections. The session title is always shown.
 
-Appearance also controls split-diff rendering, expanded thinking, and whether tool results are hidden by default. Select **Theme** to open the theme picker.
+Appearance also controls split-diff rendering, expanded thinking, whether tool results are hidden by default, and **Show startup banner** — the ASCII-art banner drawn on an empty conversation (persisted as `settings.show_banner: false` when turned off, and honored by the lean TUI too). Select **Theme** to open the theme picker.
 
 The **Behavior** tab controls busy-message handling, the auto-approve default, tab restoration, automatic snapshots, lean UI, and the maximum tab-title length. Restore-tabs and lean-UI changes take effect on the next launch. Enabling auto-approve requires confirmation.
 

--- a/pkg/leantui/banner_test.go
+++ b/pkg/leantui/banner_test.go
@@ -33,6 +33,22 @@ func TestCommitWelcomePadsBanner(t *testing.T) {
 	assert.True(t, strings.HasPrefix(helpLine, leftPad))
 }
 
+func TestCommitWelcomeSkipsHiddenBanner(t *testing.T) {
+	t.Parallel()
+	m := &model{screen: ui.NewScreen("", "", ""), hideBanner: true}
+	m.commitWelcome()
+
+	require.Equal(t, 1, m.screen.Transcript.BlockCount())
+	lines := m.screen.Transcript.BlockLines(0, 80)
+	for _, line := range lines {
+		assert.NotContains(t, ansi.Strip(line), bannerLines[0])
+	}
+
+	helpLine := ansi.Strip(lines[len(lines)-1])
+	assert.True(t, strings.HasPrefix(helpLine, strings.Repeat(" ", bannerLeftPadding)),
+		"the help hint survives a hidden banner")
+}
+
 func TestCommitWelcomeUsesConfiguredBanner(t *testing.T) {
 	t.Parallel()
 	custom := []string{"custom banner line one", "custom banner line two"}

--- a/pkg/leantui/leantui.go
+++ b/pkg/leantui/leantui.go
@@ -28,6 +28,9 @@ type Config struct {
 	AppName          string
 	DisabledCommands []string
 	RenderImages     *bool
+	// ShowBanner displays the ASCII-art welcome banner. Defaults to true
+	// when nil.
+	ShowBanner *bool
 
 	// Banner overrides the ASCII-art welcome banner. When nil the built-in
 	// bannerLines ("docker agent") is used; embedders set it to brand the lean
@@ -168,6 +171,8 @@ type model struct {
 	banner           []string
 	disabledCommands map[string]bool
 	renderImages     bool
+	// hideBanner drops the ASCII-art welcome banner; the zero value keeps it.
+	hideBanner bool
 }
 
 func newModel(term *ui.Terminal, cfg Config) *model {
@@ -202,6 +207,7 @@ func newModel(term *ui.Terminal, cfg Config) *model {
 		banner:           cfg.Banner,
 		disabledCommands: disabled,
 		renderImages:     renderImages,
+		hideBanner:       cfg.ShowBanner != nil && !*cfg.ShowBanner,
 	}
 }
 
@@ -223,6 +229,9 @@ func (m *model) commitWelcome() {
 	banner := m.banner
 	if len(banner) == 0 {
 		banner = bannerLines
+	}
+	if m.hideBanner {
+		banner = nil
 	}
 	m.screen.Transcript.AddBlock(func(int) []string {
 		lines := make([]string, 0, bannerTopPadding+len(banner)+2)

--- a/pkg/tui/banner_setting_test.go
+++ b/pkg/tui/banner_setting_test.go
@@ -1,0 +1,96 @@
+package tui
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/charmbracelet/x/ansi"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/docker/docker-agent/pkg/app"
+	"github.com/docker/docker-agent/pkg/paths"
+	"github.com/docker/docker-agent/pkg/session"
+	"github.com/docker/docker-agent/pkg/tui/animation"
+	tuibanner "github.com/docker/docker-agent/pkg/tui/banner"
+	"github.com/docker/docker-agent/pkg/tui/commands"
+	"github.com/docker/docker-agent/pkg/tui/messages"
+	"github.com/docker/docker-agent/pkg/tui/page/chat"
+	"github.com/docker/docker-agent/pkg/tui/service"
+	"github.com/docker/docker-agent/pkg/userconfig"
+)
+
+// bannerVisible builds a chat page the way initSessionComponents does and
+// reports whether the startup banner is drawn on the empty conversation.
+func bannerVisible(t *testing.T, m *appModel) bool {
+	t.Helper()
+	sess := session.New()
+	page := chat.New(animation.NewRuntime(), t.Context(),
+		app.New(t.Context(), stubRuntime{}, sess), service.NewSessionState(sess), m.chatPageOpts()...)
+	page.SetSize(160, 40)
+	return strings.Contains(ansi.Strip(page.View()), tuibanner.Lines[0])
+}
+
+// TestChatPageOpts_PassesShowBanner covers pages built after startup (new
+// tab, /clear, /fork, …): they must inherit the retained banner preference.
+func TestChatPageOpts_PassesShowBanner(t *testing.T) {
+	t.Parallel()
+
+	m, _ := newTestModel(t)
+	m.buildCommandCategories = func(context.Context, tea.Model) []commands.Category { return nil }
+
+	m.showBanner = true
+	assert.True(t, bannerVisible(t, m))
+
+	m.showBanner = false
+	assert.False(t, bannerVisible(t, m), "a disabled banner must not be drawn")
+}
+
+// TestHandleApplySettings_AppliesShowBanner proves toggling the banner in
+// /settings reaches the appModel, every existing page, and the user config.
+func TestHandleApplySettings_AppliesShowBanner(t *testing.T) {
+	setupSettingsConfigTest(t)
+
+	m := newApplySettingsModel(t)
+	second := &mockChatPage{showBanner: true}
+	m.chatPages["second"] = second
+
+	prefs := defaultTestPreferences()
+	prefs.ShowBanner = false
+	_, _ = m.handleApplySettings(messages.ApplySettingsMsg{Preferences: prefs})
+
+	assert.False(t, m.showBanner, "the preference is retained for future pages")
+	assert.False(t, m.chatPage.(*mockChatPage).showBanner, "the active page hides the banner")
+	assert.False(t, second.showBanner, "background pages hide the banner")
+	assert.False(t, userconfig.Get().GetShowBanner(), "the preference is persisted")
+}
+
+// TestNew_AppliesPersistedShowBannerAtStartup covers the startup path: a
+// persisted show_banner: false must reach the appModel and the initial page.
+// Not parallel: the config/data dir overrides are process-global.
+func TestNew_AppliesPersistedShowBannerAtStartup(t *testing.T) {
+	dir := t.TempDir()
+	paths.SetDataDir(filepath.Join(dir, "data"))
+	paths.SetConfigDir(filepath.Join(dir, "config"))
+	t.Cleanup(func() {
+		paths.SetDataDir("")
+		paths.SetConfigDir("")
+	})
+	showBanner := false
+	require.NoError(t, userconfig.Update(func(cfg *userconfig.Config) error {
+		cfg.Settings = &userconfig.Settings{ShowBanner: &showBanner}
+		return nil
+	}))
+
+	sess := session.New()
+	m := New(t.Context(), nil, app.New(t.Context(), stubRuntime{}, sess), dir, func() {}).(*appModel)
+	t.Cleanup(m.cleanupManagedResources)
+
+	assert.False(t, m.showBanner)
+	m.chatPage.SetSize(160, 40)
+	assert.NotContains(t, ansi.Strip(m.chatPage.View()), tuibanner.Lines[0],
+		"the initial page must honor the persisted setting")
+}

--- a/pkg/tui/dialog/settings.go
+++ b/pkg/tui/dialog/settings.go
@@ -46,6 +46,7 @@ const (
 	rowExpandThinking
 	rowHideToolResults
 	rowRenderImages
+	rowShowBanner
 	appearanceRowCount
 )
 
@@ -269,6 +270,8 @@ func (d *settingsDialog) changeValue(delta int) tea.Cmd {
 			d.current.HideToolResults = !d.current.HideToolResults
 		case rowRenderImages:
 			d.current.RenderImages = !d.current.RenderImages
+		case rowShowBanner:
+			d.current.ShowBanner = !d.current.ShowBanner
 		}
 		if d.selected[d.tab] >= rowPosition && d.selected[d.tab] <= rowTodos {
 			return core.CmdHandler(messages.PreviewLayoutMsg{Layout: d.current.Layout})
@@ -403,7 +406,8 @@ func (d *settingsDialog) renderAppearanceTab(content *Content, inner int) {
 		AddContent(d.renderToggleRow(rowSplitDiff, "Split diff view", d.current.SplitDiffView)).
 		AddContent(d.renderToggleRow(rowExpandThinking, "Expand thinking by default", d.current.ExpandThinking)).
 		AddContent(d.renderToggleRow(rowHideToolResults, "Hide tool results by default", d.current.HideToolResults)).
-		AddContent(d.renderToggleRow(rowRenderImages, "Render images", d.current.RenderImages))
+		AddContent(d.renderToggleRow(rowRenderImages, "Render images", d.current.RenderImages)).
+		AddContent(d.renderToggleRow(rowShowBanner, "Show startup banner", d.current.ShowBanner))
 }
 
 func (d *settingsDialog) renderBehaviorTab(content *Content, inner int) {

--- a/pkg/tui/dialog/settings_test.go
+++ b/pkg/tui/dialog/settings_test.go
@@ -13,7 +13,7 @@ import (
 
 func newTestSettingsDialog(t *testing.T, layout messages.LayoutSettings) *settingsDialog {
 	t.Helper()
-	d, ok := NewSettingsDialog(messages.Preferences{Layout: layout, SendMode: messages.SendModeSteer, SplitDiffView: true, RenderImages: true, TabTitleMaxLength: 20, SoundThreshold: 10}, true).(*settingsDialog)
+	d, ok := NewSettingsDialog(messages.Preferences{Layout: layout, SendMode: messages.SendModeSteer, SplitDiffView: true, RenderImages: true, ShowBanner: true, TabTitleMaxLength: 20, SoundThreshold: 10}, true).(*settingsDialog)
 	require.True(t, ok)
 	d.Init()
 	d.Update(tea.WindowSizeMsg{Width: 100, Height: 50})
@@ -62,10 +62,10 @@ func TestSettingsDialogNavigation(t *testing.T) {
 	for range 20 {
 		d.Update(down)
 	}
-	require.Equal(t, rowRenderImages, d.selected[tabAppearance], "down must stop at the last row")
+	require.Equal(t, rowShowBanner, d.selected[tabAppearance], "down must stop at the last row")
 
 	d.Update(up)
-	require.Equal(t, rowHideToolResults, d.selected[tabAppearance])
+	require.Equal(t, rowRenderImages, d.selected[tabAppearance])
 }
 
 func TestSettingsDialogTabSwitching(t *testing.T) {
@@ -316,6 +316,23 @@ func TestSettingsDialogTogglesCacheStablePrompts(t *testing.T) {
 	assert.Nil(t, cmd)
 	assert.True(t, d.current.CacheStablePrompts)
 	assert.Contains(t, ansi.Strip(d.View()), "Cache-stable dynamic prompts")
+}
+
+func TestSettingsDialogTogglesShowBanner(t *testing.T) {
+	t.Parallel()
+
+	d := newTestSettingsDialog(t, messages.LayoutSettings{})
+	d.selected[tabAppearance] = rowShowBanner
+	d.Update(tea.KeyPressMsg{Code: tea.KeySpace})
+	require.False(t, d.current.ShowBanner)
+	assert.Contains(t, ansi.Strip(d.View()), "Show startup banner")
+
+	_, cmd := d.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	msgs := collectMsgs(cmd)
+	require.Len(t, msgs, 2, "apply must close the dialog and emit the settings")
+	applied, ok := msgs[1].(messages.ApplySettingsMsg)
+	require.True(t, ok)
+	assert.False(t, applied.Preferences.ShowBanner)
 }
 
 func TestSettingsDialogApplyEmitsApplySettings(t *testing.T) {

--- a/pkg/tui/handlers.go
+++ b/pkg/tui/handlers.go
@@ -898,6 +898,7 @@ func (m *appModel) handleOpenSettingsDialog() (tea.Model, tea.Cmd) {
 		ExpandThinking:        settings.GetExpandThinking(),
 		HideToolResults:       settings.HideToolResults,
 		RenderImages:          settings.GetRenderImages(),
+		ShowBanner:            settings.GetShowBanner(),
 		YOLO:                  settings.YOLO,
 		RestoreTabs:           settings.GetRestoreTabs(),
 		Snapshot:              settings.SnapshotsEnabled(),
@@ -922,9 +923,11 @@ func (m *appModel) handleApplySettings(msg messages.ApplySettingsMsg) (tea.Model
 
 	m.sendMode = messages.ParseSendMode(string(preferences.SendMode))
 	m.interruptMode = messages.ParseInterruptMode(string(preferences.InterruptConfirmation))
+	m.showBanner = preferences.ShowBanner
 	for _, page := range m.chatPages {
 		page.SetSendMode(m.sendMode)
 		page.SetInterruptMode(m.interruptMode)
+		page.SetShowBanner(m.showBanner)
 	}
 	if m.sessionState.SplitDiffView() != preferences.SplitDiffView {
 		m.sessionState.SetSplitDiffView(preferences.SplitDiffView)
@@ -1001,6 +1004,7 @@ func savePreferences(p messages.Preferences) error {
 		s.WarnOnCacheMiss = boolPreference(p.WarnOnCacheMiss, false)
 		s.HideToolResults = p.HideToolResults
 		s.RenderImages = boolPreference(p.RenderImages, true)
+		s.ShowBanner = boolPreference(p.ShowBanner, true)
 		s.YOLO = p.YOLO
 		s.Lean = p.Lean
 		s.Sound = p.Sound
@@ -1060,7 +1064,8 @@ func saveSettingsToUserConfig(layout messages.LayoutSettings, mode messages.Send
 	return savePreferences(messages.Preferences{
 		Layout: layout, SendMode: mode, SplitDiffView: settings.GetSplitDiffView(),
 		ExpandThinking: settings.GetExpandThinking(), HideToolResults: settings.HideToolResults,
-		RenderImages: settings.GetRenderImages(), YOLO: settings.YOLO, RestoreTabs: settings.GetRestoreTabs(), Snapshot: settings.SnapshotsEnabled(),
+		RenderImages: settings.GetRenderImages(), ShowBanner: settings.GetShowBanner(),
+		YOLO: settings.YOLO, RestoreTabs: settings.GetRestoreTabs(), Snapshot: settings.SnapshotsEnabled(),
 		CacheStablePrompts: settings.CacheStablePromptsEnabled(),
 		WarnOnCacheMiss:    settings.CacheMissWarningsEnabled(),
 		Lean:               settings.Lean, TabTitleMaxLength: settings.GetTabTitleMaxLength(),

--- a/pkg/tui/interrupt_mode_test.go
+++ b/pkg/tui/interrupt_mode_test.go
@@ -87,6 +87,7 @@ func defaultTestPreferences() messages.Preferences {
 		SendMode:              messages.SendModeSteer,
 		SplitDiffView:         true,
 		RenderImages:          true,
+		ShowBanner:            true,
 		TabTitleMaxLength:     userconfig.DefaultTabTitleMaxLength,
 		SoundThreshold:        userconfig.DefaultSoundThreshold,
 		InterruptConfirmation: messages.InterruptModeAlways,

--- a/pkg/tui/messages/settings.go
+++ b/pkg/tui/messages/settings.go
@@ -161,6 +161,7 @@ type Preferences struct {
 	ExpandThinking        bool
 	HideToolResults       bool
 	RenderImages          bool
+	ShowBanner            bool
 	YOLO                  bool
 	RestoreTabs           bool
 	Snapshot              bool

--- a/pkg/tui/page/chat/chat.go
+++ b/pkg/tui/page/chat/chat.go
@@ -161,6 +161,9 @@ type Page interface {
 	SetSendMode(mode msgtypes.SendMode)
 	// SetInterruptMode sets how Esc interrupts a running stream.
 	SetInterruptMode(mode msgtypes.InterruptMode)
+	// SetShowBanner controls whether the ASCII-art startup banner is drawn
+	// on an empty conversation.
+	SetShowBanner(show bool)
 	// SetRoutingID records the tab identity used to address this page's
 	// one-shot UI timers back to it (messages.RoutedMsg.SessionID). The
 	// appModel keys its chat pages — and the supervisor its event routing —
@@ -232,6 +235,9 @@ type chatPage struct {
 	// Used by --exit-after-response to ensure we don't exit before receiving content
 	hasReceivedAssistantContent bool
 	showStartupBanner           bool
+	// hideBanner mirrors the user's show_banner setting; the zero value
+	// keeps the banner so page literals stay banner-enabled.
+	hideBanner bool
 
 	// Message queue for enqueuing messages while agent is working
 	messageQueue []queuedMessage
@@ -410,6 +416,14 @@ func WithHideSidebar() PageOption {
 	return func(p *chatPage) {
 		p.hideSidebar = true
 		p.keyMap.ToggleSidebar.SetEnabled(false)
+	}
+}
+
+// WithShowBanner controls whether the ASCII-art startup banner is drawn on
+// an empty conversation.
+func WithShowBanner(show bool) PageOption {
+	return func(p *chatPage) {
+		p.hideBanner = !show
 	}
 }
 
@@ -728,7 +742,7 @@ func (p *chatPage) renderCollapsedSidebar(sl sidebarLayout) string {
 
 func (p *chatPage) messagesView(sl sidebarLayout) string {
 	messagesView := p.messages.View()
-	if messagesView != "" || !p.showStartupBanner {
+	if messagesView != "" || !p.showStartupBanner || p.hideBanner {
 		return messagesView
 	}
 	if sl.chatWidth < tuibanner.Width || sl.chatHeight < tuibanner.Height {
@@ -1402,6 +1416,10 @@ func (p *chatPage) SetSendMode(mode msgtypes.SendMode) {
 
 func (p *chatPage) SetInterruptMode(mode msgtypes.InterruptMode) {
 	p.interruptMode = mode
+}
+
+func (p *chatPage) SetShowBanner(show bool) {
+	p.hideBanner = !show
 }
 
 // SetRoutingID records the tab identity this page's routed UI timers are

--- a/pkg/tui/page/chat/layout_position_test.go
+++ b/pkg/tui/page/chat/layout_position_test.go
@@ -95,6 +95,20 @@ func TestStartupBannerHiddenWhenChatIsTooSmall(t *testing.T) {
 	}
 }
 
+func TestStartupBannerHiddenWhenDisabled(t *testing.T) {
+	t.Parallel()
+
+	p := newLayoutTestPage(t, msgtypes.SidebarRight)
+	p.showStartupBanner = true
+	p.SetShowBanner(false)
+	p.SetSize(p.width, p.height)
+
+	assert.Empty(t, p.messagesView(p.computeSidebarLayout()))
+
+	p.SetShowBanner(true)
+	assert.Contains(t, ansi.Strip(p.messagesView(p.computeSidebarLayout())), tuibanner.Lines[0])
+}
+
 func TestEmptyAgentInfoDoesNotReactivateStartupBanner(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/tui/settings_persistence_test.go
+++ b/pkg/tui/settings_persistence_test.go
@@ -127,6 +127,7 @@ func TestSavePreferences_RoundTripAndPreservesExtra(t *testing.T) {
 		SplitDiffView:      false,
 		ExpandThinking:     true,
 		HideToolResults:    true,
+		ShowBanner:         false,
 		YOLO:               true,
 		RestoreTabs:        true,
 		Snapshot:           true,
@@ -145,6 +146,7 @@ func TestSavePreferences_RoundTripAndPreservesExtra(t *testing.T) {
 	assert.Equal(t, preferences.SplitDiffView, settings.GetSplitDiffView())
 	assert.Equal(t, preferences.ExpandThinking, settings.GetExpandThinking())
 	assert.Equal(t, preferences.HideToolResults, settings.HideToolResults)
+	assert.Equal(t, preferences.ShowBanner, settings.GetShowBanner())
 	assert.Equal(t, preferences.YOLO, settings.YOLO)
 	assert.Equal(t, preferences.RestoreTabs, settings.GetRestoreTabs())
 	assert.Equal(t, preferences.Snapshot, settings.SnapshotsEnabled())
@@ -176,6 +178,7 @@ func TestSavePreferences_DefaultsClearEntries(t *testing.T) {
 		Layout:            messages.LayoutSettings{SidebarPosition: messages.SidebarRight, SectionSpacing: messages.SpacingNormal},
 		SendMode:          messages.SendModeSteer,
 		SplitDiffView:     true,
+		ShowBanner:        true,
 		TabTitleMaxLength: userconfig.DefaultTabTitleMaxLength,
 		SoundThreshold:    userconfig.DefaultSoundThreshold,
 	}))
@@ -187,6 +190,7 @@ func TestSavePreferences_DefaultsClearEntries(t *testing.T) {
 	assert.Nil(t, settings.Layout)
 	assert.Empty(t, settings.BusySendMode)
 	assert.Nil(t, settings.SplitDiffView)
+	assert.Nil(t, settings.ShowBanner)
 	assert.Nil(t, settings.ExpandThinking)
 	assert.Nil(t, settings.RestoreTabs)
 	assert.Nil(t, settings.Snapshot)

--- a/pkg/tui/tui.go
+++ b/pkg/tui/tui.go
@@ -301,6 +301,10 @@ type appModel struct {
 	// via /settings.
 	interruptMode messages.InterruptMode
 
+	// showBanner displays the ASCII-art startup banner on an empty
+	// conversation. Shared by every tab and managed via /settings.
+	showBanner bool
+
 	// buildCommandCategories is a function that returns the list of command categories.
 	buildCommandCategories func(context.Context, tea.Model) []commands.Category
 
@@ -535,6 +539,7 @@ func New(ctx context.Context, spawner SessionSpawner, initialApp *app.App, initi
 		layoutSettings:                layoutSettingsFromConfig(userSettings.GetLayout()),
 		sendMode:                      messages.ParseSendMode(userSettings.GetBusySendMode()),
 		interruptMode:                 messages.ParseInterruptMode(userSettings.GetInterruptConfirmation()),
+		showBanner:                    userSettings.GetShowBanner(),
 		keyboardEnhancementsSupported: termfeatures.SupportsModifiedEnter(os.Getenv),
 		dockerDesktop:                 os.Getenv("TERM_PROGRAM") == "docker_desktop",
 		appName:                       "docker agent",
@@ -665,6 +670,7 @@ func (m *appModel) chatPageOpts() []chat.PageOption {
 		chat.WithLayoutSettings(m.layoutSettings),
 		chat.WithSendMode(m.sendMode),
 		chat.WithInterruptMode(m.interruptMode),
+		chat.WithShowBanner(m.showBanner),
 	}
 
 	if m.leanMode {

--- a/pkg/tui/tui_exit_test.go
+++ b/pkg/tui/tui_exit_test.go
@@ -36,6 +36,9 @@ type mockChatPage struct {
 
 	// interruptMode records the last SetInterruptMode value.
 	interruptMode messages.InterruptMode
+
+	// showBanner records the last SetShowBanner value.
+	showBanner bool
 }
 
 func (m *mockChatPage) Init() tea.Cmd                          { return nil }
@@ -64,6 +67,10 @@ func (m *mockChatPage) SetLayoutSettings(messages.LayoutSettings) tea.Cmd {
 func (m *mockChatPage) SetSendMode(messages.SendMode) {}
 func (m *mockChatPage) SetInterruptMode(mode messages.InterruptMode) {
 	m.interruptMode = mode
+}
+
+func (m *mockChatPage) SetShowBanner(show bool) {
+	m.showBanner = show
 }
 func (m *mockChatPage) SetRoutingID(string)       {}
 func (m *mockChatPage) TakeRoutedTimers() tea.Cmd { return nil }

--- a/pkg/userconfig/userconfig.go
+++ b/pkg/userconfig/userconfig.go
@@ -74,6 +74,9 @@ type Settings struct {
 	// RenderImages displays images returned by tools in supported terminals.
 	// Defaults to true when not set.
 	RenderImages *bool `yaml:"render_images,omitempty"`
+	// ShowBanner displays the ASCII-art startup banner in the TUI.
+	// Defaults to true when not set.
+	ShowBanner *bool `yaml:"show_banner,omitempty"`
 	// Theme is the default theme reference (e.g., "dark", "light")
 	// Theme files are loaded from ~/.cagent/themes/<theme>.yaml
 	// The special value "auto" follows the terminal's light/dark background,
@@ -250,6 +253,14 @@ func (s *Settings) GetRenderImages() bool {
 		return true
 	}
 	return *s.RenderImages
+}
+
+// GetShowBanner returns whether the startup banner is displayed, defaulting to true.
+func (s *Settings) GetShowBanner() bool {
+	if s == nil || s.ShowBanner == nil {
+		return true
+	}
+	return *s.ShowBanner
 }
 
 // GetRestoreTabs returns whether previously open tabs are restored on

--- a/pkg/userconfig/userconfig_test.go
+++ b/pkg/userconfig/userconfig_test.go
@@ -654,6 +654,7 @@ func TestConfig_Settings_Empty(t *testing.T) {
 	assert.False(t, settings.Lean)
 	assert.False(t, settings.GetExpandThinking())
 	assert.True(t, settings.GetRenderImages())
+	assert.True(t, settings.GetShowBanner())
 }
 
 func TestConfig_Settings_RenderImages(t *testing.T) {
@@ -667,6 +668,20 @@ func TestConfig_Settings_RenderImages(t *testing.T) {
 	loaded, err := loadFrom(configFile, "")
 	require.NoError(t, err)
 	assert.False(t, loaded.Settings.GetRenderImages())
+}
+
+func TestConfig_Settings_ShowBanner(t *testing.T) {
+	t.Parallel()
+
+	configFile := filepath.Join(t.TempDir(), "config.yaml")
+	showBanner := false
+	config := &Config{Settings: &Settings{ShowBanner: &showBanner}}
+	require.NoError(t, config.saveTo(configFile))
+
+	loaded, err := loadFrom(configFile, "")
+	require.NoError(t, err)
+	assert.False(t, loaded.Settings.GetShowBanner())
+	assert.True(t, (*Settings)(nil).GetShowBanner(), "banner is shown by default")
 }
 
 func TestConfig_Settings_ExpandThinking(t *testing.T) {


### PR DESCRIPTION
## What

Adds a user setting to show/hide the ASCII-art startup banner, exposed as **Show startup banner** on the **Appearance** tab of `/settings` and persisted as `settings.show_banner` in `~/.config/cagent/config.yaml`.

![Settings dialog — Appearance tab with the new "Show startup banner" toggle](https://raw.githubusercontent.com/rumpl/cagent/pr-assets/settings-show-banner.png)

## Why

The banner is the first thing an empty conversation shows. It's nice on a fresh start and pure noise for people who live in the TUI all day — until now there was no way to turn it off.

## How

- `userconfig.Settings.ShowBanner *bool` + `GetShowBanner()`, defaulting to `true` (unset means shown, and the default is never written to the config file).
- `/settings` → Appearance gains a toggle row; the value round-trips through `messages.Preferences` like the other dialog-managed settings.
- Applying the setting takes effect immediately on every open tab (`Page.SetShowBanner`) and is inherited by pages created later (new tab, `/clear`, `/fork`, session load) via `chat.WithShowBanner`.
- The lean TUI honors it too (`leantui.Config.ShowBanner`); the "Type a message…" hint line stays regardless.

## Testing

- New unit tests: config round trip + default, dialog toggle/navigation/apply, chat-page rendering with the banner disabled, live propagation to existing and future pages, startup path from a persisted `show_banner: false`, and the lean TUI welcome block.
- `go build ./...`, `go test ./pkg/tui/... ./pkg/userconfig/... ./pkg/leantui/... ./cmd/...`, `go run ./lint .`, `go vet`, `gofmt` all clean.

## Docs

- `docs/configuration/user-settings/index.md`: `show_banner` row in the settings reference, complete example, and precedence list.
- `docs/features/tui/index.md`: mention in the `/settings` Appearance section.
