### PR TITLE
test(hooks): skip the stdin-JSON hook test when jq is missing

### DIFF
--- a/pkg/hooks/helpers_other_test.go
+++ b/pkg/hooks/helpers_other_test.go
@@ -3,6 +3,7 @@
 package hooks
 
 import (
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -31,7 +32,20 @@ func emitContextEnvPwdCmd(envVars ...string) string {
 
 // printStdinJSONFieldCmd returns a command printing one field of the JSON
 // document the hook receives on stdin.
-func printStdinJSONFieldCmd(field string) string {
+//
+// This is the only test helper that needs a JSON parser in the shell, and POSIX
+// has no built-in one (the Windows mirror can lean on PowerShell's
+// ConvertFrom-Json). It shells out to jq and skips when jq is absent.
+//
+// The skip matters: without it the hook still runs, produces no output, and the
+// test fails on its content assertion instead -- reporting `"" does not contain
+// "final answer content"`, which reads as a defect in the hook plumbing rather
+// than a missing tool on the machine.
+func printStdinJSONFieldCmd(t *testing.T, field string) string {
+	t.Helper()
+	if _, err := exec.LookPath("jq"); err != nil {
+		t.Skip("jq is not installed; it is required to read a JSON field from hook stdin")
+	}
 	return `cat | jq -r '.` + field + `'`
 }
 

--- a/pkg/hooks/helpers_windows_test.go
+++ b/pkg/hooks/helpers_windows_test.go
@@ -31,7 +31,11 @@ func emitContextEnvPwdCmd(envVars ...string) string {
 
 // printStdinJSONFieldCmd returns a command printing one field of the JSON
 // document the hook receives on stdin.
-func printStdinJSONFieldCmd(field string) string {
+// Signature mirrors the POSIX helper, which needs *testing.T to skip when jq is
+// missing. PowerShell's ConvertFrom-Json is built in, so there is nothing to
+// skip on here.
+func printStdinJSONFieldCmd(t *testing.T, field string) string {
+	t.Helper()
 	return `([Console]::In.ReadToEnd() | ConvertFrom-Json).` + field
 }
 

--- a/pkg/hooks/hooks_test.go
+++ b/pkg/hooks/hooks_test.go
@@ -570,7 +570,7 @@ func TestExecuteStopReceivesResponseContent(t *testing.T) {
 
 	config := &Config{
 		Stop: []Hook{
-			{Type: HookTypeCommand, Command: printStdinJSONFieldCmd("stop_response"), Timeout: 5},
+			{Type: HookTypeCommand, Command: printStdinJSONFieldCmd(t, "stop_response"), Timeout: 5},
 		},
 	}
 


### PR DESCRIPTION
`printStdinJSONFieldCmd` shells out to `jq`. When `jq` is absent the hook still runs and exits
cleanly, producing no output, so the test fails on its *content* assertion rather than on a
missing command — reporting a hook-plumbing defect that does not exist.

Closes #4052.

## Before

On a machine without `jq` (e.g. stock `golang:1.27`):

```text
--- FAIL: TestExecuteStopReceivesResponseContent (0.00s)
    hooks_test.go:586:
        	Error: "" does not contain "final answer content"
FAIL	github.com/docker/docker-agent/pkg/hooks
```

## After

```text
    hooks_test.go:573: jq is not installed; it is required to read a JSON field from hook stdin
--- SKIP: TestExecuteStopReceivesResponseContent (0.00s)
ok  	github.com/docker/docker-agent/pkg/hooks
```

With `jq` present, unchanged:

```text
--- PASS: TestExecuteStopReceivesResponseContent (0.00s)
ok  	github.com/docker/docker-agent/pkg/hooks
```

## What changed

The helper takes `*testing.T` and guards on `exec.LookPath`:

```go
func printStdinJSONFieldCmd(t *testing.T, field string) string {
	t.Helper()
	if _, err := exec.LookPath("jq"); err != nil {
		t.Skip("jq is not installed; it is required to read a JSON field from hook stdin")
	}
	return `cat | jq -r '.` + field + `'`
}
```

The Windows mirror takes the same parameter for signature parity but needs no guard —
PowerShell's `ConvertFrom-Json` is built in. One caller updated.

## Why skip rather than drop the dependency

Removing `jq` would mean either parsing JSON with `sed`/`awk` — fragile, and a fragile test is
worse than a skipped one — or weakening the assertion to "the value appears somewhere in the
payload", which stops testing that the value arrives in the *named field*.

Skipping keeps the assertion exact wherever `jq` exists (CI, most dev machines) and makes the
failure mode honest everywhere else. Coverage is unchanged on any machine that had `jq`.

## Verification

Tested both paths in a container, by moving `/usr/bin/jq` aside and back:

| | `jq` present | `jq` absent |
|---|---|---|
| before | `ok` | `FAIL` — misleading assertion |
| after | `ok` (PASS) | `ok` (SKIP, names jq) |

Full `pkg/hooks` package passes in both states; `go vet` clean.

## Note

This is a test-only change. No production code is touched, and behaviour on machines with `jq`
installed is byte-for-byte identical.
