### PR TITLE
fix(tui): reuse explicit working directory for new sessions

### DIFF
--- a/cmd/root/run.go
+++ b/cmd/root/run.go
@@ -67,7 +67,13 @@ type runExecFlags struct {
 	// options and user settings (alias wins; within each scope safety wins
 	// over the legacy yolo/YOLO flag). Never populated from CLI flags or
 	// author YAML.
-	defaultSafety     session.SafetyPolicy
+	defaultSafety session.SafetyPolicy
+	// workingDirChanged records whether a non-empty --working-dir was
+	// explicitly passed on the command line. Captured before worktree and
+	// resume handling mutate runConfig.WorkingDir; only an explicit flag
+	// makes generic new-session actions in the TUI reuse the initial
+	// session's directory instead of opening the picker.
+	workingDirChanged bool
 	attachmentPath    string
 	remoteAddress     string
 	modelOverrides    []string
@@ -269,6 +275,9 @@ func (f *runExecFlags) runRunCommand(cmd *cobra.Command, args []string) (command
 	}
 	f.safetyChanged = cmd.Flags().Changed("safety")
 	f.yoloChanged = cmd.Flags().Changed("yolo")
+	// Captured here because runOrExec later overwrites runConfig.WorkingDir
+	// for worktrees and resumed sessions.
+	f.workingDirChanged = cmd.Flags().Changed("working-dir") && f.runConfig.WorkingDir != ""
 
 	// A --session-workingdir-root that trims to empty (e.g. an unresolved
 	// shell variable) must fail loudly instead of silently disabling the
@@ -533,6 +542,10 @@ func (f *runExecFlags) runOrExec(ctx context.Context, out *cli.Printer, args []s
 	}
 
 	var rec *recorder.Recorder
+	tuiOptions := f.tuiOpts(args)
+	if dir := f.explicitDefaultWorkingDir(sess); dir != "" {
+		tuiOptions = append(tuiOptions, tui.WithDefaultWorkingDir(dir))
+	}
 	runErr := func() error {
 		if f.lean {
 			return f.runLeanTUI(ctx, rt, sess, cleanup, args, opts...)
@@ -544,9 +557,9 @@ func (f *runExecFlags) runOrExec(ctx context.Context, out *cli.Printer, args []s
 				rec = recorder.New(m)
 				return rec
 			}
-			return runTUIWrapped(ctx, rt, sess, b.Spawner(rt), cleanup, f.tuiOpts(args), wrap, opts...)
+			return runTUIWrapped(ctx, rt, sess, b.Spawner(rt), cleanup, tuiOptions, wrap, opts...)
 		}
-		return runTUI(ctx, rt, sess, b.Spawner(rt), cleanup, f.tuiOpts(args), opts...)
+		return runTUI(ctx, rt, sess, b.Spawner(rt), cleanup, tuiOptions, opts...)
 	}()
 	if rec != nil && rec.HasInput() {
 		writeGeneratedTUITest(ctx, out, rec, cassettePath, agentFileName)
@@ -1081,6 +1094,23 @@ func (f *runExecFlags) tuiOpts(args []string) []tui.Option {
 		opts = append(opts, tui.WithTourOffer(telemetry.GetTelemetryEnabled()))
 	}
 	return opts
+}
+
+// explicitDefaultWorkingDir returns the working directory generic new-session
+// actions in the TUI should default to instead of opening the picker, or ""
+// when --working-dir was not explicitly supplied on this invocation. It
+// mirrors runTUIWrapped's resolution of the initial tab's directory (session
+// working dir, then process CWD) so new tabs open exactly where the initial
+// session did — the worktree or resume directory, not the raw flag value.
+func (f *runExecFlags) explicitDefaultWorkingDir(sess *session.Session) string {
+	if !f.workingDirChanged {
+		return ""
+	}
+	if sess.WorkingDir != "" {
+		return sess.WorkingDir
+	}
+	wd, _ := os.Getwd()
+	return wd
 }
 
 // shouldOfferTour reports whether this interactive run should show the

--- a/cmd/root/run_working_dir_test.go
+++ b/cmd/root/run_working_dir_test.go
@@ -1,0 +1,43 @@
+package root
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/docker/docker-agent/pkg/session"
+)
+
+// Only an explicit --working-dir makes generic new-session actions in the
+// TUI default to the initial session's directory; the value passed on is the
+// session's effective directory (worktree/resume resolution included), not
+// the raw flag (#4039).
+func TestExplicitDefaultWorkingDir(t *testing.T) {
+	t.Parallel()
+
+	t.Run("no explicit flag keeps the picker", func(t *testing.T) {
+		t.Parallel()
+		f := &runExecFlags{}
+		sess := session.New(session.WithWorkingDir("/repo"))
+		assert.Empty(t, f.explicitDefaultWorkingDir(sess),
+			"without --working-dir no default may be configured")
+	})
+
+	t.Run("explicit flag uses the session's effective directory", func(t *testing.T) {
+		t.Parallel()
+		f := &runExecFlags{workingDirChanged: true}
+		sess := session.New(session.WithWorkingDir("/repo/worktree"))
+		assert.Equal(t, "/repo/worktree", f.explicitDefaultWorkingDir(sess))
+	})
+
+	t.Run("explicit flag falls back to the process CWD", func(t *testing.T) {
+		t.Parallel()
+		f := &runExecFlags{workingDirChanged: true}
+		wd, err := os.Getwd()
+		require.NoError(t, err)
+		assert.Equal(t, wd, f.explicitDefaultWorkingDir(session.New()),
+			"an empty session working dir must mirror runTUIWrapped's CWD fallback")
+	})
+}

