### PR TITLE
fix(skills): reject whitespace in inline skill names

### DIFF
--- a/agent-schema.json
+++ b/agent-schema.json
@@ -991,7 +991,8 @@
       "properties": {
         "name": {
           "type": "string",
-          "description": "Skill identifier used by read_skill / run_skill and the /<name> slash command."
+          "pattern": "^\\S+$",
+          "description": "Skill identifier used by read_skill / run_skill and the /<name> slash command. Must not contain whitespace, which the slash command parser uses to separate the name from its argument."
         },
         "description": {
           "type": "string",

--- a/docs/features/skills/index.md
+++ b/docs/features/skills/index.md
@@ -101,7 +101,7 @@ Inline skills carry their body in the config itself, so they need no `SKILL.md` 
 
 | Field           | Required | Description                                                                |
 | --------------- | -------- | -------------------------------------------------------------------------- |
-| `name`          | Yes      | Skill identifier used by `read_skill` / `run_skill` and the `/<name>` command |
+| `name`          | Yes      | Skill identifier used by `read_skill` / `run_skill` and the `/<name>` command. Must not contain whitespace |
 | `description`   | Yes      | Short description shown to the agent for skill matching                    |
 | `instructions`  | Yes      | The skill body (what a `SKILL.md` would contain below its frontmatter)     |
 | `context`       | No       | Set to `fork` to run the skill as an isolated sub-agent                    |

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -13,6 +13,7 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+	"unicode"
 
 	"github.com/goccy/go-yaml"
 
@@ -547,6 +548,12 @@ func validateSkills(label string, sc *latest.SkillsConfig) error {
 		inline := &sc.Inline[i]
 		if strings.TrimSpace(inline.Name) == "" {
 			return fmt.Errorf("%s has an inline skill with no name", label)
+		}
+		// The name doubles as the `/<name>` slash command, whose parser splits
+		// the input on the first space, so whitespace here would silently
+		// produce a skill that command can never reach.
+		if strings.ContainsFunc(inline.Name, unicode.IsSpace) {
+			return fmt.Errorf("%s inline skill '%s' must not have whitespace in its name: it doubles as the /%s command", label, inline.Name, inline.Name)
 		}
 		if strings.TrimSpace(inline.Description) == "" {
 			return fmt.Errorf("%s inline skill '%s' is missing a description", label, inline.Name)

--- a/pkg/config/skills_config_test.go
+++ b/pkg/config/skills_config_test.go
@@ -503,3 +503,47 @@ func TestSkillsConfig_UnmarshalResetsReceiver(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, []string{"https://new.example.com"}, skills.Sources)
 }
+
+func TestValidateSkills_InlineSkillName(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name      string
+		skillName string
+		wantErr   string
+	}{
+		{name: "simple", skillName: "changelog"},
+		{name: "dashes and underscores", skillName: "bump-go_deps"},
+		{name: "digits and dots", skillName: "v2.check"},
+		// Only whitespace breaks the slash command; the rest resolve fine both
+		// as /<name> and through read_skill, so they stay valid.
+		{name: "non ascii", skillName: "café"},
+		{name: "colon", skillName: "release:v2"},
+		{name: "leading dot", skillName: ".hidden"},
+		{name: "empty", skillName: "", wantErr: "has an inline skill with no name"},
+		{name: "blank", skillName: "   ", wantErr: "has an inline skill with no name"},
+		{name: "space", skillName: "code review", wantErr: "must not have whitespace in its name"},
+		{name: "tab", skillName: "code\treview", wantErr: "must not have whitespace in its name"},
+		{name: "trailing space", skillName: "review ", wantErr: "must not have whitespace in its name"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			sc := latest.SkillsConfig{
+				Inline: []latest.InlineSkill{{
+					Name:         tt.skillName,
+					Description:  "A skill.",
+					Instructions: "Do the thing.",
+				}},
+			}
+
+			err := validateSkills("agent 'root'", &sc)
+			if tt.wantErr == "" {
+				require.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.wantErr)
+		})
+	}
+}


### PR DESCRIPTION
An inline skill's `name` doubles as its `/<name>` slash command. The parser in `pkg/app/app.go` splits on whitespace (`strings.Cut(input[1:], " ")`), so a name containing a space, tab, or similar character produced a skill whose slash command could never be reached — silently, with no error or warning at config load time. Only non-emptiness was validated before.

The fix adds a whitespace check to `validateSkills()` in `pkg/config/config.go`, rejecting such names at load time with a clear message. `agent-schema.json` gains a `"pattern": "^\\S+$"` constraint on the `InlineSkill.name` field, and the inline-skill field table in `docs/features/skills/index.md` documents the restriction.

The scope is deliberately narrow: only whitespace is rejected, not the stricter charset enforced for remote skill names. Remote skills must be filesystem-path-component-safe and URL-segment-safe because they are used as cache paths and URL segments. Inline skills have no such exposure — they have no `BaseDir` or `FilePath` and `read_skill_file` refuses them outright — so names like `release:v2`, `café`, or `.hidden` continue to load fine as both `/<name>` and via `read_skill`. Applying the stricter remote rule here would have been a needless backward-compatibility break for config versions v9 through v14, which all flow through this same validation after migration.

Tests added in `pkg/config/skills_config_test.go` are table-driven and cover valid names (plain, dashes/underscores, digits/dots, non-ASCII, colon, leading dot) and rejected ones (empty, blank, embedded space, tab, trailing space).