### PR TITLE
feat: expose pass@k and pass^k metrics for --repeat runs

### DIFF
--- a/pkg/evaluation/eval.go
+++ b/pkg/evaluation/eval.go
@@ -84,6 +84,7 @@ func Evaluate(ctx context.Context, ttyOut, out io.Writer, isTTY bool, runName st
 	duration := time.Since(startTime)
 
 	summary := computeSummary(results)
+	summary.RepeatMetrics = computeRepeatMetrics(results, cfg.Repeat)
 	printSummary(out, summary, duration)
 
 	run := &EvalRun{

--- a/pkg/evaluation/eval_test.go
+++ b/pkg/evaluation/eval_test.go
@@ -1387,3 +1387,101 @@ func TestBuildTranscriptBudgetTermination(t *testing.T) {
 		assert.NotContains(t, transcript, "intruder")
 	})
 }
+
+func TestComputeRepeatMetrics_NilForSingleRun(t *testing.T) {
+	t.Parallel()
+	assert.Nil(t, computeRepeatMetrics(nil, 1))
+	assert.Nil(t, computeRepeatMetrics(nil, 0))
+	assert.Nil(t, computeRepeatMetrics([]Result{}, 3))
+}
+
+func TestComputeRepeatMetrics_AllPassEveryTime(t *testing.T) {
+	t.Parallel()
+	results := []Result{
+		{InputPath: "a.json", SizeExpected: "M", Size: "M"},
+		{InputPath: "a.json", SizeExpected: "M", Size: "M"},
+		{InputPath: "b.json", SizeExpected: "S", Size: "S"},
+		{InputPath: "b.json", SizeExpected: "S", Size: "S"},
+	}
+	m := computeRepeatMetrics(results, 2)
+	require.NotNil(t, m)
+	assert.Equal(t, 2, m.K)
+	assert.Equal(t, 2, m.Total)
+	assert.InDelta(t, 1.0, m.PassK, 1e-9)
+	assert.InDelta(t, 1.0, m.HatK, 1e-9)
+}
+
+func TestComputeRepeatMetrics_FlakyEval(t *testing.T) {
+	t.Parallel()
+	results := []Result{
+		{InputPath: "a.json", SizeExpected: "M", Size: "M"}, // pass
+		{InputPath: "a.json", SizeExpected: "M", Size: "S"}, // fail
+	}
+	m := computeRepeatMetrics(results, 2)
+	require.NotNil(t, m)
+	assert.InDelta(t, 1.0, m.PassK, 1e-9, "pass@k: passed at least once")
+	assert.InDelta(t, 0.0, m.HatK, 1e-9, "pass^k: did not pass every time")
+}
+
+func TestComputeRepeatMetrics_NeverPasses(t *testing.T) {
+	t.Parallel()
+	results := []Result{
+		{InputPath: "a.json", SizeExpected: "M", Size: "S"},
+		{InputPath: "a.json", SizeExpected: "M", Size: "S"},
+	}
+	m := computeRepeatMetrics(results, 2)
+	require.NotNil(t, m)
+	assert.InDelta(t, 0.0, m.PassK, 1e-9)
+	assert.InDelta(t, 0.0, m.HatK, 1e-9)
+}
+
+func TestComputeRepeatMetrics_MixedEvals(t *testing.T) {
+	t.Parallel()
+	// 3 unique evals repeated 2 times:
+	// a: pass, pass  → anyPass=true, allPass=true
+	// b: pass, fail  → anyPass=true, allPass=false
+	// c: fail, fail  → anyPass=false, allPass=false
+	results := []Result{
+		{InputPath: "a.json"},
+		{InputPath: "a.json"},
+		{InputPath: "b.json", SizeExpected: "M", Size: "M"},
+		{InputPath: "b.json", SizeExpected: "M", Size: "S"},
+		{InputPath: "c.json", Error: "boom"},
+		{InputPath: "c.json", Error: "boom"},
+	}
+	m := computeRepeatMetrics(results, 2)
+	require.NotNil(t, m)
+	assert.Equal(t, 3, m.Total)
+	assert.InDelta(t, 2.0/3.0, m.PassK, 1e-9, "2 of 3 evals passed at least once")
+	assert.InDelta(t, 1.0/3.0, m.HatK, 1e-9, "1 of 3 evals passed every time")
+}
+
+func TestPrintSummary_WithRepeatMetrics(t *testing.T) {
+	t.Parallel()
+	summary := Summary{
+		TotalEvals: 6,
+		RepeatMetrics: &RepeatMetrics{
+			K:     3,
+			PassK: 1.0,
+			HatK:  0.5,
+			Total: 2,
+		},
+	}
+	var buf bytes.Buffer
+	printSummary(&buf, summary, time.Minute)
+	output := buf.String()
+	assert.Contains(t, output, "pass@3")
+	assert.Contains(t, output, "pass^3")
+	assert.Contains(t, output, "100.0%")
+	assert.Contains(t, output, "50.0%")
+}
+
+func TestPrintSummary_NoRepeatMetricsWhenNil(t *testing.T) {
+	t.Parallel()
+	summary := Summary{TotalEvals: 2}
+	var buf bytes.Buffer
+	printSummary(&buf, summary, time.Minute)
+	output := buf.String()
+	assert.NotContains(t, output, "pass@")
+	assert.NotContains(t, output, "Repeat")
+}

