### PR TITLE
fix(tui): stabilize slash command description alignment

### DIFF
--- a/pkg/tui/components/completion/completion.go
+++ b/pkg/tui/components/completion/completion.go
@@ -340,13 +340,7 @@ func (c *manager) View() string {
 		visibleStart := c.scrollOffset
 		visibleEnd := min(c.scrollOffset+maxItems, len(c.filteredItems))
 
-		maxLabelLen := 0
-		for i := visibleStart; i < visibleEnd; i++ {
-			labelLen := lipgloss.Width(c.filteredItems[i].Label)
-			if labelLen > maxLabelLen {
-				maxLabelLen = labelLen
-			}
-		}
+		maxLabelLen := c.labelColumnWidth()
 
 		for i := visibleStart; i < visibleEnd; i++ {
 			item := c.filteredItems[i]
@@ -387,6 +381,14 @@ func (c *manager) View() string {
 
 	content := lipgloss.JoinVertical(lipgloss.Left, lines...)
 	return styles.CompletionBoxStyle.Render(content)
+}
+
+func (c *manager) labelColumnWidth() int {
+	width := 0
+	for _, item := range c.items {
+		width = max(width, lipgloss.Width(item.Label))
+	}
+	return width
 }
 
 func (c *manager) GetLayers() []*lipgloss.Layer {

--- a/pkg/tui/components/completion/completion_test.go
+++ b/pkg/tui/components/completion/completion_test.go
@@ -2,12 +2,44 @@ package completion
 
 import (
 	"reflect"
+	"strings"
 	"testing"
 
 	tea "charm.land/bubbletea/v2"
+	"github.com/charmbracelet/x/ansi"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestCompletionLabelColumnWidthIsStableWhileFiltering(t *testing.T) {
+	t.Parallel()
+	m := New().(*manager)
+	m.width = 80
+	m.Update(OpenMsg{Items: []Item{
+		{Label: "Short", Description: "Short description"},
+		{Label: "Much Longer Command", Description: "Long description"},
+	}})
+
+	fullLine := completionLine(t, m.View(), "Short")
+	fullDescriptionColumn := strings.Index(fullLine, "Short description")
+	require.Positive(t, fullDescriptionColumn)
+
+	m.Update(QueryMsg{Query: "short"})
+	filteredLine := completionLine(t, m.View(), "Short")
+
+	assert.Equal(t, fullDescriptionColumn, strings.Index(filteredLine, "Short description"))
+}
+
+func completionLine(t *testing.T, view, label string) string {
+	t.Helper()
+	for line := range strings.SplitSeq(ansi.Strip(view), "\n") {
+		if strings.Contains(line, label) {
+			return line
+		}
+	}
+	require.FailNow(t, "completion line not found", label)
+	return ""
+}
 
 func TestCompletionManagerStaysOpenWithNoResults(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
## Summary

- size the completion label column from the complete item set
- keep slash-command descriptions aligned while filtering
- add regression coverage for stable description positioning

## Validation

- `go test ./pkg/tui/components/completion`
- `go test ./pkg/tui/components/editor/... ./pkg/tui/components/completion`
- `go vet ./pkg/tui/components/completion`
- `task build`