### PR TITLE
feat(#3996): resolve image output capability from models.dev

### DIFF
--- a/agent-schema.json
+++ b/agent-schema.json
@@ -1758,6 +1758,10 @@
           "$ref": "#/definitions/CapabilitiesConfig",
           "description": "Explicit attachment capability override for models the models.dev catalogue does not describe correctly (custom OpenAI-compatible providers, local models like Ollama, or dropped model versions). When set, the declared flags are authoritative and no models.dev lookup is performed; when omitted, capabilities are detected automatically. Without it, such models fall back to text-only and their image/PDF/audio/video attachments are silently dropped."
         },
+        "output_capabilities": {
+          "$ref": "#/definitions/OutputCapabilitiesConfig",
+          "description": "Explicit, owner-declared generative output capabilities for this model. Never inferred from the model name or any catalogue — omit it, or leave a flag unset/false, to preserve existing behavior. Consumed by capability-gated request contracts (e.g. the Gemini gateway image-output route) that must not activate for a model unless its owner has affirmatively opted it in. Cannot be combined with first_available (set output_capabilities.image on the candidate models instead)."
+        },
         "cost": {
           "$ref": "#/definitions/CostConfig",
           "description": "Explicit token pricing (USD per 1M tokens), overriding the models.dev catalogue. Used for per-turn cost computation, session cost tracking, the /model picker, and the after_llm_call hook's cost field. Makes an uncatalogued model (custom base_url provider, local or private deployment) 'priced' instead of billing $0. Prices must not be negative; an all-zero table means 'priced, free'. Cannot be combined with first_available."
@@ -1784,6 +1788,17 @@
         "video": {
           "type": "boolean",
           "description": "Whether the model accepts video attachments"
+        }
+      },
+      "additionalProperties": false
+    },
+    "OutputCapabilitiesConfig": {
+      "type": "object",
+      "description": "Explicit, owner-declared generative output capabilities for a model. There is no automatic detection — no catalogue of output-capable models exists, and matching on the model name string is deliberately avoided as unreliable — so this is nil/omitted by default. Omitted or false preserves existing behavior; only an explicit true opts a model into output-capability-gated behavior.",
+      "properties": {
+        "image": {
+          "type": "boolean",
+          "description": "Whether the model is declared able to generate image output. Never inferred; must be set explicitly by the owner."
         }
       },
       "additionalProperties": false

--- a/agent-schema.json
+++ b/agent-schema.json
@@ -1760,7 +1760,7 @@
         },
         "output_capabilities": {
           "$ref": "#/definitions/OutputCapabilitiesConfig",
-          "description": "Explicit, owner-declared generative output capabilities for this model. Never inferred from the model name or any catalogue — omit it, or leave a flag unset/false, to preserve existing behavior. Consumed by capability-gated request contracts (e.g. the Gemini gateway image-output route) that must not activate for a model unless its owner has affirmatively opted it in. Cannot be combined with first_available (set output_capabilities.image on the candidate models instead)."
+          "description": "Optional generative output capability override for this model. Resolution precedence is explicit false, explicit true, then the exact models.dev record's Modalities.Output=image for an omitted image flag (including an empty block). Unknown or unavailable catalogue metadata stays disabled; model names are never used to infer capability. Cannot be combined with first_available (set output_capabilities.image on the candidate models instead)."
         },
         "cost": {
           "$ref": "#/definitions/CostConfig",
@@ -1794,11 +1794,11 @@
     },
     "OutputCapabilitiesConfig": {
       "type": "object",
-      "description": "Explicit, owner-declared generative output capabilities for a model. There is no automatic detection — no catalogue of output-capable models exists, and matching on the model name string is deliberately avoided as unreliable — so this is nil/omitted by default. Omitted or false preserves existing behavior; only an explicit true opts a model into output-capability-gated behavior.",
+      "description": "Generative output capability overrides for a model. Resolution precedence is explicit false, explicit true, then the exact models.dev record's Modalities.Output=image when the image flag is omitted, including an empty block. Unknown or unavailable catalogue metadata stays disabled; model names are never used to infer capability.",
       "properties": {
         "image": {
           "type": "boolean",
-          "description": "Whether the model is declared able to generate image output. Never inferred; must be set explicitly by the owner."
+          "description": "Whether the model can generate image output. Explicit false takes precedence over explicit true; when omitted, Docker Agent uses the exact models.dev record's output modalities and otherwise leaves image output disabled."
         }
       },
       "additionalProperties": false

--- a/docs/configuration/models/index.md
+++ b/docs/configuration/models/index.md
@@ -35,11 +35,13 @@ models:
     parallel_tool_calls: boolean # Optional: allow parallel tool calls
     track_usage: boolean # Optional: track token usage
     routing: [list] # Optional: rule-based model routing
-    capabilities: # Optional: override attachment capabilities
+    capabilities: # Optional: override attachment (input) capabilities
       image: boolean # Optional: whether the model accepts image attachments
       pdf: boolean # Optional: whether the model accepts PDF attachments
       audio: boolean # Optional: whether the model accepts audio attachments
       video: boolean # Optional: whether the model accepts video attachments
+    output_capabilities: # Optional: owner-declared generative output capabilities (never inferred)
+      image: boolean # Optional: whether the model is declared able to generate image output
     cost: # Optional: explicit token pricing (USD per 1M tokens)
       input: float # Optional: price per 1M input tokens
       output: float # Optional: price per 1M output tokens
@@ -73,7 +75,8 @@ models:
 | `parallel_tool_calls` | boolean    | ✗        | Allow model to call multiple tools at once                                            |
 | `track_usage`         | boolean    | ✗        | Track and report token usage for this model                                           |
 | `routing`             | array      | ✗        | Rule-based routing to different models. See [Model Routing](../routing/index.md). |
-| `capabilities`        | object     | ✗        | Override attachment capabilities for this model. See [Attachment Capability Overrides](#attachment-capability-overrides). |
+| `capabilities`        | object     | ✗        | Override attachment (input) capabilities for this model. See [Attachment Capability Overrides](#attachment-capability-overrides). |
+| `output_capabilities` | object     | ✗        | Owner-declared generative output capabilities for this model, e.g. image generation. Never inferred. Cannot be combined with `first_available`. See [Output Capabilities](#output-capabilities). |
 | `cost`                | object     | ✗        | Explicit token pricing in USD per 1M tokens, overriding the built-in catalogue. See [Custom Token Pricing](#custom-token-pricing). |
 | `provider_opts`       | object     | ✗        | Provider-specific options (see provider pages)                                        |
 | `title_model`         | string     | ✗        | Model used for session-title generation. Can be a named model from the `models:` section or an inline `provider/model` string. When omitted, the agent's primary model generates titles. Cannot be combined with `first_available`. |
@@ -147,6 +150,41 @@ the conservative text-only default and have their media parts stripped.
 See [`examples/capability-overrides.yaml`](https://github.com/docker/docker-agent/blob/main/examples/capability-overrides.yaml) for a complete example, and
 [`examples/strip-unsupported-media.yaml`](https://github.com/docker/docker-agent/blob/main/examples/strip-unsupported-media.yaml) for a fixture demonstrating the
 stripping behaviour with and without an override.
+
+## Output Capabilities
+
+`output_capabilities` declares what a model can generate, as opposed to
+`capabilities`, which declares what it accepts as input. There is no
+automatic detection for output capabilities: no catalogue of
+output-capable models exists, and matching on the model name string is
+deliberately avoided as unreliable. A model's output capabilities are
+therefore always unknown/off unless the owner declares them.
+
+```yaml
+models:
+  gemini-image:
+    provider: google
+    model: gemini-2.5-flash-image
+    output_capabilities:
+      image: true # this model is declared able to generate image output
+```
+
+| Field                       | Type    | Description                                                  |
+| --------------------------- | ------- | -------------------------------------------------------------|
+| `output_capabilities.image` | boolean | Whether the model is declared able to generate image output  |
+
+Omitting `output_capabilities`, or leaving `image` unset or `false`, always
+preserves existing behavior. Setting it to `true` only opts the model into
+behavior that specifically keys off a declared image-output capability (for
+example, a provider-specific request-shape guard); it does not by itself
+change what Docker Agent sends to or renders from the model.
+
+> [!WARNING]
+> **Constraint**
+>
+> `output_capabilities` cannot be combined with `first_available` model selection — the combination is rejected at validation time. Declare it on the concrete candidate models instead.
+
+See [`examples/gemini_image_output.yaml`](https://github.com/docker/docker-agent/blob/main/examples/gemini_image_output.yaml) for a complete example.
 
 ## Custom Token Pricing
 

--- a/examples/gemini_image_output.yaml
+++ b/examples/gemini_image_output.yaml
@@ -1,0 +1,30 @@
+# Gemini image-output model: the model can generate an image directly as
+# part of its reply, instead of only describing one.
+#
+# The `gemini-image` model below declares `output_capabilities.image: true` —
+# an explicit, owner-provided statement that this model can generate image
+# output. It is never inferred from the model name or any catalogue; omit
+# it, or leave it false, and behavior is unchanged.
+#
+# Native generated images aren't currently presented inline in the
+# terminal UI, so the model's text reply is what you'll see today.
+#
+# Try it out:
+#   docker agent run examples/gemini_image_output.yaml \
+#     "Generate an image of a red panda working at a terminal"
+#   docker agent run examples/gemini_image_output.yaml \
+#     "Generate an image of a lighthouse at sunset, and describe the color palette you used"
+models:
+  gemini-image:
+    provider: google
+    model: gemini-2.5-flash-image
+    output_capabilities:
+      image: true
+
+agents:
+  root:
+    model: gemini-image
+    description: Minimal agent for exercising Gemini native image-output generation.
+    instruction: |
+      When asked to draw or generate an image, do so directly using your
+      native image-generation capability. Briefly describe what you made.

--- a/pkg/config/first_available_test.go
+++ b/pkg/config/first_available_test.go
@@ -108,6 +108,42 @@ func TestResolveFirstAvailableModels_NamedCandidate(t *testing.T) {
 	assert.Equal(t, "claude-sonnet-4-6", got.Model)
 }
 
+// TestResolveFirstAvailableModels_PreservesConcreteCandidateOutputCapabilities is
+// the regression for a selected candidate's owner-declared
+// output_capabilities.image: resolveCandidate returns a named model's
+// ModelConfig as-is (see resolveCandidate in first_available.go), but a
+// future change to that path (e.g. rebuilding the struct field-by-field, or
+// routing through ParseModelRef) could silently drop it. A selector itself
+// can never carry output_capabilities (see TestValidateFirstAvailable's
+// "combined with output_capabilities" cases) — only a concrete candidate can
+// — so this is the only place that guarantee can be pinned end to end.
+func TestResolveFirstAvailableModels_PreservesConcreteCandidateOutputCapabilities(t *testing.T) {
+	t.Parallel()
+
+	cfg := &latest.Config{
+		Models: map[string]latest.ModelConfig{
+			"gemini_image": {
+				Provider:           "google",
+				Model:              "gemini-2.5-flash-image",
+				OutputCapabilities: &latest.OutputCapabilitiesConfig{Image: new(true)},
+			},
+			"smart": {FirstAvailable: []string{"gemini_image", "dmr/ai/qwen3"}},
+		},
+	}
+
+	env := environment.NewMapEnvProvider(map[string]string{"GEMINI_API_KEY": "test-key"})
+
+	require.NoError(t, ResolveFirstAvailableModels(t.Context(), cfg, "", env))
+
+	got := cfg.Models["smart"]
+	assert.Equal(t, "google", got.Provider)
+	assert.Equal(t, "gemini-2.5-flash-image", got.Model)
+	require.NotNil(t, got.OutputCapabilities,
+		"the selected concrete candidate's output_capabilities block must survive selection/resolution")
+	require.NotNil(t, got.OutputCapabilities.Image)
+	assert.True(t, *got.OutputCapabilities.Image)
+}
+
 func TestResolveFirstAvailableModels_SkipsRoutingCandidateWithMissingCredentials(t *testing.T) {
 	t.Parallel()
 
@@ -372,6 +408,16 @@ func TestValidateFirstAvailable(t *testing.T) {
 			name:    "combined with auth",
 			model:   latest.ModelConfig{FirstAvailable: []string{"anthropic/claude-sonnet-4-6"}, Auth: &latest.AuthConfig{Type: "anthropic_wif"}},
 			wantErr: "cannot be combined with auth",
+		},
+		{
+			name:    "combined with output_capabilities",
+			model:   latest.ModelConfig{FirstAvailable: []string{"google/gemini-2.5-flash-image"}, OutputCapabilities: &latest.OutputCapabilitiesConfig{Image: new(true)}},
+			wantErr: "cannot be combined with output_capabilities",
+		},
+		{
+			name:    "combined with output_capabilities false",
+			model:   latest.ModelConfig{FirstAvailable: []string{"google/gemini-2.5-flash-image"}, OutputCapabilities: &latest.OutputCapabilitiesConfig{Image: new(false)}},
+			wantErr: "cannot be combined with output_capabilities",
 		},
 		{
 			name:    "empty candidate",

--- a/pkg/config/latest/output_capabilities_test.go
+++ b/pkg/config/latest/output_capabilities_test.go
@@ -1,0 +1,134 @@
+package latest
+
+import (
+	"testing"
+
+	"github.com/goccy/go-yaml"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestModelConfigOutputCapabilitiesYAMLRoundTrip pins that an explicit
+// output_capabilities.image declaration survives parse and re-marshal, and
+// defeats the provider/model shorthand collapse the same way capabilities does.
+func TestModelConfigOutputCapabilitiesYAMLRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	const in = `provider: google
+model: gemini-2.5-flash-image
+output_capabilities:
+  image: true
+`
+	var f FlexibleModelConfig
+	require.NoError(t, yaml.Unmarshal([]byte(in), &f))
+
+	require.NotNil(t, f.OutputCapabilities, "output_capabilities should be parsed")
+	require.NotNil(t, f.OutputCapabilities.Image)
+	assert.True(t, *f.OutputCapabilities.Image)
+
+	assert.False(t, f.isShorthandOnly(), "output_capabilities override must defeat shorthand marshalling")
+
+	out, err := yaml.Marshal(f)
+	require.NoError(t, err)
+
+	var rt FlexibleModelConfig
+	require.NoError(t, yaml.Unmarshal(out, &rt))
+	require.NotNil(t, rt.OutputCapabilities, "output_capabilities should survive a marshal round-trip; got:\n%s", out)
+	require.NotNil(t, rt.OutputCapabilities.Image)
+	assert.True(t, *rt.OutputCapabilities.Image)
+}
+
+// TestModelConfigOutputCapabilitiesFalseYAMLRoundTrip pins that an explicit
+// `image: false` is distinguishable from a block without `image` and has
+// highest precedence over explicit true or the models.dev catalogue.
+func TestModelConfigOutputCapabilitiesFalseYAMLRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	const in = `provider: google
+model: gemini-2.5-flash
+output_capabilities:
+  image: false
+`
+	var f FlexibleModelConfig
+	require.NoError(t, yaml.Unmarshal([]byte(in), &f))
+
+	require.NotNil(t, f.OutputCapabilities, "an explicit false block should still be parsed as present")
+	require.NotNil(t, f.OutputCapabilities.Image)
+	assert.False(t, *f.OutputCapabilities.Image)
+}
+
+// TestModelConfigShorthandOnlyWithoutOutputCapabilities pins that a bare
+// provider/model with no output_capabilities block still collapses to the
+// shorthand form on marshal.
+func TestModelConfigShorthandOnlyWithoutOutputCapabilities(t *testing.T) {
+	t.Parallel()
+
+	const in = `provider: openai
+model: gpt-4o
+`
+	var f FlexibleModelConfig
+	require.NoError(t, yaml.Unmarshal([]byte(in), &f))
+
+	assert.Nil(t, f.OutputCapabilities)
+	assert.True(t, f.isShorthandOnly(), "a bare provider/model must still marshal as shorthand")
+}
+
+// TestModelConfigOutputCapabilitiesOmittedStaysNil pins that a missing block
+// stays nil. Both nil and an empty block leave the image flag unset for
+// models.dev resolution.
+func TestModelConfigOutputCapabilitiesOmittedStaysNil(t *testing.T) {
+	t.Parallel()
+
+	const in = `provider: google
+model: gemini-2.5-flash
+`
+	var f FlexibleModelConfig
+	require.NoError(t, yaml.Unmarshal([]byte(in), &f))
+
+	assert.Nil(t, f.OutputCapabilities)
+}
+
+func TestModelConfigOutputCapabilitiesEmptyBlockLeavesImageUnset(t *testing.T) {
+	t.Parallel()
+
+	const in = `provider: google
+model: gemini-2.5-flash-image
+output_capabilities: {}
+`
+	var f FlexibleModelConfig
+	require.NoError(t, yaml.Unmarshal([]byte(in), &f))
+
+	require.NotNil(t, f.OutputCapabilities)
+	assert.Nil(t, f.OutputCapabilities.Image)
+}
+
+func TestModelConfigCloneCopiesOutputCapabilities(t *testing.T) {
+	t.Parallel()
+
+	orig := &ModelConfig{
+		Provider:           "google",
+		Model:              "gemini-2.5-flash-image",
+		OutputCapabilities: &OutputCapabilitiesConfig{Image: new(true)},
+	}
+
+	clone := orig.Clone()
+	require.NotNil(t, clone.OutputCapabilities)
+	require.NotNil(t, clone.OutputCapabilities.Image)
+	assert.True(t, *clone.OutputCapabilities.Image)
+
+	// Mutating the clone must not affect the original (deep copy).
+	*clone.OutputCapabilities.Image = false
+	assert.True(t, *orig.OutputCapabilities.Image, "clone must not share the OutputCapabilities pointer with the original")
+}
+
+// TestModelConfigCloneNilOutputCapabilities pins that a model with no
+// declaration clones to nil, not a zero-value struct — the "unknown" state
+// must not be silently upgraded to an authoritative false on clone.
+func TestModelConfigCloneNilOutputCapabilities(t *testing.T) {
+	t.Parallel()
+
+	orig := &ModelConfig{Provider: "google", Model: "gemini-2.5-flash"}
+
+	clone := orig.Clone()
+	assert.Nil(t, clone.OutputCapabilities)
+}

--- a/pkg/config/latest/types.go
+++ b/pkg/config/latest/types.go
@@ -128,6 +128,16 @@ func (b *BudgetConfig) validate() error {
 	return nil
 }
 
+// Bool returns a pointer to value. It is primarily useful in configuration
+// literals where a nil pointer means no override.
+//
+// Deprecated: use new(value) in new code.
+//
+//nolint:modernize // Compatibility API for configuration literals.
+func Bool(value bool) *bool {
+	return &value
+}
+
 // SafetyMode is a declarative safety-mode default that agent authors
 // (runtime.safety, agents.<name>.safety) and users (settings.safety,
 // alias safety) can put in YAML. Only the four canonical session modes
@@ -1220,9 +1230,14 @@ type ModelConfig struct {
 	// of 0.9 applies. Useful next to CompactionModel: a model that compacts
 	// with a slower/smaller summarizer may want to trigger earlier.
 	CompactionThreshold *float64 `json:"compaction_threshold,omitempty"`
-	// Capabilities optionally declares the model's attachment capabilities,
-	// overriding the automatic models.dev-based detection. See [CapabilitiesConfig].
+	// Capabilities optionally declares the model's attachment (input)
+	// capabilities, overriding the automatic models.dev-based detection. See
+	// [CapabilitiesConfig].
 	Capabilities *CapabilitiesConfig `json:"capabilities,omitempty"`
+	// OutputCapabilities optionally overrides the model's generative *output*
+	// capabilities. An omitted flag is resolved from the models.dev catalogue;
+	// an explicit value takes precedence. See [OutputCapabilitiesConfig].
+	OutputCapabilities *OutputCapabilitiesConfig `json:"output_capabilities,omitempty"`
 	// Cost optionally declares the model's token pricing explicitly,
 	// overriding the models.dev catalogue. See [CostConfig].
 	Cost *CostConfig `json:"cost,omitempty"`
@@ -1288,6 +1303,15 @@ type CapabilitiesConfig struct {
 	Audio bool `json:"audio,omitempty"`
 	// Video reports whether the model accepts video attachments.
 	Video bool `json:"video,omitempty"`
+}
+
+// OutputCapabilitiesConfig overrides model generative *output* capabilities.
+// A nil flag defers to models.dev, while an explicit true or false is
+// authoritative. Custom models not found in the catalogue conservatively
+// resolve as unable to generate image output.
+type OutputCapabilitiesConfig struct {
+	// Image reports whether the model can generate image output.
+	Image *bool `json:"image,omitempty"`
 }
 
 // IsFirstAvailable reports whether this model is a first-available selector
@@ -1467,6 +1491,7 @@ func (f *FlexibleModelConfig) isShorthandOnly() bool {
 		f.CompactionModel == "" &&
 		f.CompactionThreshold == nil &&
 		f.Capabilities == nil &&
+		f.OutputCapabilities == nil &&
 		f.Cost == nil
 }
 

--- a/pkg/config/latest/types.go
+++ b/pkg/config/latest/types.go
@@ -1235,8 +1235,9 @@ type ModelConfig struct {
 	// [CapabilitiesConfig].
 	Capabilities *CapabilitiesConfig `json:"capabilities,omitempty"`
 	// OutputCapabilities optionally overrides the model's generative *output*
-	// capabilities. An omitted flag is resolved from the models.dev catalogue;
-	// an explicit value takes precedence. See [OutputCapabilitiesConfig].
+	// capabilities. Explicit false takes precedence over explicit true; an
+	// omitted Image flag (including an empty block) falls back to the exact
+	// models.dev record, and unknown or unavailable metadata stays disabled.
 	OutputCapabilities *OutputCapabilitiesConfig `json:"output_capabilities,omitempty"`
 	// Cost optionally declares the model's token pricing explicitly,
 	// overriding the models.dev catalogue. See [CostConfig].

--- a/pkg/config/latest/validate.go
+++ b/pkg/config/latest/validate.go
@@ -187,6 +187,9 @@ func (m *ModelConfig) validateFirstAvailable() error {
 	if m.Cost != nil {
 		return errors.New("first_available cannot be combined with cost (set it on the candidate models instead)")
 	}
+	if m.OutputCapabilities != nil {
+		return errors.New("first_available cannot be combined with output_capabilities (set output_capabilities.image on the candidate models instead)")
+	}
 	for i, ref := range m.FirstAvailable {
 		if strings.TrimSpace(ref) == "" {
 			return fmt.Errorf("first_available[%d] must not be empty", i)

--- a/pkg/config/latest/validate_test.go
+++ b/pkg/config/latest/validate_test.go
@@ -74,6 +74,8 @@ func TestModelConfigValidateFirstAvailable(t *testing.T) {
 		{name: "with compaction_model", model: ModelConfig{FirstAvailable: candidates, CompactionModel: "small"}, wantErr: "first_available cannot be combined with compaction_model"},
 		{name: "with compaction_threshold", model: ModelConfig{FirstAvailable: candidates, CompactionThreshold: new(0.5)}, wantErr: "first_available cannot be combined with compaction_threshold"},
 		{name: "with cost", model: ModelConfig{FirstAvailable: candidates, Cost: &CostConfig{Input: 1}}, wantErr: "first_available cannot be combined with cost"},
+		{name: "with output_capabilities", model: ModelConfig{FirstAvailable: candidates, OutputCapabilities: &OutputCapabilitiesConfig{Image: new(true)}}, wantErr: "first_available cannot be combined with output_capabilities"},
+		{name: "with output_capabilities false", model: ModelConfig{FirstAvailable: candidates, OutputCapabilities: &OutputCapabilitiesConfig{Image: new(false)}}, wantErr: "first_available cannot be combined with output_capabilities"},
 	}
 
 	for _, tt := range tests {

--- a/pkg/config/schema_test.go
+++ b/pkg/config/schema_test.go
@@ -189,6 +189,91 @@ agents:
 	assert.True(t, result.Valid(), "expected schema to accept audio/video capabilities: %v", result.Errors())
 }
 
+// TestJsonSchemaRejectsMalformedOutputCapabilities mirrors
+// TestJsonSchemaRejectsMalformedCapabilities for output_capabilities.image: a
+// non-boolean value must fail schema validation rather than silently
+// coercing.
+func TestJsonSchemaRejectsMalformedOutputCapabilities(t *testing.T) {
+	t.Parallel()
+
+	schemaBytes, err := os.ReadFile(schemaFile)
+	require.NoError(t, err)
+
+	schema, err := gojsonschema.NewSchema(gojsonschema.NewBytesLoader(schemaBytes))
+	require.NoError(t, err)
+
+	const in = `version: "15"
+models:
+  m:
+    provider: google
+    model: gemini-2.5-flash-image
+    output_capabilities:
+      image: "yes"
+agents:
+  root:
+    model: m
+    instruction: hi
+`
+
+	var rawJSON any
+	require.NoError(t, yaml.Unmarshal([]byte(in), &rawJSON))
+
+	result, err := schema.Validate(gojsonschema.NewRawLoader(rawJSON))
+	require.NoError(t, err)
+	assert.False(t, result.Valid(), "expected schema to reject a non-boolean output_capabilities.image")
+}
+
+// TestJsonSchemaAcceptsOutputCapabilities confirms output_capabilities.image
+// validates against the schema, both true and false, and that an unknown
+// key under output_capabilities is rejected (additionalProperties: false),
+// mirroring the strictness of CapabilitiesConfig.
+func TestJsonSchemaAcceptsOutputCapabilities(t *testing.T) {
+	t.Parallel()
+
+	schemaBytes, err := os.ReadFile(schemaFile)
+	require.NoError(t, err)
+
+	schema, err := gojsonschema.NewSchema(gojsonschema.NewBytesLoader(schemaBytes))
+	require.NoError(t, err)
+
+	const base = `version: "15"
+models:
+  m:
+    provider: google
+    model: gemini-2.5-flash-image
+    output_capabilities:
+%s
+agents:
+  root:
+    model: m
+    instruction: hi
+`
+
+	tests := []struct {
+		name  string
+		field string
+		valid bool
+	}{
+		{name: "image true", field: "      image: true\n", valid: true},
+		{name: "image false", field: "      image: false\n", valid: true},
+		{name: "image omitted (empty block)", field: "      {}\n", valid: true},
+		{name: "unknown key", field: "      video: true\n", valid: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var rawJSON any
+			require.NoError(t, yaml.Unmarshal(fmt.Appendf(nil, base, tt.field), &rawJSON))
+
+			result, err := schema.Validate(gojsonschema.NewRawLoader(rawJSON))
+			require.NoError(t, err)
+			assert.Equal(t, tt.valid, result.Valid(), "output_capabilities %s: %v", tt.name, result.Errors())
+		})
+	}
+}
+
 // TestSchemaMatchesGoTypes verifies that every JSON-tagged field in the Go
 // config structs has a corresponding property in agent-schema.json (and
 // vice-versa). This prevents the schema from silently drifting out of sync

--- a/pkg/model/provider/base/base.go
+++ b/pkg/model/provider/base/base.go
@@ -1,6 +1,8 @@
 package base
 
 import (
+	"context"
+
 	"github.com/docker/docker-agent/pkg/config/latest"
 	"github.com/docker/docker-agent/pkg/environment"
 	"github.com/docker/docker-agent/pkg/model/provider/options"
@@ -75,6 +77,16 @@ func (c *Config) CapsOverride() *modelinfo.CapsOverride {
 		return nil
 	}
 	return &modelinfo.CapsOverride{Image: caps.Image, PDF: caps.PDF, Audio: caps.Audio, Video: caps.Video}
+}
+
+// ImageOutputEnabled resolves the model's image-output capability from its
+// explicit tri-state configuration and, when unset, the models.dev catalogue.
+func (c *Config) ImageOutputEnabled(ctx context.Context) bool {
+	var override *bool
+	if caps := c.ModelConfig.OutputCapabilities; caps != nil {
+		override = caps.Image
+	}
+	return modelinfo.ResolveOutputImage(ctx, c.ModelOptions.ModelsDevStore(), c.ID(), override)
 }
 
 // EmbeddingResult contains the embedding and usage information

--- a/pkg/model/provider/base/base_test.go
+++ b/pkg/model/provider/base/base_test.go
@@ -7,7 +7,9 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/docker/docker-agent/pkg/config/latest"
+	"github.com/docker/docker-agent/pkg/model/provider/options"
 	"github.com/docker/docker-agent/pkg/modelinfo"
+	"github.com/docker/docker-agent/pkg/modelsdev"
 )
 
 func TestConfigCapsOverride(t *testing.T) {
@@ -55,4 +57,40 @@ func TestConfigCapsOverride(t *testing.T) {
 		assert.False(t, got.Audio)
 		assert.False(t, got.Video)
 	})
+}
+
+func TestConfigImageOutputEnabled(t *testing.T) {
+	t.Parallel()
+
+	store := modelsdev.NewDatabaseStore(&modelsdev.Database{Providers: map[string]modelsdev.Provider{
+		"google": {Models: map[string]modelsdev.Model{
+			"image-model": {Modalities: modelsdev.Modalities{Output: []string{"text", "image"}}},
+		}},
+	}})
+
+	tests := []struct {
+		name               string
+		outputCapabilities *latest.OutputCapabilitiesConfig
+		want               bool
+	}{
+		{name: "catalogue fallback", want: true},
+		{name: "explicit true", outputCapabilities: &latest.OutputCapabilitiesConfig{Image: new(true)}, want: true},
+		{name: "explicit false", outputCapabilities: &latest.OutputCapabilitiesConfig{Image: new(false)}, want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			cfg := Config{
+				ModelConfig: latest.ModelConfig{
+					Provider:           "google",
+					Model:              "image-model",
+					OutputCapabilities: tt.outputCapabilities,
+				},
+				ModelOptions: options.Apply(options.WithModelsDevStore(store)),
+			}
+			assert.Equal(t, tt.want, cfg.ImageOutputEnabled(t.Context()))
+		})
+	}
 }

--- a/pkg/model/provider/clone_test.go
+++ b/pkg/model/provider/clone_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/docker/docker-agent/pkg/chat"
 	"github.com/docker/docker-agent/pkg/config/latest"
 	"github.com/docker/docker-agent/pkg/environment"
+	"github.com/docker/docker-agent/pkg/model/provider/base"
 	"github.com/docker/docker-agent/pkg/model/provider/options"
 )
 
@@ -174,6 +175,21 @@ func TestCloneWithOptions_PreservesMaxTokens(t *testing.T) {
 		"MaxTokens should be preserved after cloning with unrelated options")
 	assert.Equal(t, maxTokens, *clonedConfig.ModelConfig.MaxTokens,
 		"MaxTokens value should be unchanged after cloning")
+}
+
+func TestCloneWithOptions_PreservesOutputCapabilities(t *testing.T) {
+	t.Parallel()
+
+	image := true
+	cfg := base.Config{ModelConfig: latest.ModelConfig{
+		OutputCapabilities: &latest.OutputCapabilitiesConfig{Image: &image},
+	}}
+
+	cloned, _ := mergeCloneOptions(cfg, []options.Opt{options.WithGeneratingTitle()})
+
+	require.NotNil(t, cloned.OutputCapabilities)
+	require.NotNil(t, cloned.OutputCapabilities.Image)
+	assert.True(t, *cloned.OutputCapabilities.Image)
 }
 
 func TestCloneWithOptions_OverridesMaxTokens(t *testing.T) {

--- a/pkg/modelinfo/modelinfo.go
+++ b/pkg/modelinfo/modelinfo.go
@@ -713,7 +713,42 @@ func LoadCaps(ctx context.Context, store *modelsdev.Store, id modelsdev.ID) Mode
 	return capsFromModalities(model.Modalities.Input)
 }
 
-// capsFromModalities maps a models.dev input-modality list to the capability
+// ResolveOutputImage applies an explicit image-output override when present;
+// otherwise it derives support from the models.dev output modalities. Missing
+// catalogue data conservatively disables image output.
+func ResolveOutputImage(ctx context.Context, store *modelsdev.Store, id modelsdev.ID, override *bool) bool {
+	if override != nil {
+		return *override
+	}
+	if store == nil {
+		return false
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, loadCapsTimeout)
+	defer cancel()
+
+	model, err := store.GetModel(ctx, id)
+	if err != nil {
+		if ctx.Err() != nil {
+			slog.WarnContext(ctx, "modelinfo: models.dev output lookup timed out, disabling image output",
+				"model", id.String(), "timeout", loadCapsTimeout)
+		} else {
+			warnCapsLookupMiss(ctx, id, err)
+		}
+		return false
+	}
+	return hasOutputModality(model.Modalities.Output, "image")
+}
+
+func hasOutputModality(modalities []string, expected string) bool {
+	for _, modality := range modalities {
+		if strings.EqualFold(modality, expected) {
+			return true
+		}
+	}
+	return false
+}
+
 // booleans it grants. Unknown modality names are ignored.
 func capsFromModalities(input []string) ModelCapabilities {
 	var mc ModelCapabilities

--- a/pkg/modelinfo/output_capabilities_test.go
+++ b/pkg/modelinfo/output_capabilities_test.go
@@ -1,0 +1,50 @@
+package modelinfo
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/docker/docker-agent/pkg/modelsdev"
+)
+
+func TestResolveOutputImage(t *testing.T) {
+	t.Parallel()
+
+	store := modelsdev.NewDatabaseStore(&modelsdev.Database{Providers: map[string]modelsdev.Provider{
+		"google": {Models: map[string]modelsdev.Model{
+			"image-model": {Modalities: modelsdev.Modalities{Output: []string{"text", "IMAGE"}}},
+			"text-model":  {Modalities: modelsdev.Modalities{Output: []string{"text"}}},
+		}},
+	}})
+
+	tests := []struct {
+		name     string
+		store    *modelsdev.Store
+		model    string
+		override *bool
+		want     bool
+	}{
+		{name: "explicit true overrides catalogue", store: store, model: "text-model", override: new(true), want: true},
+		{name: "explicit false overrides catalogue", store: store, model: "image-model", override: new(false), want: false},
+		{name: "catalogue image case insensitive", store: store, model: "image-model", want: true},
+		{name: "catalogue text only", store: store, model: "text-model", want: false},
+		{name: "catalogue output list is not mutated", store: store, model: "image-model", want: true},
+		{name: "missing model", store: store, model: "missing", want: false},
+		{name: "nil store", model: "image-model", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := ResolveOutputImage(t.Context(), tt.store, modelsdev.NewID("google", tt.model), tt.override)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+
+	model, err := store.GetModel(t.Context(), modelsdev.NewID("google", "image-model"))
+	require.NoError(t, err)
+	assert.Equal(t, []string{"text", "IMAGE"}, model.Modalities.Output)
+}


### PR DESCRIPTION
## What and why

Add latest-only `output_capabilities.image` configuration/schema support. Explicit true or false wins. Omitted, empty, or unset metadata consults exact provider-qualified models.dev output metadata; unknown models, unavailable providers, and lookup failures remain disabled. No capability is inferred from a model-name prefix. Numbered configuration packages remain frozen.

Part of docker/docker-agent#3996. Review this PR against its immediate parent, docker/docker-agent#4017, rather than the aggregate stack against `main`.

## Commit inventory

Head: `51559ff510bf01ea053e3923c329c80ba724dca5`; parent SHA: `2c5fd913464ef376471cc098b8e9481367f16b6a`.

- `b705039ca893933097887e9bbc66ba90231e34f3` — feat(#3996): add output_capabilities.image model override
- `51559ff510bf01ea053e3923c329c80ba724dca5` — feat(#3996): resolve image output capability from models.dev

## Validation

Build, test compilation, owning-package tests and the named fixture passed at this PR head.

Exact deterministic fixture command:

```sh
go test -v -count=1 ./pkg/modelinfo ./pkg/config/latest -run 'TestResolveOutputImage|Test.*OutputCapabilities'
```

Matched top-level tests: `pkg/config/latest`: **7**; `pkg/modelinfo`: **1**.

Deterministic scope: the named local fixture exercises this PR boundary with disposable configuration/stores and fake or loopback providers as applicable. Every listed package ran nonzero matching top-level tests.

Deferred/live scope: No new live catalogue/provider run was executed; deterministic resolution covers explicit and omitted metadata. The final stack head passed build, lint, full tests, an uncached full suite, focused race tests and documentation checks in disposable environments. Remote CI is tracked by the checks below; no new paid-provider or active-database validation was run.
