### PR TITLE
fix(skills): let inline skills override discovered ones

### DIFF
--- a/docs/features/skills/index.md
+++ b/docs/features/skills/index.md
@@ -95,7 +95,7 @@ agents:
       - type: filesystem
 ```
 
-Inline skills carry their body in the config itself, so they need no `SKILL.md` file and require no filesystem source. They are **always exposed** — the name filter only applies to file- and URL-based skills. Because inline skills travel inside the agent YAML, they also work in `--sandbox` mode without any kit staging, and they can be shared with the agent via `share push`.
+Inline skills carry their body in the config itself, so they need no `SKILL.md` file and require no filesystem source. They are **always exposed** — the name filter only applies to file- and URL-based skills. An inline skill also **takes precedence** over a discovered skill of the same name: the config is explicit, whereas local skills are picked up from whatever happens to sit in the [search paths](#search-paths). The shadowed skill is dropped and a warning is logged at startup. Because inline skills travel inside the agent YAML, they also work in `--sandbox` mode without any kit staging, and they can be shared with the agent via `share push`.
 
 ### Inline Skill Fields
 
@@ -339,6 +339,7 @@ When multiple skills share the same name:
 2. Project skills load next, from git root toward current directory
 3. Skills closer to the current directory override those further away
 4. At the same directory level, `.agents/skills/` overrides `.github/skills/`
+5. An [inline skill](#inline-skills) overrides any discovered skill of the same name
 
 ## Skills in Sandbox Mode
 

--- a/pkg/teamloader/skills_filter_test.go
+++ b/pkg/teamloader/skills_filter_test.go
@@ -107,6 +107,68 @@ func TestInlineSkills_Empty(t *testing.T) {
 	assert.Nil(t, inlineSkills(nil))
 }
 
+func TestOverrideWithInlineSkills_NoInlineKeepsLoaded(t *testing.T) {
+	t.Parallel()
+	loaded := []skills.Skill{{Name: "git"}, {Name: "docker"}}
+
+	assert.Equal(t, loaded, overrideWithInlineSkills(loaded, nil))
+}
+
+func TestOverrideWithInlineSkills_InlineWinsOverDiscovered(t *testing.T) {
+	t.Parallel()
+	// A discovered skill sharing a name with an inline one must be dropped,
+	// not merely appended after it: otherwise the model sees the name twice
+	// and lookups resolve to the discovered skill.
+	loaded := []skills.Skill{
+		{Name: "commit", Description: "from disk", FilePath: "/skills/commit/SKILL.md", Local: true},
+		{Name: "docker", Description: "from disk", Local: true},
+	}
+	inline := []skills.Skill{{Name: "commit", Description: "from config", InlineContent: "body"}}
+
+	result := overrideWithInlineSkills(loaded, inline)
+
+	require.Len(t, result, 2)
+	assert.Equal(t, "docker", result[0].Name)
+	assert.Equal(t, "commit", result[1].Name)
+	assert.Equal(t, "from config", result[1].Description)
+	assert.True(t, result[1].IsInline())
+}
+
+func TestOverrideWithInlineSkills_DropsEveryShadowedDuplicate(t *testing.T) {
+	t.Parallel()
+	// skills.Load keys local and remote skills separately, so the same name can
+	// appear more than once. An inline definition must displace all of them.
+	loaded := []skills.Skill{
+		{Name: "git", Description: "local", Local: true},
+		{Name: "git", Description: "remote"},
+	}
+	inline := []skills.Skill{{Name: "git", Description: "inline", InlineContent: "body"}}
+
+	result := overrideWithInlineSkills(loaded, inline)
+
+	require.Len(t, result, 1)
+	assert.Equal(t, "inline", result[0].Description)
+}
+
+func TestOverrideWithInlineSkills_DisjointNamesAreConcatenated(t *testing.T) {
+	t.Parallel()
+	loaded := []skills.Skill{{Name: "git", Local: true}}
+	inline := []skills.Skill{{Name: "changelog", InlineContent: "body"}}
+
+	result := overrideWithInlineSkills(loaded, inline)
+
+	require.Len(t, result, 2)
+	assert.Equal(t, "git", result[0].Name)
+	assert.Equal(t, "changelog", result[1].Name)
+}
+
+func TestOverrideWithInlineSkills_NoLoadedSkills(t *testing.T) {
+	t.Parallel()
+	inline := []skills.Skill{{Name: "changelog", InlineContent: "body"}}
+
+	assert.Equal(t, inline, overrideWithInlineSkills(nil, inline))
+}
+
 func TestFilterSkillsByName_KeepsAllDuplicateNameMatches(t *testing.T) {
 	t.Parallel()
 	// The loaded slice may contain multiple skills with the same name (e.g. one

--- a/pkg/teamloader/teamloader.go
+++ b/pkg/teamloader/teamloader.go
@@ -405,7 +405,7 @@ func LoadWithConfig(ctx context.Context, agentSource config.Source, runConfig *c
 			loadedSkills = filterSkillsByName(loadedSkills, agentConfig.Skills.Include)
 			// Inline skills are defined in the agent config itself; they are
 			// always exposed and never subject to the include filter.
-			loadedSkills = append(loadedSkills, inlineSkills(agentConfig.Skills.Inline)...)
+			loadedSkills = overrideWithInlineSkills(loadedSkills, inlineSkills(agentConfig.Skills.Inline))
 			if len(loadedSkills) > 0 {
 				skillSet := skillstool.New(loadedSkills, workingDir)
 				// Resolve the additional toolsets each fork skill exposes in
@@ -883,6 +883,33 @@ func inlineSkills(defs []latest.InlineSkill) []skills.Skill {
 		})
 	}
 	return out
+}
+
+// overrideWithInlineSkills folds inline skills into the discovered ones,
+// letting an inline definition win over a file- or URL-loaded skill of the
+// same name: the agent config is explicit, while local skills are picked up
+// from whatever happens to sit in the search paths. Appending blindly would
+// leave the shadowed skill advertised to the model — the same name listed
+// twice, with lookups resolving to the discovered one.
+func overrideWithInlineSkills(loaded, inline []skills.Skill) []skills.Skill {
+	if len(inline) == 0 {
+		return loaded
+	}
+
+	inlined := make(map[string]bool, len(inline))
+	for _, s := range inline {
+		inlined[s.Name] = true
+	}
+
+	merged := make([]skills.Skill, 0, len(loaded)+len(inline))
+	for _, s := range loaded {
+		if inlined[s.Name] {
+			slog.Warn("Inline skill overrides a discovered skill with the same name", "name", s.Name, "path", s.FilePath)
+			continue
+		}
+		merged = append(merged, s)
+	}
+	return append(merged, inline...)
 }
 
 // forkSkillToolSets builds, for each fork skill that declares toolsets, the


### PR DESCRIPTION
When an agent YAML defines skills inline under `skills:` *and* the filesystem or URL discovery finds a skill with the same name, the discovered skill was appended before the inline one in `pkg/teamloader/teamloader.go`. Because `findSkill` returns the first name match, the discovered `SKILL.md` always won every lookup. Worse, both entries were advertised to the model in the system prompt under the same name but with conflicting descriptions, with no warning logged.

The fix introduces `overrideWithInlineSkills()` in `pkg/teamloader/teamloader.go`. It drops any discovered skill whose name collides with an inline definition and logs a warning, so inline skills win unambiguously. Surviving discovered skills keep their relative order; inline skills are appended in config order. This makes runtime behaviour consistent with `mergeSkills()` in `pkg/config/skills.go`, whose doc comment already stated "the agent's inline skill wins" for skill-group merging.

The docs in `docs/features/skills/index.md` are updated to document the precedence rule explicitly. Tests in `pkg/teamloader/skills_filter_test.go` cover the no-inline, override, all-duplicates-dropped, disjoint, and empty-discovered cases.