--- a/pkg/evaluation/scoring.go
+++ b/pkg/evaluation/scoring.go
@@ -105,6 +105,13 @@ func printSummary(out io.Writer, summary Summary, duration time.Duration) {
 	printF1Score(out, "Tool Calls", summary.ToolsF1Sum, summary.ToolsCount)
 	printMetric(out, "Relevance", int(summary.RelevancePassed), int(summary.RelevanceTotal))
 
+	if summary.RepeatMetrics != nil {
+		rm := summary.RepeatMetrics
+		fmt.Fprintf(out, "\n  Repeat metrics (k=%d, %d unique evals):\n", rm.K, rm.Total)
+		fmt.Fprintf(out, "   pass@%d: %.1f%% (passed at least once)\n", rm.K, rm.PassK*100)
+		fmt.Fprintf(out, "   pass^%d: %.1f%% (passed every time)\n", rm.K, rm.HatK*100)
+	}
+
 	fmt.Fprintf(out, "\nTotal Cost: $%.6f\n", summary.TotalCost)
 	fmt.Fprintf(out, "Total Time: %s\n", duration.Round(time.Second))
 }
@@ -133,5 +140,55 @@ func statusIcon(ratio float64) string {
 		return "⚠️"
 	default:
 		return "❌"
+	}
+}
+
+// computeRepeatMetrics derives pass@k and pass^k from repeated evaluation
+// results. Results are grouped by InputPath (the source eval file); k is
+// the configured repetition count.
+func computeRepeatMetrics(results []Result, k int) *RepeatMetrics {
+	if k <= 1 {
+		return nil
+	}
+
+	type evalStats struct {
+		passed int
+		total  int
+	}
+	byEval := map[string]*evalStats{}
+	for _, r := range results {
+		key := r.InputPath
+		s, ok := byEval[key]
+		if !ok {
+			s = &evalStats{}
+			byEval[key] = s
+		}
+		s.total++
+		_, failures := r.checkResults()
+		if len(failures) == 0 {
+			s.passed++
+		}
+	}
+
+	if len(byEval) == 0 {
+		return nil
+	}
+
+	var anyPass, allPass int
+	for _, s := range byEval {
+		if s.passed > 0 {
+			anyPass++
+		}
+		if s.passed == s.total {
+			allPass++
+		}
+	}
+
+	total := len(byEval)
+	return &RepeatMetrics{
+		K:     k,
+		PassK: float64(anyPass) / float64(total),
+		HatK:  float64(allPass) / float64(total),
+		Total: total,
 	}
 }

--- a/pkg/evaluation/types.go
+++ b/pkg/evaluation/types.go
@@ -108,6 +108,9 @@ type Summary struct {
 	ToolsCount      int     `json:"tools_count"`
 	RelevancePassed float64 `json:"relevance_passed"`
 	RelevanceTotal  float64 `json:"relevance_total"`
+
+	// RepeatMetrics is populated only when --repeat > 1.
+	RepeatMetrics *RepeatMetrics `json:"repeat_metrics,omitempty"`
 }
 
 // EvalRun contains the results and metadata for an evaluation run.
@@ -158,6 +161,20 @@ type Config struct {
 // DefaultContainerRuntime is the container runtime executable used when
 // Config.ContainerRuntime is empty, keeping the historical Docker behavior.
 const DefaultContainerRuntime = "docker"
+
+// RepeatMetrics captures pass@k and pass^k statistics when --repeat > 1.
+//
+//   - pass@k: fraction of unique evaluations that passed at least once across
+//     k repetitions ("any pass"). Measures whether the agent can produce the
+//     correct answer at all.
+//   - pass^k: fraction of unique evaluations that passed every repetition
+//     ("all pass"). Measures determinism / reliability.
+type RepeatMetrics struct {
+	K     int     `json:"k"`
+	PassK float64 `json:"pass_at_k"`  // any-pass rate
+	HatK  float64 `json:"pass_hat_k"` // all-pass rate
+	Total int     `json:"total"`      // number of unique evaluations
+}
 
 // containerRuntimeOrDefault returns the container runtime executable to
 // invoke, falling back to DefaultContainerRuntime when none is configured.


### PR DESCRIPTION
## Summary

When `--repeat k` is greater than 1, compute and display two consistency metrics that quantify how reliable the agent's answers are across repeated runs of the same evaluation.

## Metrics

| Metric | Meaning | Use case |
|--------|---------|----------|
| **pass@k** | Fraction of unique evals that passed **at least once** across k repetitions | Can the agent produce the correct answer at all? |
| **pass^k** | Fraction of unique evals that passed **every** repetition | Is the agent deterministic / reliable? |

Example output:
```
  Repeat metrics (k=3, 10 unique evals):
   pass@3: 90.0% (passed at least once)
   pass^3: 60.0% (passed every time)
```

## Changes

### `pkg/evaluation/types.go`
- `RepeatMetrics` struct — K, PassK (any-pass rate), HatK (all-pass rate), Total (unique eval count)
- `Summary.RepeatMetrics` — populated only when `--repeat > 1`

### `pkg/evaluation/scoring.go`
- `computeRepeatMetrics()` — groups results by `InputPath`, counts any-pass and all-pass per unique eval
- Updated `printSummary()` — prints the repeat block when metrics are present

### `pkg/evaluation/eval.go`
- Wires `computeRepeatMetrics(results, cfg.Repeat)` into the `Evaluate()` pipeline

### `pkg/evaluation/eval_test.go`
- All-pass, flaky, never-pass, mixed, and nil cases for `computeRepeatMetrics`
- `printSummary` rendering with and without repeat metrics

Closes #4085