--- a/pkg/tui/spawn_default_dir_test.go
+++ b/pkg/tui/spawn_default_dir_test.go
@@ -1,0 +1,116 @@
+package tui
+
+import (
+	"context"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/docker/docker-agent/pkg/app"
+	"github.com/docker/docker-agent/pkg/session"
+	"github.com/docker/docker-agent/pkg/tui/animation"
+	"github.com/docker/docker-agent/pkg/tui/commands"
+	"github.com/docker/docker-agent/pkg/tui/components/spinner"
+	"github.com/docker/docker-agent/pkg/tui/components/statusbar"
+	"github.com/docker/docker-agent/pkg/tui/components/tabbar"
+	"github.com/docker/docker-agent/pkg/tui/dialog"
+	"github.com/docker/docker-agent/pkg/tui/messages"
+	"github.com/docker/docker-agent/pkg/tui/service/supervisor"
+	"github.com/docker/docker-agent/pkg/tui/styles"
+)
+
+// spySpawner records the working directories it was asked to spawn in and
+// returns a live app wired to stubRuntime so the full spawn path runs.
+type spySpawner struct {
+	dirs []string
+}
+
+func (s *spySpawner) spawn(ctx context.Context, workingDir string) (*app.App, *session.Session, func(), error) {
+	s.dirs = append(s.dirs, workingDir)
+	sess := session.New(session.WithWorkingDir(workingDir))
+	return app.New(ctx, stubRuntime{}, sess), sess, func() {}, nil
+}
+
+// newSpawnTestModel wires a model with a real supervisor around spy plus the
+// components handleSpawnSession/handleSwitchTab touch on a successful spawn.
+func newSpawnTestModel(t *testing.T, spy *spySpawner, opts ...Option) *appModel {
+	t.Helper()
+	m, _ := newTestModel(t)
+	m.ar = animation.NewRuntime()
+	m.buildCommandCategories = func(context.Context, tea.Model) []commands.Category { return nil }
+	m.application = app.New(t.Context(), stubRuntime{}, session.New())
+	m.workingSpinner = spinner.New(m.ar, spinner.ModeSpinnerOnly, styles.SpinnerDotsHighlightStyle)
+	m.tabBar = tabbar.New(m.ar, 0)
+	m.statusBar = statusbar.New(m)
+	m.supervisor = supervisor.New(spy.spawn)
+	// Mirror New: the initial session is registered with the supervisor.
+	m.supervisor.AddSession(t.Context(), m.application, m.application.Session(), "/initial", func() {})
+	m.width, m.height = 120, 40
+	for _, opt := range opts {
+		opt(m)
+	}
+	return m
+}
+
+// A generic spawn request (no directory) must reuse the configured default
+// working directory instead of opening the picker (#4039).
+func TestHandleSpawnSession_EmptyDirUsesConfiguredDefault(t *testing.T) {
+	t.Parallel()
+
+	spy := &spySpawner{}
+	m := newSpawnTestModel(t, spy, WithDefaultWorkingDir("/work/dir"))
+
+	_, _ = m.handleSpawnSession("")
+
+	assert.Equal(t, []string{"/work/dir"}, spy.dirs,
+		"the spawner must receive the configured default directory")
+	assert.Equal(t, 2, m.supervisor.Count(),
+		"the new session must be added instead of opening the picker")
+}
+
+// Without a configured default the picker keeps opening, exactly as before.
+func TestHandleSpawnSession_EmptyDirWithoutDefaultOpensPicker(t *testing.T) {
+	t.Parallel()
+
+	spy := &spySpawner{}
+	m := newSpawnTestModel(t, spy)
+
+	_, cmd := m.handleSpawnSession("")
+
+	assert.Empty(t, spy.dirs, "nothing must be spawned without a directory")
+	require.NotNil(t, cmd)
+	assert.True(t, hasMsg[dialog.OpenDialogMsg](collectMsgs(cmd)),
+		"the working-directory picker must open")
+}
+
+// A concrete directory in the request (picker selection, explicit
+// SpawnSessionMsg) wins over the configured default.
+func TestHandleSpawnSession_ExplicitDirOverridesDefault(t *testing.T) {
+	t.Parallel()
+
+	spy := &spySpawner{}
+	m := newSpawnTestModel(t, spy, WithDefaultWorkingDir("/default/dir"))
+
+	_, _ = m.handleSpawnSession("/explicit/dir")
+
+	assert.Equal(t, []string{"/explicit/dir"}, spy.dirs,
+		"an explicit directory must win over the configured default")
+}
+
+// The /new command routes through the same handler: with a configured
+// default it must spawn there instead of opening the picker.
+func TestNewSessionMsg_UsesConfiguredDefaultDir(t *testing.T) {
+	t.Parallel()
+
+	spy := &spySpawner{}
+	m := newSpawnTestModel(t, spy, WithDefaultWorkingDir("/work/dir"))
+
+	_, _ = m.Update(messages.NewSessionMsg{})
+
+	assert.Equal(t, []string{"/work/dir"}, spy.dirs,
+		"/new must spawn in the configured default directory")
+	assert.Equal(t, 2, m.supervisor.Count(),
+		"the new session must be added instead of opening the picker")
+}

