### PR TITLE
chore: replace sort.Slice with slices.SortFunc

### DIFF
--- a/pkg/plans/service.go
+++ b/pkg/plans/service.go
@@ -1,6 +1,7 @@
 package plans
 
 import (
+	"cmp"
 	"context"
 	"errors"
 	"fmt"
@@ -8,7 +9,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
-	"sort"
+	"slices"
 	"strings"
 	"time"
 
@@ -76,7 +77,7 @@ func (s *service) List(ctx context.Context, opts ListOptions) (ListResult, error
 	result.Warnings = append(result.Warnings, warnings...)
 	// The documented order is by name; enforce it here so it holds for any
 	// injected Storage, not only backends that happen to sort.
-	sort.SliceStable(summaries, func(i, j int) bool { return summaries[i].Name < summaries[j].Name })
+	slices.SortStableFunc(summaries, func(a, b plan.Summary) int { return cmp.Compare(a.Name, b.Name) })
 	for _, sum := range summaries {
 		result.Plans = append(result.Plans, Plan{
 			Scope:     ScopeShared,

--- a/pkg/sandbox/kit/kit.go
+++ b/pkg/sandbox/kit/kit.go
@@ -24,6 +24,7 @@
 package kit
 
 import (
+	"cmp"
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
@@ -803,7 +804,7 @@ func (r *Result) PrintSummary(w io.Writer) {
 
 	skillFiles := r.skillFilesGrouped()
 	promptEntries := append([]Entry(nil), r.Manifest.PromptFiles...)
-	sort.Slice(promptEntries, func(i, j int) bool { return promptEntries[i].Target < promptEntries[j].Target })
+	slices.SortFunc(promptEntries, func(a, b Entry) int { return cmp.Compare(a.Target, b.Target) })
 
 	if len(skillFiles) == 0 && len(promptEntries) == 0 {
 		return
@@ -875,7 +876,7 @@ type skillGroup struct {
 // it sees exactly what the sandbox will see.
 func (r *Result) skillFilesGrouped() []skillGroup {
 	entries := append([]Entry(nil), r.Manifest.Skills...)
-	sort.Slice(entries, func(i, j int) bool { return entries[i].Target < entries[j].Target })
+	slices.SortFunc(entries, func(a, b Entry) int { return cmp.Compare(a.Target, b.Target) })
 
 	groups := make([]skillGroup, 0, len(entries))
 	for _, e := range entries {

--- a/pkg/tools/builtin/mcpcatalog/mcpcatalog.go
+++ b/pkg/tools/builtin/mcpcatalog/mcpcatalog.go
@@ -44,11 +44,13 @@
 package mcpcatalog
 
 import (
+	"cmp"
 	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
+	"slices"
 	"sort"
 	"strings"
 	"sync"
@@ -491,7 +493,7 @@ func (t *Toolset) Tools(ctx context.Context) ([]tools.Tool, error) {
 	// Tools() invocations, but for a given snapshot we want a deterministic
 	// merged list so model-side prompt caches and TUI rendering don't
 	// flicker on each turn.
-	sort.Slice(enabled, func(i, j int) bool { return enabled[i].id < enabled[j].id })
+	slices.SortFunc(enabled, func(a, b enabledServer) int { return cmp.Compare(a.id, b.id) })
 
 	for _, e := range enabled {
 		if err := ctx.Err(); err != nil {
@@ -645,7 +647,7 @@ func (t *Toolset) handleSearch(_ context.Context, args SearchArgs) (*tools.ToolC
 		return tools.ResultError(fmt.Sprintf("no remote MCP servers match %q (catalog has %d entries)", args.Query, t.catalog.Count)), nil
 	}
 
-	sort.Slice(matches, func(i, j int) bool { return matches[i].ID < matches[j].ID })
+	slices.SortFunc(matches, func(a, b SearchResult) int { return cmp.Compare(a.ID, b.ID) })
 
 	out, err := json.Marshal(matches)
 	if err != nil {
@@ -933,7 +935,7 @@ func (t *Toolset) handleList(_ context.Context, _ ListArgs) (*tools.ToolCallResu
 			Started: ts.IsStarted(),
 		})
 	}
-	sort.Slice(enabled, func(i, j int) bool { return enabled[i].ID < enabled[j].ID })
+	slices.SortFunc(enabled, func(a, b EnabledServer) int { return cmp.Compare(a.ID, b.ID) })
 
 	out, err := json.Marshal(enabled)
 	if err != nil {

--- a/pkg/tools/builtin/plan/plan.go
+++ b/pkg/tools/builtin/plan/plan.go
@@ -20,6 +20,7 @@ package plan
 
 import (
 	"bytes"
+	"cmp"
 	"context"
 	"encoding/json"
 	"errors"
@@ -28,7 +29,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
-	"sort"
+	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -1098,8 +1099,8 @@ func (s *FilesystemStorage) List(ctx context.Context) ([]Summary, []string, erro
 		})
 	}
 
-	sort.Slice(plans, func(i, j int) bool {
-		return plans[i].Name < plans[j].Name
+	slices.SortFunc(plans, func(a, b Summary) int {
+		return cmp.Compare(a.Name, b.Name)
 	})
 
 	return plans, warnings, nil


### PR DESCRIPTION
Replace 7 `sort.Slice`/`sort.SliceStable` calls with `slices.SortFunc`/`slices.SortStableFunc` + `cmp.Compare` across 4 files.

**Why**: `slices.SortFunc` avoids reflection, is type-safe, and is the idiomatic API since Go 1.21 (no dependency on the Go 1.27 upgrade).

**Files changed**:
- `pkg/tools/builtin/plan/plan.go` — 1 call
- `pkg/tools/builtin/mcpcatalog/mcpcatalog.go` — 3 calls
- `pkg/sandbox/kit/kit.go` — 2 calls
- `pkg/plans/service.go` — 1 call (stable sort preserved via `SortStableFunc`)

**Testing**: `go build ./...`, `go test` on all 4 touched packages, `go vet`, `go run ./lint .`, `go mod tidy --diff` all pass clean.