### PR TITLE
fix(mcp): prevent GitHub restart loop

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -110,6 +110,8 @@ linters:
       replace-allow-list:
         - github.com/charmbracelet/ultraviolet
         - github.com/cyphar/filepath-securejoin
+        # TODO(docker/docker-agent#4068): drop with the go.mod replace.
+        - github.com/modelcontextprotocol/go-sdk
     gocritic:
       disabled-checks:
         - dupImport

--- a/go.mod
+++ b/go.mod
@@ -237,3 +237,8 @@ require (
 replace github.com/charmbracelet/ultraviolet => github.com/dgageot/ultraviolet v0.0.0-20260313154905-9451997d56b6
 
 replace github.com/cyphar/filepath-securejoin => github.com/cyphar/filepath-securejoin v0.4.1
+
+// TODO(docker/docker-agent#4068): pin v1.6.1 because v1.7.0 mishandles
+// GitHub's subscriptions/listen rejection. Keep require v1.7.0 for ADK/MVS;
+// remove once https://github.com/modelcontextprotocol/go-sdk/pull/1193 ships.
+replace github.com/modelcontextprotocol/go-sdk => github.com/modelcontextprotocol/go-sdk v1.6.1

--- a/go.sum
+++ b/go.sum
@@ -345,8 +345,8 @@ github.com/moby/sys/sequential v0.6.0 h1:qrx7XFUd/5DxtqcoH1h438hF5TmOvzC/lspjy7z
 github.com/moby/sys/sequential v0.6.0/go.mod h1:uyv8EUTrca5PnDsdMGXhZe6CCe8U/UiTWd+lL+7b/Ko=
 github.com/moby/term v0.5.2 h1:6qk3FJAFDs6i/q3W/pQ97SX192qKfZgGjCQqfCJkgzQ=
 github.com/moby/term v0.5.2/go.mod h1:d3djjFCrjnB+fl8NJux+EJzu0msscUP+f8it8hPkFLc=
-github.com/modelcontextprotocol/go-sdk v1.7.0 h1:yqjY2dsbKAC0LSuWZVBMrHgiG8ukXv6NRo0JiALay44=
-github.com/modelcontextprotocol/go-sdk v1.7.0/go.mod h1:dL7u98E/zjJTGzEq+j30jQ8K2k1mb6LeAH4inEcSGts=
+github.com/modelcontextprotocol/go-sdk v1.6.1 h1:0zOSupjKUxPKSocPT1Wtago+mUHU2/uZ4xSOY0FGReU=
+github.com/modelcontextprotocol/go-sdk v1.6.1/go.mod h1:kzm3kzFL1/+AziGOE0nUs3gvPoNxMCvkxokMkuFapXQ=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=

--- a/pkg/tools/mcp/remote_test.go
+++ b/pkg/tools/mcp/remote_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/docker/docker-agent/pkg/tools/lifecycle"
 	"github.com/docker/docker-agent/pkg/upstream"
 )
 
