### PR TITLE
fix(#3996): leave reasoning headroom for Gemini session titles

### DIFF
--- a/pkg/model/provider/gemini/client.go
+++ b/pkg/model/provider/gemini/client.go
@@ -425,7 +425,7 @@ func extractMimeType(dataURLPrefix string) string {
 	return "image/jpeg" // Default fallback
 }
 
-// buildConfig creates GenerateContentConfig from model config
+// BuildConfig creates GenerateContentConfig from model config.
 func (c *Client) buildConfig() *genai.GenerateContentConfig {
 	config := &genai.GenerateContentConfig{}
 	if c.ModelConfig.MaxTokens != nil {
@@ -453,7 +453,11 @@ func (c *Client) buildConfig() *genai.GenerateContentConfig {
 	// Apply thinking configuration for Gemini models.
 	// See https://ai.google.dev/gemini-api/docs/thinking
 	if c.ModelOptions.NoThinking() {
-		// NoThinking requested (e.g. title generation). For Gemini 3+ models
+		if c.ModelOptions.GeneratingTitle() {
+			return config
+		}
+
+		// NoThinking requested (e.g. MCP sampling). For Gemini 3+ models
 		// that always think, use the lowest level and bump MaxOutputTokens so
 		// internal reasoning doesn't consume the entire budget. Gemini 2.5 and
 		// older can fully disable thinking with ThinkingBudget=0.

--- a/pkg/model/provider/gemini/client_test.go
+++ b/pkg/model/provider/gemini/client_test.go
@@ -10,9 +10,73 @@ import (
 	"github.com/docker/docker-agent/pkg/chat"
 	"github.com/docker/docker-agent/pkg/config/latest"
 	"github.com/docker/docker-agent/pkg/model/provider/base"
+	"github.com/docker/docker-agent/pkg/model/provider/options"
 	"github.com/docker/docker-agent/pkg/modelsdev"
 	"github.com/docker/docker-agent/pkg/tools"
 )
+
+func TestBuildConfig_NoThinking(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		model         string
+		opts          []options.Opt
+		wantThinking  bool
+		wantMinTokens bool
+	}{
+		{
+			name:         "title generation omits thinking config",
+			model:        "gemini-3-flash",
+			opts:         []options.Opt{options.WithGeneratingTitle(), options.WithNoThinking()},
+			wantThinking: false,
+		},
+		{
+			name:          "MCP sampling disables Gemini 3 thinking",
+			model:         "gemini-3-flash",
+			opts:          []options.Opt{options.WithNoThinking()},
+			wantThinking:  true,
+			wantMinTokens: true,
+		},
+		{
+			name:         "MCP sampling disables Gemini 2.5 thinking",
+			model:        "gemini-2.5-flash",
+			opts:         []options.Opt{options.WithNoThinking()},
+			wantThinking: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			client := &Client{Config: base.Config{
+				ModelConfig: latest.ModelConfig{
+					Provider:       "google",
+					Model:          tt.model,
+					ThinkingBudget: &latest.ThinkingBudget{Effort: "high"},
+				},
+				ModelOptions: options.Apply(tt.opts...),
+			}}
+
+			config := client.buildConfig()
+			if !tt.wantThinking {
+				assert.Nil(t, config.ThinkingConfig)
+				return
+			}
+
+			require.NotNil(t, config.ThinkingConfig)
+			assert.False(t, config.ThinkingConfig.IncludeThoughts)
+			if tt.wantMinTokens {
+				assert.Equal(t, genai.ThinkingLevelLow, config.ThinkingConfig.ThinkingLevel)
+				assert.GreaterOrEqual(t, config.MaxOutputTokens, int32(200))
+				return
+			}
+			require.NotNil(t, config.ThinkingConfig.ThinkingBudget)
+			assert.Zero(t, *config.ThinkingConfig.ThinkingBudget)
+		})
+	}
+}
 
 func TestBuildConfig_Gemini25_ThinkingBudget(t *testing.T) {
 	t.Parallel()

--- a/pkg/sessiontitle/generator.go
+++ b/pkg/sessiontitle/generator.go
@@ -28,11 +28,9 @@ const (
 	systemPrompt     = "You are a helpful AI assistant that generates concise, descriptive titles for conversations. You will be given up to 2 recent user messages and asked to create a single-line title that captures the main topic. Never use newlines or line breaks in your response."
 	userPromptFormat = "Based on the following recent user messages from a conversation with an AI assistant, generate a short, descriptive title (maximum 50 characters) that captures the main topic or purpose of the conversation. Return ONLY the title text on a single line, nothing else. Do not include any newlines, explanations, or formatting.\n\nRecent user messages:\n%s\n\n"
 
-	// titleMaxTokens is the max output token budget for title generation.
-	// This is sized for visible output only (~50 chars ≈ 12-15 tokens).
-	// Providers that need extra headroom for hidden reasoning tokens
-	// (e.g. OpenAI reasoning models) handle the adjustment internally.
-	titleMaxTokens = 20
+	// Gemini 3 may still consume a small hidden reasoning budget even when
+	// thinking is disabled. The visible title is capped separately at 50 chars.
+	titleMaxTokens = 128
 
 	// titleGenerationTimeout is the maximum time to wait for title generation.
 	// Title generation should be quick since we disable thinking and use low max_tokens.

--- a/pkg/sessiontitle/generator_test.go
+++ b/pkg/sessiontitle/generator_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/docker/docker-agent/pkg/chat"
 	"github.com/docker/docker-agent/pkg/config/latest"
 	"github.com/docker/docker-agent/pkg/model/provider/base"
+	"github.com/docker/docker-agent/pkg/model/provider/options"
 	"github.com/docker/docker-agent/pkg/modelsdev"
 	"github.com/docker/docker-agent/pkg/tools"
 )
@@ -74,6 +75,28 @@ func streamWithContent(content string) chat.MessageStream {
 		},
 		errAt: -1,
 	}
+}
+
+func TestGenerateOnceUsesTitleHeadroomAndClearsStructuredOutput(t *testing.T) {
+	t.Parallel()
+
+	structured := &latest.StructuredOutput{Schema: map[string]any{"type": "object"}}
+	baseProvider := &mockProvider{
+		id: modelsdev.NewID("google", "gemini-3-flash"),
+		baseCfgFn: func() base.Config {
+			maxTokens := int64(7)
+			return base.Config{
+				ModelConfig:  latest.ModelConfig{MaxTokens: &maxTokens},
+				ModelOptions: options.Apply(options.WithStructuredOutput(structured)),
+			}
+		},
+		createFn: func() (chat.MessageStream, error) { return streamWithContent("Title"), nil },
+	}
+
+	_, err := generateOnce(t.Context(), baseProvider, buildPrompt([]string{"hello"}))
+	require.NoError(t, err)
+	assert.Equal(t, 1, baseProvider.calls, "a failed clone would call the base provider and lose title-specific options")
+	assert.Equal(t, 128, titleMaxTokens)
 }
 
 func TestGenerator_Generate_FallsBackOnStreamCreateError(t *testing.T) {


### PR DESCRIPTION
## What and why

Omit thinkingConfig for session-title calls without returning early from request construction. Use a shared 128-token title budget for reasoning headroom with a separate 50-character visible limit. Ordinary request thinking behavior is unchanged. This is a mitigation, not a provider-success guarantee.

Part of docker/docker-agent#3996. Review this PR against its immediate parent, docker/docker-agent#4027, rather than the aggregate stack against `main`.

## Commit inventory

Head: `8eed51894134f104fa449f2cfbe7e510a22d3956`; parent SHA: `da8faa29eace36625b546c4d7103b4d08543d57e`.

- `8eed51894134f104fa449f2cfbe7e510a22d3956` — fix(#3996): leave reasoning headroom for Gemini session titles

## Validation

Build, test compilation, owning-package tests and the named fixture passed at this PR head.

Exact deterministic fixture command:

```sh
go test -v -count=1 ./pkg/model/provider/gemini ./pkg/sessiontitle -run 'TestBuildConfig_NoThinking|TestBuildConfig_Gemini25_ThinkingBudget|TestBuildConfig_Gemini3_ThinkingLevel|TestGenerateOnceUsesTitleHeadroomAndClearsStructuredOutput|TestGenerator_Generate_FallsBackOnEmptyOutput'
```

Matched top-level tests: `pkg/model/provider/gemini`: **4**; `pkg/sessiontitle`: **2**.

Deterministic scope: the named local fixture exercises this PR boundary with disposable configuration/stores and fake or loopback providers as applicable. Every listed package ran nonzero matching top-level tests.

Deferred/live scope: Live provider, remote CI, and platform execution are not claimed by this deterministic receipt. The final stack head passed build, lint, full tests, an uncached full suite, focused race tests and documentation checks in disposable environments. Remote CI is tracked by the checks below; no new paid-provider or active-database validation was run.
