### PR TITLE
chore: update docker-agent-action to v2.0.5

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -18,7 +18,7 @@ jobs:
     if: |
       github.event_name == 'issue_comment' ||
       github.event.workflow_run.conclusion == 'success'
-    uses: docker/docker-agent-action/.github/workflows/review-pr.yml@baf90543d81f5de59751dfd10e6cf45e21a5a982 # v2.0.3
+    uses: docker/docker-agent-action/.github/workflows/review-pr.yml@06e1767af06263c93d712449cbf859778d9392ee # v2.0.5
     # Scoped to the job so other jobs in this workflow aren't over-permissioned
     permissions:
       contents: read # Read repository files and PR diffs


### PR DESCRIPTION
## Summary
Updates `docker-agent-action` reference in `.github/workflows/pr-review.yml` to [v2.0.5](https://github.com/docker/docker-agent-action/releases/tag/v2.0.5).
- **Commit**: `06e1767af06263c93d712449cbf859778d9392ee`
- **Version**: `v2.0.5`
> Auto-generated by the [release](https://github.com/docker/docker-agent-action/actions/runs/32832244227) workflow.