### PR TITLE
docs: auto-update for merged PRs (2026-08-25)

### DIFF
--- a/docs/features/code-mode/index.md
+++ b/docs/features/code-mode/index.md
@@ -53,6 +53,7 @@ It is not a general-purpose replacement for direct tool calls: for an agent that
 - **Failures are diagnosable.** If the script throws or returns unexpectedly, the response includes the tool calls it made before failing (name, arguments, and result or error), so the model can see what happened and adjust the script on the next attempt.
 - **Not every tool is wrapped.** Tools in the `todo` category are excluded from the script environment and stay directly callable as ordinary tools — Code Mode does not replace them.
 - **The script runs in an embedded, sandboxed JS engine** ([goja](https://github.com/dop251/goja)), not Node.js or a browser: there is no filesystem, network, or process access beyond the tool functions injected into it.
+- **Partial startup is supported.** If one toolset fails to initialize (for example, an MCP server that won't connect), Code Mode remains available with the successfully loaded toolsets. The failed toolset is omitted from the JavaScript environment and retried on subsequent turns. A warning is emitted once when the failure first occurs, but not on subsequent turns while the failure persists. When the toolset recovers, its tools silently reappear in the environment.
 
 ## Interaction With Permissions and Tool Approval
 


### PR DESCRIPTION
This PR updates documentation to reflect code changes merged into `main` in the last 36 hours.

## Documentation Changes

### Code Mode - Partial Startup Support (PR #4008)

**File:** `docs/features/code-mode/index.md`

**Change:** Added documentation for the new partial startup behavior introduced in #4008.

**Details:** Code Mode now supports partial startup when one or more toolsets fail to initialize. Previously, if any toolset failed, the entire Code Mode wrapper would be unavailable. Now:
- Successfully loaded toolsets remain available in the JavaScript environment
- Failed toolsets are omitted and retried on subsequent turns
- A warning is emitted once when a failure first occurs
- Recovery is silent - tools reappear automatically when the toolset recovers

This improves resilience when using Code Mode with multiple toolsets, particularly MCP servers that may have connectivity issues.

## Source PRs Reviewed

The following PRs were reviewed for documentation impact:

- ✅ **#4008** - fix(codemode): preserve tools after partial startup → **Documented above**
- ⚪ #4045 - chore: migrate to OpenTelemetry SDK 1.45 → No doc changes needed (version-agnostic docs)
- ⚪ #4043 - chore(test): upgrade testify to v1.12.1 → No doc changes needed (test dependency)
- ⚪ #4042 - fix(tui): reuse explicit working directory for new sessions → No doc changes needed (behavior refinement)
- ⚪ #4040 - chore: refresh embedded models.dev snapshot → No doc changes needed (data update)
- ⚪ #4036 - chore: upgrade to Go 1.27.0 and apply 1.27 modernizations → No doc changes needed (internal toolchain)
- ⚪ #4034 - chore: replace sort.Slice with slices.SortFunc → No doc changes needed (internal refactoring)