### PR TITLE
feat: add assertions schema to EvalCriteria for code-based grading

### DIFF
--- a/pkg/session/branch.go
+++ b/pkg/session/branch.go
@@ -328,6 +328,7 @@ func cloneEvalCriteria(src *EvalCriteria) *EvalCriteria {
 	}
 	cp := *src
 	cp.Relevance = cloneStringSlice(src.Relevance)
+	cp.Assertions = slices.Clone(src.Assertions)
 	return &cp
 }
 
@@ -360,6 +361,15 @@ func cloneEvalResultChecks(src EvalResultChecks) EvalResultChecks {
 		relevance := *src.Relevance
 		relevance.Results = slices.Clone(src.Relevance.Results)
 		cp.Relevance = &relevance
+	}
+	if src.Assertions != nil {
+		assertions := *src.Assertions
+		assertions.Results = slices.Clone(src.Assertions.Results)
+		cp.Assertions = &assertions
+	}
+	if src.Verify != nil {
+		verify := *src.Verify
+		cp.Verify = &verify
 	}
 	return cp
 }

--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -638,9 +638,11 @@ type EvalResult struct {
 // EvalResultChecks groups the individual check results.
 // Only checks that were evaluated will be present (omitted if nil).
 type EvalResultChecks struct {
-	Size      *SizeCheck      `json:"size,omitempty"`
-	ToolCalls *ToolCallsCheck `json:"tool_calls,omitempty"`
-	Relevance *RelevanceCheck `json:"relevance,omitempty"`
+	Size       *SizeCheck       `json:"size,omitempty"`
+	ToolCalls  *ToolCallsCheck  `json:"tool_calls,omitempty"`
+	Relevance  *RelevanceCheck  `json:"relevance,omitempty"`
+	Assertions *AssertionsCheck `json:"assertions,omitempty"`
+	Verify     *VerifyCheck     `json:"verify,omitempty"`
 }
 
 // SizeCheck contains the result of the response size check.
@@ -671,13 +673,51 @@ type RelevanceCriterionResult struct {
 	Reason    string `json:"reason,omitempty"`
 }
 
+// AssertionsCheck contains the results of code-based assertion evaluations.
+type AssertionsCheck struct {
+	Passed      bool              `json:"passed"`
+	PassedCount int               `json:"passed_count"`
+	Total       int               `json:"total"`
+	Results     []AssertionResult `json:"results"`
+}
+
+// AssertionResult records the outcome of a single assertion.
+type AssertionResult struct {
+	Name   string `json:"name"`
+	Type   string `json:"type"`
+	Passed bool   `json:"passed"`
+	Reason string `json:"reason,omitempty"`
+}
+
+// VerifyCheck contains the result of the post-agent verify script.
+type VerifyCheck struct {
+	Passed   bool   `json:"passed"`
+	ExitCode int    `json:"exit_code"`
+	Output   string `json:"output,omitempty"`
+}
+
 // EvalCriteria contains the evaluation criteria for a session.
 type EvalCriteria struct {
-	Relevance  []string `json:"relevance"`             // Statements that should be true about the response
-	WorkingDir string   `json:"working_dir,omitempty"` // Subdirectory under evals/working_dirs/
-	Size       string   `json:"size,omitempty"`        // Expected response size: S, M, L, XL
-	Setup      string   `json:"setup,omitempty"`       // Optional sh script to run in the container before docker agent run --exec
-	Image      string   `json:"image,omitempty"`       // Custom Docker image for this eval (overrides --base-image)
+	Relevance  []string    `json:"relevance"`             // Statements that should be true about the response
+	Assertions []Assertion `json:"assertions,omitempty"`  // Code-based assertions evaluated against the agent output
+	Verify     string      `json:"verify,omitempty"`      // Shell script for post-agent outcome verification
+	WorkingDir string      `json:"working_dir,omitempty"` // Subdirectory under evals/working_dirs/
+	Size       string      `json:"size,omitempty"`        // Expected response size: S, M, L, XL
+	Setup      string      `json:"setup,omitempty"`       // Optional sh script to run in the container before docker agent run --exec
+	Image      string      `json:"image,omitempty"`       // Custom Docker image for this eval (overrides --base-image)
+}
+
+// Assertion defines a single code-based grading check evaluated against agent output.
+type Assertion struct {
+	// Name identifies this assertion in logs and results.
+	Name string `json:"name"`
+	// Type selects the evaluator: "contains", "not_contains", "equals",
+	// "starts_with", "ends_with", "regex", "json_path", "cost_threshold",
+	// or "tool_called".
+	Type string `json:"type"`
+	// Value is the expected string, regex pattern, JSONPath expression, or
+	// threshold against which the agent output is checked.
+	Value string `json:"value"`
 }
 
 // UnmarshalJSON implements custom JSON unmarshaling for EvalCriteria that

--- a/pkg/session/session_test.go
+++ b/pkg/session/session_test.go
@@ -513,6 +513,22 @@ func TestEvalCriteriaUnmarshalJSON(t *testing.T) {
 			},
 		},
 		{
+			name:  "valid with assertions",
+			input: `{"relevance":[],"assertions":[{"name":"has greeting","type":"contains","value":"hello"}]}`,
+			want: EvalCriteria{
+				Relevance:  []string{},
+				Assertions: []Assertion{{Name: "has greeting", Type: "contains", Value: "hello"}},
+			},
+		},
+		{
+			name:  "valid with verify",
+			input: `{"relevance":[],"verify":"test -f output.txt"}`,
+			want: EvalCriteria{
+				Relevance: []string{},
+				Verify:    "test -f output.txt",
+			},
+		},
+		{
 			name:  "empty object",
 			input: `{}`,
 			want:  EvalCriteria{},


### PR DESCRIPTION
## Summary

Add code-based assertion support to the evaluation criteria schema, enabling declarative grading checks that run against agent output without requiring an LLM judge.

## Changes

### `pkg/session/session.go`
- **`Assertion` struct** — `Name`, `Type`, `Value` fields for declarative checks. Supported types: `contains`, `not_contains`, `equals`, `starts_with`, `ends_with`, `regex`, `cost_threshold`, `tool_called`.
- **`Assertions` field** on `EvalCriteria` — optional list of code-based assertions.
- **`Verify` field** on `EvalCriteria` — optional shell script for post-agent outcome verification.
- **`AssertionsCheck`** — result type with passed/total counts and per-assertion results.
- **`AssertionResult`** — individual assertion outcome (name, type, passed, reason).
- **`VerifyCheck`** — verify script result (passed, exit_code, output).
- Added both to `EvalResultChecks`.

### `pkg/session/branch.go`
- Updated `cloneEvalCriteria` to deep-clone the `Assertions` slice.
- Updated `cloneEvalResultChecks` to deep-clone `AssertionsCheck` and `VerifyCheck`.

### `pkg/session/session_test.go`
- Added test cases for JSON unmarshaling of assertions and verify fields.

## Example eval JSON

```json
{
  "evals": {
    "relevance": ["The agent created the file"],
    "assertions": [
      {"name": "mentions file", "type": "contains", "value": "hello.txt"},
      {"name": "used write tool", "type": "tool_called", "value": "write_file"},
      {"name": "cost under budget", "type": "cost_threshold", "value": "0.50"}
    ],
    "verify": "test -f /workspace/hello.txt"
  }
}
```

Closes #4082