### PR TITLE
feat: upgrade relevance judge prompt with rubric, CoT, and anti-bias rules

### DIFF
--- a/pkg/evaluation/judge.go
+++ b/pkg/evaluation/judge.go
@@ -17,19 +17,37 @@ import (
 )
 
 // relevancePrompt is the prompt template for the judge model to evaluate responses.
-const relevancePrompt = `You are an evaluation judge. Check if the response matches the given relevance criteria.
+// It uses a rubric-driven, chain-of-thought approach with anti-bias rules to
+// produce consistent and fair relevance judgments.
+const relevancePrompt = `You are a strict evaluation judge grading an AI agent's output against a specific criterion.
+
+Your task:
+1. Read the response carefully.
+2. Read the criterion.
+3. Think step-by-step (chain of thought) about whether the response satisfies the criterion.
+4. Produce your verdict.
+
+Rubric:
+- "pass": The response clearly and fully satisfies the criterion.
+- "fail": The response does not satisfy the criterion, or only partially satisfies it.
+
+Anti-bias rules:
+- Evaluate ONLY the criterion given. Do not reward or penalize unrelated qualities.
+- Ignore response length, politeness, or formatting unless the criterion explicitly requires them.
+- Do not give credit for effort or partial answers — the criterion is binary.
+- Evaluate the substance, not the style.
 
 Response to evaluate:
 <response>
 %s
 </response>
 
-Criteria to check:
+Criterion to check:
 <criteria>
 %s
 </criteria>
 
-Evaluate whether the response satisfies the criteria and respond with your judgment.`
+Think step-by-step, then respond with your judgment.`
 
 // judgeResponseSchema defines the JSON schema for structured output from the judge model.
 var judgeResponseSchema = &latest.StructuredOutput{


### PR DESCRIPTION
## Summary

Replace the minimal relevance judge prompt with a structured evaluation prompt that produces more consistent and fair judgments across eval runs.

## Problem

The existing prompt (`You are an evaluation judge. Check if the response matches the given relevance criteria.`) gives the judge model too little guidance, leading to:

- **Leniency bias** — partial answers or tangentially related responses get a pass
- **Style bias** — long, polite, or well-formatted responses are favored over concise correct ones
- **Inconsistency** — the same criterion can produce different verdicts across runs without clear reasoning

## Changes

### `pkg/evaluation/judge.go`

Replaced the prompt with a rubric-driven, chain-of-thought template:

| Aspect | Before | After |
|--------|--------|-------|
| Rubric | None | Explicit pass ("clearly and fully satisfies") / fail ("does not or only partially satisfies") |
| Reasoning | "Evaluate whether..." | Step-by-step CoT: read → analyze → reason → verdict |
| Anti-bias | None | 4 rules: criterion-only evaluation, ignore length/politeness/formatting, no partial credit, substance over style |

The structured-output JSON schema (`{"result": "pass"/"fail", "reason": "..."}`) is **unchanged** — this is a prompt-only change.

## Testing

All existing tests pass unchanged — the prompt upgrade does not alter the response format or parsing logic.

Closes #4084