@@ -874,4 +875,132 @@ func TestOAuthHTTPClientWithHeaders_ResolverKeepsEnvHeadersFreshAndHostScoped(t 
 	v, _ := thirdPartyHeader.Load().(string)
 	assert.Empty(t, v,
 		"requests to a third-party host must NOT carry the configured header even with a resolver (credential-leak guard)")
+}
+
+// githubStyleMCPServer mimics GitHub's MCP endpoint (docker/docker-agent#4068):
+// it serves both handshake generations but rejects subscriptions/listen with
+// HTTP 404 + JSON-RPC -32601.
+type githubStyleMCPServer struct {
+	*httptest.Server
+
+	discovers   atomic.Int64
+	initializes atomic.Int64
+	listens     atomic.Int64
+	toolsLists  atomic.Int64
+}
+
+// handshakes counts connection setups. Max, not sum: one setup may combine a
+// discover probe with an initialize fallback.
+func (s *githubStyleMCPServer) handshakes() int64 {
+	return max(s.discovers.Load(), s.initializes.Load())
+}
+
+func newGitHubStyleMCPServer(t *testing.T) *githubStyleMCPServer {
+	t.Helper()
+
+	srv := &githubStyleMCPServer{}
+	srv.Server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+
+		var req struct {
+			ID     json.RawMessage `json:"id"`
+			Method string          `json:"method"`
+			Params struct {
+				ProtocolVersion string `json:"protocolVersion"`
+			} `json:"params"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			http.Error(w, "bad request", http.StatusBadRequest)
+			return
+		}
+		if req.ID == nil {
+			// Notification: no response expected.
+			w.WriteHeader(http.StatusAccepted)
+			return
+		}
+
+		result := func(result string) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprintf(w, `{"jsonrpc":"2.0","id":%s,"result":%s}`, req.ID, result)
+		}
+		methodNotFound := func() {
+			msg, err := json.Marshal(fmt.Sprintf("method not found: %q", req.Method))
+			require.NoError(t, err)
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusNotFound)
+			fmt.Fprintf(w, `{"jsonrpc":"2.0","id":%s,"error":{"code":-32601,"message":%s}}`, req.ID, msg)
+		}
+
+		switch req.Method {
+		case "server/discover":
+			srv.discovers.Add(1)
+			result(`{"supportedVersions":["2026-07-28"],"capabilities":{"tools":{"listChanged":true},"prompts":{"listChanged":true}}}`)
+		case "subscriptions/listen":
+			srv.listens.Add(1)
+			methodNotFound()
+		case "initialize":
+			srv.initializes.Add(1)
+			version := req.Params.ProtocolVersion
+			if version == "" {
+				version = "2025-11-25"
+			}
+			result(fmt.Sprintf(`{"protocolVersion":%q,"capabilities":{"tools":{"listChanged":true},"prompts":{"listChanged":true}},"serverInfo":{"name":"github-mcp-stub","version":"0.0.1"}}`, version))
+		case "tools/list":
+			srv.toolsLists.Add(1)
+			result(`{"tools":[{"name":"issue_read","description":"Read a GitHub issue","inputSchema":{"type":"object"}}]}`)
+		case "prompts/list":
+			result(`{"prompts":[]}`)
+		default:
+			methodNotFound()
+		}
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// TestRemoteToolset_SurvivesSubscriptionsListenRejection is the regression
+// test for docker/docker-agent#4068: against a server that rejects
+// subscriptions/listen the way GitHub MCP does, the toolset must serve
+// tools/list and stay Ready without reconnecting.
+func TestRemoteToolset_SurvivesSubscriptionsListenRejection(t *testing.T) {
+	t.Parallel()
+
+	srv := newGitHubStyleMCPServer(t)
+
+	client := newRemoteClient(srv.URL, "streamable", nil, NewInMemoryTokenStore(), nil, false, nil)
+	ts := &Toolset{
+		name:      "github",
+		mcpClient: client,
+		logID:     sanitizeRemoteAddress(srv.URL),
+	}
+	ts.supervisor = newSupervisor(ts, remotePolicy(lifecycle.Policy{
+		Backoff: lifecycle.Backoff{Initial: 10 * time.Millisecond, Max: 40 * time.Millisecond},
+	}))
+
+	require.NoError(t, ts.Start(t.Context()), "Start must succeed against a GitHub-style MCP endpoint")
+	t.Cleanup(func() { _ = ts.Stop(context.WithoutCancel(t.Context())) })
+	restarted := ts.supervisor.Restarted()
+
+	toolList, err := ts.Tools(t.Context())
+	require.NoError(t, err, "Tools must succeed after Start")
+	require.Len(t, toolList, 1)
+	assert.Equal(t, "github_issue_read", toolList[0].Name)
+	require.Positive(t, srv.toolsLists.Load(), "tools/list must actually reach the server")
+
+	select {
+	case <-restarted:
+		t.Fatal("reconnect cycle observed: the session died and the supervisor restarted it")
+	case <-time.After(500 * time.Millisecond):
+	}
+	assert.LessOrEqual(t, srv.handshakes(), int64(1),
+		"handshake must run at most once (discover=%d initialize=%d)", srv.discovers.Load(), srv.initializes.Load())
+	// 0 under the pinned v1.6.1 SDK; 1 stays valid once a fixed SDK reinstates
+	// the probe and tolerates the rejection (go-sdk#1193).
+	assert.LessOrEqual(t, srv.listens.Load(), int64(1),
+		"subscriptions/listen must not be retried in a loop")
+	assert.Equal(t, lifecycle.StateReady, ts.State().State, "toolset must stay Ready through the observation window")
 }


### PR DESCRIPTION
## Summary

Prevents the GitHub remote MCP server from entering an endless reconnect loop after rejecting `subscriptions/listen`.

The MCP Go SDK is temporarily forced to v1.6.1 until the upstream fix in modelcontextprotocol/go-sdk#1193 is included in a tagged release. A hermetic regression test covers the reported server behavior.

Fixes #4068.

## Root cause

- go-sdk v1.7.0 negotiates MCP `2026-07-28`.
- Docker Agent registers tool and prompt list-change handlers, causing the SDK to open `subscriptions/listen`.
- GitHub MCP intentionally rejects that optional stream with HTTP 404 and JSON-RPC `-32601`.
- go-sdk v1.7.0 classifies the stateless 404 as a missing session and closes the connection.
- The supervisor sees each reconnect as initially successful, resets its retry budget, and starts another cycle when the session immediately closes.

## Changes

- Temporarily replace go-sdk v1.7.0 with v1.6.1.
- Allow the temporary module replacement in the linter configuration.
- Add a GitHub-style hermetic MCP server fixture.
- Add regression coverage verifying that:
  - the remote toolset starts successfully;
  - `tools/list` remains usable;
  - the session stays ready;
  - no reconnect cycle occurs.

## Issue expectations

| Expectation | Implementation |
|---|---|
| Stop the GitHub MCP restart loop | v1.6.1 avoids the affected `subscriptions/listen` negotiation path |
| Keep GitHub MCP tools available | Regression test requires `tools/list` to succeed |
| Prevent recurrence | Test covers the exact HTTP 404 and JSON-RPC `-32601` server response |
| Preserve other MCP notifications | Existing handler registration remains unchanged |

## Validation

- `task test`
- `task build`
- `task check-plan-cross`
- `env -u DOCKER_AGENT_MODELS_GATEWAY task test-binary`
- `golangci-lint v2.13.1 run`
- `go run ./lint .`
- `go test -race -count=5 -run TestRemoteToolset_SurvivesSubscriptionsListenRejection ./pkg/tools/mcp/`
- `go vet ./pkg/tools/mcp ./pkg/tools/lifecycle`
- `go mod tidy -diff`

## Residual considerations

- The replacement must be removed when a tagged go-sdk release contains modelcontextprotocol/go-sdk#1193.
- The generic supervisor behavior that resets the retry budget after immediately unstable connections remains a separate resilience concern.
- The Qwen-specific TUI `Working…` symptom was not independently reproduced and is not addressed by this change.
