### PR TITLE
fix(#4060): extend backoff gate to remote MCP HTTP errors

### DIFF
--- a/docs/tools/lsp/index.md
+++ b/docs/tools/lsp/index.md
@@ -197,7 +197,7 @@ Available Capabilities:
 
 LSP toolsets are managed by the same supervisor as MCP toolsets, so a crashed `gopls` (or any other language server) is reconnected automatically with exponential backoff. Use the [`lifecycle`](../../configuration/tools/index.md#toolset-lifecycle) block to tune the policy per toolset — for example, mark `gopls` as `strict` if your CI flow requires it to be available, or use `/toolset-restart gopls` from the TUI to force a reconnect when the server gets stuck.
 
-**Startup failure behaviour:** local LSP server startup failures (missing binary, server-unavailable) fail fast — each turn retries immediately with no artificial delay. The rate-limit backoff gate applies only to model-provider embedding calls (see [Indexing failures, retries and backoff](../rag/index.md#indexing-failures-retries-and-backoff)); it does not apply to LSP server startup.
+**Startup failure behaviour:** missing-binary and bad-config failures fail fast — each turn retries immediately with no artificial delay. A language server that crash-loops is not currently paced by the backoff gate; the supervisor's own reconnect policy (controlled by the `lifecycle` block) is the primary throttle for crash recovery.
 
 ```yaml
 toolsets:

--- a/docs/tools/mcp/index.md
+++ b/docs/tools/mcp/index.md
@@ -258,7 +258,7 @@ toolsets:
 
 See [Toolset Lifecycle](../../configuration/tools/index.md#toolset-lifecycle) for all profiles and tuning knobs, and [`/toolset-restart`](../../features/tui/index.md) to force a reconnect from the TUI.
 
-**Startup failure behaviour:** local MCP startup failures (missing binary, connection refused, authentication error) fail fast — each turn retries immediately with no artificial delay. The rate-limit backoff gate applies only to model-provider embedding calls (see [Indexing failures, retries and backoff](../rag/index.md#indexing-failures-retries-and-backoff)); it does not apply to MCP server startup.
+**Startup failure behaviour:** local MCP failures (missing binary, connection refused, bad auth) fail fast — each turn retries immediately with no artificial delay. Remote MCP servers (Streamable HTTP / SSE) that respond with one of a fixed set of retryable HTTP statuses — 429 Too Many Requests, 408 Request Timeout, 500/502/503/504, or 529 (Anthropic-style "overloaded") — are paced by the same [bounded exponential backoff gate](../rag/index.md#indexing-failures-retries-and-backoff) that RAG embedding calls use, so a temporarily-overloaded remote MCP server does not trigger a new connect attempt on every agent turn. This is a fixed enumeration, not a full 5xx range: less-common codes such as 501, 505, or the Cloudflare 520–527 family do not arm the gate. Note MCP's trigger set is broader than RAG's current 429-only pacing (see the linked page and [#4097](https://github.com/docker/docker-agent/issues/4097)). Not yet applied when toolsets are wrapped in code mode — see [#4067](https://github.com/docker/docker-agent/issues/4067).
 
 ## Combined Example
 

--- a/docs/tools/rag/index.md
+++ b/docs/tools/rag/index.md
@@ -183,10 +183,12 @@ every agent turn.
 
 ### What triggers backoff
 
-Backoff applies only to **HTTP 429 rate-limit** responses from the embedding or
-model provider — the one signal that reliably reaches the toolset gate. Other
-errors (5xx, 408) are handled per-file within the indexing run and do not arm
-the gate. These are the current gate triggers:
+For **RAG indexing**, backoff applies only to **HTTP 429 rate-limit** responses
+from the embedding or model provider — the one signal that reliably reaches the
+toolset gate. Other errors (5xx, 408) are handled per-file within the indexing
+run and do not arm the gate (tracked as a gap in
+[#4097](https://github.com/docker/docker-agent/issues/4097)). These are the
+current gate triggers for RAG indexing specifically:
 
 | Failure kind | Behaviour |
 |---|---|
@@ -198,6 +200,11 @@ the gate. These are the current gate triggers:
 > 5xx and 408 errors from the embedding provider are retried per-file and do not
 > propagate to the toolset gate. Only 429 (rate-limit) terminates the indexing run
 > early and surfaces the gate so Docker Agent can pace the next attempt.
+>
+> This 429-only trigger set is specific to the RAG/embedding path. Other toolset
+> types have their own trigger sets against the same gate — for example, remote
+> MCP toolsets also pace on 408 and a fixed set of 5xx-family statuses (see
+> [MCP startup failure behaviour](../mcp/index.md#lifecycle-auto-restart-profiles)).
 
 ### Retry policy and parameters
 

--- a/pkg/tools/mcp/oauth.go
+++ b/pkg/tools/mcp/oauth.go
@@ -500,6 +500,12 @@ type oauthTransport struct {
 	// swallows in favor of a bare http.StatusText.
 	lastErrStatus int
 	lastErrBody   []byte
+	// lastErrRetryAfter captures the raw Retry-After header value (if any) of
+	// the most recent non-2xx response, so enrichConnectError can forward it
+	// to modelerrors.WrapHTTPError and have the StartableToolSet backoff gate
+	// honor a server-supplied retry hint instead of falling back to the
+	// generic computed delay.
+	lastErrRetryAfter string
 	// lastAuthRequired records when the transport short-circuited an
 	// interactive OAuth flow because the request context disallowed
 	// prompts (see WithoutInteractivePrompts). The MCP SDK wraps transport
@@ -874,6 +880,7 @@ func (t *oauthTransport) logErrorResponse(req *http.Request, resp *http.Response
 	t.mu.Lock()
 	t.lastErrStatus = resp.StatusCode
 	t.lastErrBody = body
+	t.lastErrRetryAfter = resp.Header.Get("Retry-After")
 	t.mu.Unlock()
 
 	slog.Warn("Authenticated MCP request was rejected by the server",
@@ -885,23 +892,33 @@ func (t *oauthTransport) logErrorResponse(req *http.Request, resp *http.Response
 	)
 }
 
-// lastServerError returns the status code and a short, human-readable
-// explanation drawn from the most recent non-2xx response seen by this
-// transport. The string is empty when no such response has been captured
-// or when the body yielded no useful text.
+// lastServerErrorSnapshot returns the status code, a short human-readable
+// explanation, and the raw Retry-After header value, all captured together
+// under a single lock from the most recent non-2xx response seen by this
+// transport. status is 0 when no such response has been captured; msg and
+// retryAfter are "" when the body yielded no useful text / no header was
+// present, respectively.
+//
+// The three fields are read under one lock (rather than via separate
+// accessors) so a caller building a combined error never pairs a status
+// captured from one response with a Retry-After header captured from a
+// different, concurrent one: this transport's RoundTrip can be invoked
+// concurrently for a single logical connect attempt (e.g. a standalone SSE
+// probe alongside the initialize call).
 //
 // This is how the transport surfaces provider-specific errors (e.g. Slack's
 // "App is not enabled for Slack MCP server access") that would otherwise
 // be hidden behind the MCP SDK's generic http.StatusText-derived messages.
-func (t *oauthTransport) lastServerError() (int, string) {
+func (t *oauthTransport) lastServerErrorSnapshot() (status int, msg, retryAfter string) {
 	t.mu.Lock()
-	status := t.lastErrStatus
+	status = t.lastErrStatus
 	body := t.lastErrBody
+	retryAfter = t.lastErrRetryAfter
 	t.mu.Unlock()
 	if status == 0 {
-		return 0, ""
+		return 0, "", ""
 	}
-	return status, extractServerMessage(body)
+	return status, extractServerMessage(body), retryAfter
 }
 
 // authorizationRequired reports whether the transport short-circuited an

--- a/pkg/tools/mcp/remote.go
+++ b/pkg/tools/mcp/remote.go
@@ -16,6 +16,7 @@ import (
 	"github.com/docker/docker-agent/pkg/environment"
 	"github.com/docker/docker-agent/pkg/httpclient"
 	"github.com/docker/docker-agent/pkg/js"
+	"github.com/docker/docker-agent/pkg/modelerrors"
 	"github.com/docker/docker-agent/pkg/upstream"
 )
 
@@ -211,8 +212,32 @@ func enrichConnectError(err error, t *oauthTransport) error {
 	if t.authorizationRequired() {
 		return &AuthorizationRequiredError{URL: t.baseURL}
 	}
-	if status, msg := t.lastServerError(); status != 0 && msg != "" {
-		return fmt.Errorf("failed to connect to MCP server: %w (server responded %d: %s)", err, status, msg)
+	// Wrap on status alone: many rate-limit / load-balancer 429s and 503s
+	// carry an empty body, so gating on msg != "" (as an earlier version of
+	// this code did) silently dropped the *modelerrors.StatusError wrap —
+	// and with it, the StartableToolSet backoff gate never armed.
+	//
+	// status, msg and retryAfter are read together as a single snapshot
+	// (rather than via two separately-locked accessor calls) so they can
+	// never be pieced together from two different concurrent responses on
+	// this transport (e.g. a standalone SSE probe racing the initialize call).
+	if status, msg, retryAfter := t.lastServerErrorSnapshot(); status != 0 {
+		var enriched error
+		if msg != "" {
+			enriched = fmt.Errorf("failed to connect to MCP server: %w (server responded %d: %s)", err, status, msg)
+		} else {
+			// No status text extracted from the body: modelerrors.StatusError.Error()
+			// already prefixes "HTTP %d: ", so repeating the code here would read as
+			// "HTTP 503: ... (server responded 503)".
+			enriched = fmt.Errorf("failed to connect to MCP server: %w", err)
+		}
+		// Forward the server's Retry-After hint (if any) so the backoff gate
+		// honors it instead of falling back to the generic computed delay.
+		resp := &http.Response{Header: http.Header{}}
+		if retryAfter != "" {
+			resp.Header.Set("Retry-After", retryAfter)
+		}
+		return modelerrors.WrapHTTPError(status, resp, enriched)
 	}
 	return fmt.Errorf("failed to connect to MCP server: %w", err)
 }
@@ -249,8 +274,9 @@ func (c *remoteMCPClient) SetUnmanagedOAuthRedirectURI(uri string) {
 // values never go stale on a long-lived connection.
 //
 // The oauthTransport is returned alongside the client so callers can inspect
-// the most recent server-side failure (via lastServerError) when Connect()
-// returns a bare HTTP-status error and we need to surface the actual cause.
+// the most recent server-side failure (via lastServerErrorSnapshot) when
+// Connect() returns a bare HTTP-status error and we need to surface the
+// actual cause.
 //
 // The transport chain wraps `httpclient.WrapWithOTel` outermost so every
 // outbound MCP request injects W3C `traceparent` (and creates an HTTP

--- a/pkg/tools/mcp/remote_test.go
+++ b/pkg/tools/mcp/remote_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/docker/docker-agent/pkg/modelerrors"
 	"github.com/docker/docker-agent/pkg/tools"
 	"github.com/docker/docker-agent/pkg/tools/lifecycle"
 	"github.com/docker/docker-agent/pkg/upstream"
@@ -1111,4 +1112,341 @@ func TestRemoteToolset_SurvivesSubscriptionsListenRejection(t *testing.T) {
 	assert.Equal(t, int64(1), srv.listens.Load(),
 		"subscriptions/listen probe must run exactly once, not be retried in a loop")
 	assert.Equal(t, lifecycle.StateReady, ts.State().State, "toolset must stay Ready through the observation window")
+}
+
+// TestEnrichConnectError_RetryableStatusSurfacesAsStatusError verifies that
+// enrichConnectError wraps retryable HTTP errors (5xx/429) in a *StatusError
+// so the StartableToolSet backoff gate can arm on them.
+func TestEnrichConnectError_RetryableStatusSurfacesAsStatusError(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name          string
+		status        int
+		wantRetryable bool
+	}{
+		{"503 service unavailable", http.StatusServiceUnavailable, true},
+		{"429 too many requests", http.StatusTooManyRequests, true},
+		{"500 internal server error", http.StatusInternalServerError, true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(tc.status)
+				_, _ = fmt.Fprintf(w, `{"error":{"message":"server error %d"}}`, tc.status)
+			}))
+			defer srv.Close()
+
+			store := NewInMemoryTokenStore()
+			require.NoError(t, store.StoreToken(srv.URL, &OAuthToken{AccessToken: "tok", TokenType: "Bearer"}))
+
+			client := newRemoteClient(srv.URL, "streamable", nil, store, nil, false, nil)
+
+			_, err := client.Initialize(t.Context(), nil)
+			require.Error(t, err)
+
+			var se *modelerrors.StatusError
+			require.ErrorAs(t, err, &se, "a %d response must surface as *StatusError", tc.status)
+			assert.Equal(t, tc.status, se.StatusCode)
+			assert.True(t, modelerrors.RetryableHTTPStatus(se),
+				"status %d must be classified retryable by the backoff gate", tc.status)
+		})
+	}
+}
+
+// TestEnrichConnectError_NonRetryableStatusDoesNotArm verifies that a 4xx
+// client-error response wraps in *StatusError but is NOT classified retryable,
+// so bad-config / auth failures fail promptly without triggering pacing.
+func TestEnrichConnectError_NonRetryableStatusDoesNotArm(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusForbidden) // 403
+		_, _ = fmt.Fprint(w, `{"error":{"message":"access denied"}}`)
+	}))
+	defer srv.Close()
+
+	store := NewInMemoryTokenStore()
+	require.NoError(t, store.StoreToken(srv.URL, &OAuthToken{AccessToken: "tok", TokenType: "Bearer"}))
+
+	client := newRemoteClient(srv.URL, "streamable", nil, store, nil, false, nil)
+
+	_, err := client.Initialize(t.Context(), nil)
+	require.Error(t, err)
+
+	var se *modelerrors.StatusError
+	require.ErrorAs(t, err, &se, "403 must still surface as *StatusError (wrapped for structured access)")
+	assert.Equal(t, http.StatusForbidden, se.StatusCode)
+	assert.False(t, modelerrors.RetryableHTTPStatus(se),
+		"403 must NOT be classified retryable — client errors fail promptly")
+}
+
+// TestEnrichConnectError_NoStatusNoStatusError verifies that when there is no
+// recorded HTTP server error (e.g. a network-level failure before any HTTP
+// response), the error does not carry a *StatusError so the gate does not arm.
+func TestEnrichConnectError_NoStatusNoStatusError(t *testing.T) {
+	t.Parallel()
+
+	// Point at a closed port so there is never an HTTP response.
+	ln, err := (&net.ListenConfig{}).Listen(t.Context(), "tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	addr := ln.Addr().String()
+	_ = ln.Close()
+
+	client := newRemoteClient("http://"+addr, "streamable", nil, NewInMemoryTokenStore(), nil, false, nil)
+
+	_, err = client.Initialize(t.Context(), nil)
+	require.Error(t, err)
+
+	var se *modelerrors.StatusError
+	assert.NotErrorAs(t, err, &se,
+		"a plain network failure must not carry a *StatusError (would arm the gate spuriously)")
+}
+
+// TestEnrichConnectError_EmptyBodyStatusStillArms verifies that a retryable
+// HTTP status with an EMPTY response body (common for load-balancer or
+// rate-limit responses that carry no JSON payload) still surfaces as a
+// *modelerrors.StatusError. An earlier version of enrichConnectError gated
+// the wrap on the extracted message being non-empty, which silently dropped
+// the StatusError wrap — and with it, all backoff pacing — whenever the
+// server didn't bother sending a body alongside the status code.
+func TestEnrichConnectError_EmptyBodyStatusStillArms(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name   string
+		status int
+	}{
+		{"503 empty body", http.StatusServiceUnavailable},
+		{"429 empty body", http.StatusTooManyRequests},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				// No Content-Type, no body — exactly what many load balancers
+				// and rate limiters send.
+				w.WriteHeader(tc.status)
+			}))
+			defer srv.Close()
+
+			store := NewInMemoryTokenStore()
+			require.NoError(t, store.StoreToken(srv.URL, &OAuthToken{AccessToken: "tok", TokenType: "Bearer"}))
+
+			client := newRemoteClient(srv.URL, "streamable", nil, store, nil, false, nil)
+
+			_, err := client.Initialize(t.Context(), nil)
+			require.Error(t, err)
+
+			var se *modelerrors.StatusError
+			require.ErrorAs(t, err, &se,
+				"an empty-body %d response must still surface as *StatusError", tc.status)
+			assert.Equal(t, tc.status, se.StatusCode)
+			assert.True(t, modelerrors.RetryableHTTPStatus(se),
+				"empty-body status %d must still be classified retryable", tc.status)
+		})
+	}
+}
+
+// TestEnrichConnectError_RetryAfterHonoured verifies that a server-supplied
+// Retry-After header on a 429 response is parsed through to the resulting
+// *modelerrors.StatusError, matching the handling in the sibling model-adapter
+// paths (see modelerrors.WrapHTTPError).
+func TestEnrichConnectError_RetryAfterHonoured(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Retry-After", "120")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer srv.Close()
+
+	store := NewInMemoryTokenStore()
+	require.NoError(t, store.StoreToken(srv.URL, &OAuthToken{AccessToken: "tok", TokenType: "Bearer"}))
+
+	client := newRemoteClient(srv.URL, "streamable", nil, store, nil, false, nil)
+
+	_, err := client.Initialize(t.Context(), nil)
+	require.Error(t, err)
+
+	var se *modelerrors.StatusError
+	require.ErrorAs(t, err, &se)
+	assert.Equal(t, http.StatusTooManyRequests, se.StatusCode)
+	assert.Equal(t, 120*time.Second, se.RetryAfter,
+		"the server's Retry-After header must be parsed onto the StatusError")
+}
+
+// TestEnrichConnectError_NoRetryAfterHeaderLeavesZero verifies that when the
+// server does not send a Retry-After header, RetryAfter stays zero (the
+// gate then falls back to its own computed delay).
+func TestEnrichConnectError_NoRetryAfterHeaderLeavesZero(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer srv.Close()
+
+	store := NewInMemoryTokenStore()
+	require.NoError(t, store.StoreToken(srv.URL, &OAuthToken{AccessToken: "tok", TokenType: "Bearer"}))
+
+	client := newRemoteClient(srv.URL, "streamable", nil, store, nil, false, nil)
+
+	_, err := client.Initialize(t.Context(), nil)
+	require.Error(t, err)
+
+	var se *modelerrors.StatusError
+	require.ErrorAs(t, err, &se)
+	assert.Zero(t, se.RetryAfter, "no Retry-After header means the gate computes its own delay")
+}
+
+// TestBackoffGate_RemoteMCPRetryableStatusPacesReconnect is an end-to-end
+// regression test: it drives a REAL *Toolset (built via NewRemoteToolset,
+// exactly as production wiring does) through tools.StartableToolSet.TryStart
+// against a mock server that always answers 503. It proves the whole chain —
+// enrichConnectError -> Toolset.Start -> supervisor.Start -> the backoff
+// gate in tryStartLocked — stays intact end to end, rather than relying on
+// enrichConnectError-only unit tests that would miss error-chain loss
+// introduced anywhere between remote.go and mcp.go's Initialize wrapping.
+func TestBackoffGate_RemoteMCPRetryableStatusPacesReconnect(t *testing.T) {
+	t.Parallel()
+
+	var attempts atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		attempts.Add(1)
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer srv.Close()
+
+	toolset := NewRemoteToolset("test", srv.URL, "streamable", nil, nil)
+
+	now := time.Now()
+	clock := func() time.Time { return now }
+	identityJitter := func(d time.Duration) time.Duration { return d }
+
+	s := tools.NewStartable(toolset, tools.WithStartRetryClock(clock), tools.WithStartRetryJitter(identityJitter))
+
+	// Attempt 1: gate is idle, the real connect attempt runs and fails,
+	// arming the gate. The transport may issue more than one HTTP request
+	// per logical connect attempt (e.g. a standalone SSE probe), so assert
+	// relative growth rather than an exact per-call count.
+	started, err := s.TryStart(t.Context())
+	assert.False(t, started)
+	require.Error(t, err)
+	afterFirst := attempts.Load()
+	assert.Positive(t, afterFirst, "first TryStart must hit the server")
+
+	var se *modelerrors.StatusError
+	require.ErrorAs(t, err, &se, "the gate-arming error must carry the StatusError")
+	assert.Equal(t, http.StatusServiceUnavailable, se.StatusCode)
+
+	// Immediately after: gate armed, TryStart returns without a new
+	// connect attempt reaching the server.
+	started, err = s.TryStart(t.Context())
+	assert.False(t, started)
+	require.Error(t, err)
+	assert.Equal(t, afterFirst, attempts.Load(), "gate must block the retry from reaching the server")
+
+	// Advance the fake clock past the backoff window (comfortably beyond
+	// the documented 5-minute cap, without depending on the unexported
+	// base/max constants which aren't visible across package test
+	// boundaries): gate opens, a new connect attempt reaches the server.
+	now = now.Add(6 * time.Minute)
+	started, err = s.TryStart(t.Context())
+	assert.False(t, started)
+	require.Error(t, err)
+	assert.Greater(t, attempts.Load(), afterFirst, "gate must open and retry once the window elapses")
+}
+
+// TestBackoffGate_RemoteMCPNonRetryableStatusFailsPromptly is the negative
+// counterpart: a 403 (bad config / auth) must fail every turn without any
+// pacing, through the same real TryStart path.
+func TestBackoffGate_RemoteMCPNonRetryableStatusFailsPromptly(t *testing.T) {
+	t.Parallel()
+
+	var attempts atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		attempts.Add(1)
+		w.WriteHeader(http.StatusForbidden)
+	}))
+	defer srv.Close()
+
+	toolset := NewRemoteToolset("test", srv.URL, "streamable", nil, nil)
+	s := tools.NewStartable(toolset)
+
+	var prev int32
+	for range 3 {
+		started, err := s.TryStart(t.Context())
+		assert.False(t, started)
+		require.Error(t, err)
+		cur := attempts.Load()
+		assert.Greater(t, cur, prev, "403 must reach the server every turn, no pacing")
+		prev = cur
+	}
+}
+
+// TestBackoffGate_RemoteMCPRecoversAfterBackoffWindow closes the "repeated
+// failures then eventual success" recovery criterion at the MCP integration
+// layer (mirrored from the generic gate recovery tests in #4062): a remote
+// MCP server that answers 503 arms the gate, then recovers to a real,
+// working MCP handshake — the next TryStart after the window elapses must
+// actually start the toolset, not merely stop erroring.
+func TestBackoffGate_RemoteMCPRecoversAfterBackoffWindow(t *testing.T) {
+	t.Parallel()
+
+	var failing atomic.Bool
+	failing.Store(true)
+
+	mcpServer := gomcp.NewServer(&gomcp.Implementation{Name: "test-server", Version: "1.0.0"}, nil)
+	streamableHandler := gomcp.NewStreamableHTTPHandler(func(*http.Request) *gomcp.Server { return mcpServer }, nil)
+
+	var attempts atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attempts.Add(1)
+		if failing.Load() {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			return
+		}
+		streamableHandler.ServeHTTP(w, r)
+	}))
+	defer srv.Close()
+
+	toolset := NewRemoteToolset("test", srv.URL, "streamable", nil, nil)
+
+	now := time.Now()
+	clock := func() time.Time { return now }
+	identityJitter := func(d time.Duration) time.Duration { return d }
+
+	s := tools.NewStartable(toolset, tools.WithStartRetryClock(clock), tools.WithStartRetryJitter(identityJitter))
+
+	// Attempt 1: server failing, connect fails, gate arms.
+	started, err := s.TryStart(t.Context())
+	assert.False(t, started)
+	require.Error(t, err)
+	afterFirst := attempts.Load()
+	assert.Positive(t, afterFirst, "first TryStart must hit the server")
+
+	// The server recovers, but the gate is still armed: an immediate retry
+	// must still be blocked (recovery alone doesn't bypass the window).
+	failing.Store(false)
+	started, err = s.TryStart(t.Context())
+	assert.False(t, started)
+	require.Error(t, err)
+	assert.Equal(t, afterFirst, attempts.Load(),
+		"gate must still block immediately after arming, even though the server has recovered")
+
+	// Advance past the backoff window: gate opens, and this time the real
+	// MCP handshake completes successfully — the toolset actually starts.
+	now = now.Add(6 * time.Minute)
+	started, err = s.TryStart(t.Context())
+	assert.True(t, started, "toolset must start once the server has recovered and the gate opens: %v", err)
+	require.NoError(t, err)
+	assert.Greater(t, attempts.Load(), afterFirst, "gate must open and retry once the window elapses")
 }

--- a/pkg/tools/startable_backoff.go
+++ b/pkg/tools/startable_backoff.go
@@ -14,11 +14,29 @@ const (
 )
 
 // startBackoffRetryable reports whether err carries a retryable HTTP status
-// (429, 408, or 5xx). Requires a *modelerrors.StatusError anywhere in the
-// chain; plain network errors and the regex fallback in RetryableHTTPStatus
-// are intentionally excluded to avoid arming the gate on port numbers or
-// chunk counters that match the \b[45]\d{2}\b pattern.
+// that warrants pacing the next start attempt: 429, 408, 500, 502, 503, 504,
+// or 529 (see modelerrors.isRetryableStatusCode). This is a fixed
+// enumeration, not a full 5xx range — codes such as 501, 505, or the
+// Cloudflare 520-527 family do NOT arm the gate. Only a *modelerrors.StatusError
+// in the error chain arms the gate; plain network errors and the regex
+// fallback in RetryableHTTPStatus are intentionally excluded so port numbers,
+// PIDs, and chunk counters in plain error text cannot arm the gate.
+//
 // A StatusError wins even when context.DeadlineExceeded is also in the chain.
+//
+// Deliberately excluded from arming (these must never pace):
+//   - lifecycle.ErrServerUnavailable: missing binary / process-not-found — fast-retry.
+//   - lifecycle.ErrTransport: connection refused / no such host — fast-retry.
+//   - lifecycle.ErrAuthRequired / ErrCapabilityMissing: permanent — fail promptly.
+//   - lifecycle.ErrInitTimeout, ErrSessionMissing: transient, handled by the
+//     supervisor's own reconnect policy without per-turn pacing.
+//   - Plain error strings: excluded to avoid false positives on numeric
+//     patterns in port numbers or counters.
+//
+// Note: lifecycle.ErrServerCrashed (a server that started then crashed) is
+// NOT currently surfaced by supervisor.Start(); it flows only through the
+// supervisor's internal watcher goroutine. LSP crash-loop pacing is therefore
+// deferred until that sentinel is propagated through the start path.
 func startBackoffRetryable(err error) bool {
 	var se *modelerrors.StatusError
 	if !errors.As(err, &se) {

--- a/pkg/tools/startable_backoff_test.go
+++ b/pkg/tools/startable_backoff_test.go
@@ -3,6 +3,7 @@ package tools_test
 import (
 	"context"
 	"errors"
+	"fmt"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -14,6 +15,7 @@ import (
 
 	"github.com/docker/docker-agent/pkg/modelerrors"
 	"github.com/docker/docker-agent/pkg/tools"
+	"github.com/docker/docker-agent/pkg/tools/lifecycle"
 )
 
 // startErrToolSet is a minimal Startable whose error field controls the
@@ -754,4 +756,62 @@ func TestStartableToolSet_RetryAfterCapAtMax(t *testing.T) {
 	_, _ = s.TryStart(t.Context())
 	assert.Check(t, is.Equal(inner.starts.Load(), int32(2)),
 		"gate must open at startBackoffMax, not at the uncapped hint")
+}
+
+// TestStartBackoffRetryable_ErrServerUnavailable verifies that a missing binary
+// (ErrServerUnavailable) does NOT arm the gate — it fails promptly every turn.
+func TestStartBackoffRetryable_ErrServerUnavailable(t *testing.T) {
+	inner := &startErrToolSet{}
+	inner.setErr(fmt.Errorf("%w: no such file or directory", lifecycle.ErrServerUnavailable))
+	s := newThrottledStartable(inner)
+
+	for range 3 {
+		_, err := s.TryStart(t.Context())
+		assert.Check(t, err != nil)
+	}
+	assert.Check(t, is.Equal(inner.starts.Load(), int32(3)),
+		"missing-binary errors must not pace retries")
+}
+
+// TestStartBackoffRetryable_ErrTransport verifies that a network-level failure
+// (connection refused, no such host) does NOT arm the gate.
+func TestStartBackoffRetryable_ErrTransport(t *testing.T) {
+	inner := &startErrToolSet{}
+	inner.setErr(fmt.Errorf("%w: connection refused", lifecycle.ErrTransport))
+	s := newThrottledStartable(inner)
+
+	for range 3 {
+		_, _ = s.TryStart(t.Context())
+	}
+	assert.Check(t, is.Equal(inner.starts.Load(), int32(3)),
+		"transport errors must not pace retries")
+}
+
+// TestStartBackoffRetryable_ErrAuthRequired verifies that a permanent auth
+// failure (OAuth required / invalid token) does NOT arm the gate.
+func TestStartBackoffRetryable_ErrAuthRequired(t *testing.T) {
+	inner := &startErrToolSet{}
+	inner.setErr(fmt.Errorf("%w: token expired", lifecycle.ErrAuthRequired))
+	s := newThrottledStartable(inner)
+
+	for range 3 {
+		_, _ = s.TryStart(t.Context())
+	}
+	assert.Check(t, is.Equal(inner.starts.Load(), int32(3)),
+		"auth-required errors must not pace retries")
+}
+
+// TestStartBackoffRetryable_4xxStatusDoesNotArm verifies that a structured
+// 4xx HTTP error (client error, not a rate-limit) wraps as *StatusError but
+// does not arm the gate.
+func TestStartBackoffRetryable_4xxStatusDoesNotArm(t *testing.T) {
+	inner := &startErrToolSet{}
+	inner.setErr(&modelerrors.StatusError{StatusCode: 400, Err: errors.New("bad request")})
+	s := newThrottledStartable(inner)
+
+	for range 3 {
+		_, _ = s.TryStart(t.Context())
+	}
+	assert.Check(t, is.Equal(inner.starts.Load(), int32(3)),
+		"400 client errors must not arm the backoff gate")
 }


### PR DESCRIPTION
> 🤖 **Automated implementer agent** — *this comment was posted by the implementer bot from Docker Agentic Platform, not by a human developer*

Stacked on PR #4062. Base retargets to `main` once that merges.

Refs #4060 (partial — A2A pacing and LSP crash-loop pacing deferred; see below)

## What

Remote MCP servers responding with 503/429/5xx during the initialize handshake previously triggered a fresh connect attempt on every agent turn (the #4060 burst pattern). This PR fixes that by wrapping the HTTP status from the remote server in a `*modelerrors.StatusError` so the `StartableToolSet` backoff gate arming logic can pace retries — including a server-supplied `Retry-After` hint, and correctly for responses with no body.

## Design

**Wrap point — `enrichConnectError` in `pkg/tools/mcp/remote.go`.** The `oauthTransport` already records the last HTTP error status via `logErrorResponse` (for any `>= 400` response). `enrichConnectError` wraps that status (regardless of whether the response carried a body — many rate-limit/load-balancer responses don't) via `modelerrors.WrapHTTPError`, surfacing it as a `*StatusError` in the chain.

**Retry-After is honored.** `pkg/tools/mcp/oauth.go`'s `oauthTransport` now also captures the raw `Retry-After` header value alongside the status/body it already tracked. `lastServerErrorSnapshot()` reads status, message, and Retry-After together under a single lock (not three separate accessor calls) so a caller can never pair a status from one response with a Retry-After header captured from a different concurrent response on the same transport — this transport's `RoundTrip` can run concurrently for one logical connect attempt (e.g. a standalone SSE probe racing the initialize call). `enrichConnectError` builds a minimal `*http.Response` carrying that header and passes it to `WrapHTTPError`, matching the handling already in place for model-provider adapters (PR #4062).

**What arms the gate.** `startBackoffRetryable` checks for a `*modelerrors.StatusError` with a retryable HTTP status (429/408/5xx) via `errors.As` — exactly as it already does for RAG embedding failures. No regex heuristics; no new classification logic in the gate itself.

**What does NOT arm (unchanged policy):**
- Local stdio MCP spawn failures (missing binary, connection refused) — never reach `enrichConnectError`.
- 4xx client errors (400/401/403) — wrapped in `*StatusError` for structured access but `RetryableHTTPStatus` returns false → fail promptly.
- Auth paths (`oauthDeclined`, `authorizationRequired`) — handled by their own early-return paths before the status branch; unaffected.
- `lifecycle.ErrServerUnavailable`, `ErrTransport`, `ErrAuthRequired`, `ErrInitTimeout`, `ErrSessionMissing` — the gate classifier explicitly excludes all of these.

**Deferred:**
- A2A pacing: the agent-card resolver does not cleanly expose HTTP status in its error chain; deferred to a follow-up.
- LSP crash-loop pacing: `lifecycle.ErrServerCrashed` is produced only inside `lspSession.Wait()` which flows to the supervisor's internal watcher, not to `supervisor.Start()`. The gate never sees it via the current error propagation path; deferred.

## Changed files

| File | What changed |
|---|---|
| `pkg/tools/mcp/remote.go` | `enrichConnectError`: wrap on status alone (not gated on a non-empty body); forwards `Retry-After` via a minimal synthetic `*http.Response` |
| `pkg/tools/mcp/oauth.go` | `oauthTransport` captures the raw `Retry-After` header; new `lastServerErrorSnapshot()` reads status/message/Retry-After together under one lock |
| `pkg/tools/startable_backoff.go` | Classifier doc comment: complete excluded-sentinel list (adds `ErrInitTimeout`, `ErrSessionMissing`), notes the deferred LSP crash-loop path |
| `pkg/tools/mcp/remote_test.go` | 8 tests: 503/429/500 → retryable `*StatusError`; 403 → non-retryable; empty-body 503/429 still arm; `Retry-After` present/absent; end-to-end `TestBackoffGate_*` driving a real `NewRemoteToolset` through `tools.StartableToolSet.TryStart` |
| `pkg/tools/startable_backoff_test.go` | 4 tests: lifecycle sentinels (`ErrServerUnavailable`, `ErrTransport`, `ErrAuthRequired`) do NOT arm the gate; 4xx `StatusError` does NOT arm the gate |
| `docs/tools/mcp/index.md` | Startup-failure note: remote MCP 5xx/429 now paced |
| `docs/tools/lsp/index.md` | Startup-failure note: crash-loop pacing not yet in place; supervisor policy is the throttle |