--- a/pkg/tui/tui.go
+++ b/pkg/tui/tui.go
@@ -287,6 +287,13 @@ type appModel struct {
 	// hideSidebar hides the sidebar and disables the ctrl+b toggle.
 	hideSidebar bool
 
+	// defaultNewSessionDir, when non-empty, is the directory generic
+	// new-session actions (/new, Ctrl+T, the tab-bar and status-bar "+")
+	// spawn in instead of opening the working-directory picker. Set only
+	// when --working-dir was explicitly supplied on the CLI; a directory
+	// carried by the spawn request still wins.
+	defaultNewSessionDir string
+
 	// layoutSettings is the active TUI layout customization (sidebar position
 	// and section visibility). Shared by every tab and managed via /settings.
 	layoutSettings messages.LayoutSettings
@@ -360,6 +367,16 @@ func WithHideSidebar() Option {
 func WithImageWriter(writer *tuiimage.Writer) Option {
 	return func(m *appModel) {
 		m.imageWriter = writer
+	}
+}
+
+// WithDefaultWorkingDir makes generic new-session actions (/new, Ctrl+T,
+// the tab-bar and status-bar "+") spawn in dir instead of opening the
+// working-directory picker. A directory carried by the spawn request still
+// wins. Used when --working-dir was explicitly supplied on the CLI.
+func WithDefaultWorkingDir(dir string) Option {
+	return func(m *appModel) {
+		m.defaultNewSessionDir = dir
 	}
 }
 
@@ -1804,7 +1821,11 @@ func (m *appModel) handleClearSession() (tea.Model, tea.Cmd) {
 
 // handleSpawnSession spawns a new session.
 func (m *appModel) handleSpawnSession(workingDir string) (tea.Model, tea.Cmd) {
-	// If no working dir specified, open the picker
+	// A generic request (no directory) inherits the explicit --working-dir
+	// default when one is configured; otherwise ask via the picker.
+	if workingDir == "" {
+		workingDir = m.defaultNewSessionDir
+	}
 	if workingDir == "" {
 		return m.openWorkingDirPicker()
 	}


### PR DESCRIPTION
## Summary

- preserve whether `--working-dir` was explicitly supplied
- reuse the effective initial working directory for `/new`, Ctrl+T, and new-tab buttons
- retain the working-directory picker when the flag is absent
- keep explicitly selected session directories higher priority than the default

Closes #4039

## Issue expectations

| Expectation | Implementation |
|---|---|
| `/new` reuses an explicit `--working-dir` | yes |
| New-tab keyboard and button actions reuse it | yes |
| Runs without `--working-dir` retain the picker | yes |
| Worktree and resumed-session paths use the effective directory | yes |
| Explicit picker selections remain authoritative | yes |

## Validation

- `task test`
- `task build`
- `task lint`
- `task check-plan-cross`
- manual PTY test with explicit `--working-dir`: two tabs created in the same directory without opening the picker
- manual control test without `--working-dir`: picker opened as before

`task test-binary` was also attempted. Its existing `TestExecMissingKeys` expectation failed because `DOCKER_AGENT_MODELS_GATEWAY` was set in the environment, causing validation to reach the missing-message error instead of the expected missing-key error. This is unrelated to the changed paths.
