### PR TITLE
docs: auto-update for merged PRs (2026-08-26)

### DIFF
--- a/docs/providers/deepseek/index.md
+++ b/docs/providers/deepseek/index.md
@@ -33,7 +33,7 @@ The simplest way to use DeepSeek:
 ```yaml
 agents:
   root:
-    model: deepseek/deepseek-chat
+    model: deepseek/deepseek-v4-pro
     description: Assistant using DeepSeek
     instruction: You are a helpful assistant.
 ```
@@ -46,7 +46,7 @@ For more control over parameters:
 models:
   deepseek_model:
     provider: deepseek
-    model: deepseek-chat
+    model: deepseek-v4-pro
     temperature: 0.7
     max_tokens: 8192
 
@@ -65,8 +65,9 @@ for current model IDs, context limits, and pricing.
 
 | Model | Description |
 | --- | --- |
-| `deepseek-chat` | DeepSeek-V3, general-purpose chat and tool calling |
-| `deepseek-reasoner` | DeepSeek-R1, extended-reasoning model |
+| `deepseek-v4-pro` | DeepSeek V4 Pro, extended-reasoning model with tool calling |
+| `deepseek-v4-flash` | DeepSeek V4 Flash, fast general-purpose model with tool calling |
+| `deepseek-v4-flash-vision-exp` | DeepSeek V4 Flash Vision (experimental), multimodal model with image input |
 
 > Model IDs are case-sensitive and must be passed exactly as the catalogue lists
 > them.
@@ -84,8 +85,8 @@ DeepSeek is implemented as a built-in alias in Docker Agent:
 ```yaml
 agents:
   coder:
-    model: deepseek/deepseek-chat
-    description: Code assistant using DeepSeek-V3
+    model: deepseek/deepseek-v4-pro
+    description: Code assistant using DeepSeek V4 Pro
     instruction: |
       You are an expert programmer.
       Write clean, well-documented code and follow language best practices.


### PR DESCRIPTION
## Documentation Updates

This PR updates documentation to reflect code changes merged into `main` in the last 36 hours.

### Covered PRs

#### PR #4058: fix: replace removed deepseek-chat with deepseek-v4-pro
**Source:** https://github.com/docker/docker-agent/pull/4058

**Documentation changes:**
- Updated `docs/providers/deepseek/index.md` to reflect the current DeepSeek model lineup
- Replaced all references to `deepseek-chat` with `deepseek-v4-pro`
- Updated the Available Models table to include:
  - `deepseek-v4-pro` (extended-reasoning model with tool calling)
  - `deepseek-v4-flash` (fast general-purpose model with tool calling)
  - `deepseek-v4-flash-vision-exp` (experimental multimodal model with image input)
- Removed outdated references to `deepseek-chat` and `deepseek-reasoner`

### Context

DeepSeek removed `deepseek-chat` and `deepseek-reasoner` from their live API, replacing them with the V4 model lineup. The code changes in PR #4058 updated examples, tests, and configuration to use the new models.

---

**Auto-generated by docker-agent documentation maintenance workflow**