### PR TITLE
feat(skills): expand embedded commands in inline skills

### DIFF
--- a/docs/features/skills/index.md
+++ b/docs/features/skills/index.md
@@ -112,7 +112,7 @@ Inline skills carry their body in the config itself, so they need no `SKILL.md` 
 > [!NOTE]
 > **Inline vs. file-based skills**
 >
-> Inline skills support the subset of the SKILL.md format that fits in YAML. They cannot bundle supporting files (no `read_skill_file`) or use `` !`command` `` expansion. For skills that need bundled resources or executable helpers, use a `SKILL.md` directory instead.
+> Inline skills support the subset of the SKILL.md format that fits in YAML. They cannot bundle supporting files (no `read_skill_file`), so for skills that need bundled resources use a `SKILL.md` directory instead. They do support [embedded commands](#embedded-commands).
 
 ## SKILL.md Format
 
@@ -153,8 +153,7 @@ When asked to create a Dockerfile:
 
 ### Embedded Commands
 
-A file-based skill can inject the output of a command into its body with the
-`` !`command` `` syntax:
+A local skill — whether loaded from a `SKILL.md` file or [defined inline](#inline-skills) in the agent config — can inject the output of a command into its body with the `` !`command` `` syntax:
 
 ```markdown
 Current branch: !`git branch --show-current`
@@ -168,10 +167,18 @@ already allows the command (an `allow` rule, autonomous mode, or a read-only
 command under the balanced mode). Refusing a command leaves an error note in its
 place; the rest of the skill is still loaded.
 
-Expansion is skipped entirely for remote and inline skills. It is also skipped
-when a skill is invoked directly with `/<name>`: input resolution has no parent
-tool call to own an approval prompt, so the commands are reported as skipped
-instead of running unannounced.
+Expansion is skipped entirely for remote skills, whose body is fetched over the
+network from a third party. It is also skipped when a skill is invoked directly
+with `/<name>`: input resolution has no parent tool call to own an approval
+prompt, so the commands are reported as skipped instead of running unannounced.
+
+> [!WARNING]
+> An inline skill's commands come from the agent config itself, so an agent YAML
+> you did not write — for example one pulled from a registry with
+> `docker-agent run myorg/agent:tag` — can carry them. That config also chooses
+> the agent's instructions, toolsets and `permissions` rules, so treat a
+> third-party agent config as you would any other untrusted code and read it
+> before running it.
 
 ## Running a Skill as a Sub-Agent
 

--- a/examples/skills_inline.yaml
+++ b/examples/skills_inline.yaml
@@ -14,7 +14,8 @@
 #   - model        optional; model override for fork-mode skills
 #   - allowed_tools optional; tools the skill expects to use
 #
-# Inline skills are always exposed and are never affected by name filters.
+# Inline skills are always exposed and are never affected by name filters. They
+# also take precedence over a discovered skill of the same name.
 agents:
   root:
     model: openai/gpt-4o-mini
@@ -32,6 +33,20 @@ agents:
           1. Pick the right category: Added, Changed, Fixed, Removed.
           2. Write one imperative sentence summarising the user-visible change.
           3. Avoid implementation detail; focus on what changed for users.
+
+      # Like a SKILL.md file, an inline body can embed !`command` patterns. The
+      # command is emitted as a `shell` tool call and goes through the normal
+      # approval policy before it runs; refusing it leaves an error note behind.
+      - name: release-notes
+        description: Draft release notes for the commits since the last tag.
+        instructions: |
+          Draft release notes for this repository.
+
+          Current branch: !`git branch --show-current`
+          Commits since the last tag:
+          !`git log $(git describe --tags --abbrev=0)..HEAD --oneline`
+
+          Group the commits by theme and summarise each group in one sentence.
 
       # A fork-mode skill: runs in an isolated sub-session via run_skill.
       - name: triage

--- a/pkg/skills/skills.go
+++ b/pkg/skills/skills.go
@@ -53,6 +53,16 @@ func (s Skill) IsFork() bool {
 	return s.Context == "fork"
 }
 
+// ExpandsCommands reports whether !`command` patterns in the skill body may be
+// executed. Local files and the agent config are part of what the user chose to
+// run, and the config already dictates instructions, toolsets and permissions,
+// so a command embedded in it grants nothing it could not already do. A remote
+// body is data fetched from a third-party server at runtime and never earns
+// that authority.
+func (s Skill) ExpandsCommands() bool {
+	return s.Local || s.IsInline()
+}
+
 // Load discovers and loads skills from the given sources.
 // Each source is either "local" (for filesystem-based skills) or an HTTP/HTTPS
 // URL (for remote skills per the well-known skills discovery spec).

--- a/pkg/tools/builtin/skills/skills.go
+++ b/pkg/tools/builtin/skills/skills.go
@@ -127,47 +127,42 @@ func (s *ToolSet) FindSkill(name string) *skills.Skill {
 	return s.findSkill(name)
 }
 
-// ReadSkillContent returns the content of a skill's SKILL.md by name.
-// For local skills, it expands any !`command` patterns in the content by
-// executing the commands and replacing the patterns with their stdout output.
-// Every command is submitted to rt for approval first: a skill body is data,
-// not agent config, so a command hidden in one must never run unannounced.
-// Command expansion is disabled for remote and inline skills to prevent
-// arbitrary code execution.
+// ReadSkillContent returns the content of a skill's SKILL.md by name, or the
+// body carried in the agent config for an inline skill.
+// For local and inline skills, it expands any !`command` patterns in the
+// content by executing the commands and replacing the patterns with their
+// stdout output. Every command is submitted to rt for approval first: a skill
+// body is data, not agent config, so a command hidden in one must never run
+// unannounced. Command expansion is disabled for remote skills to prevent
+// arbitrary code execution on behalf of a third-party server.
 func (s *ToolSet) ReadSkillContent(ctx context.Context, name string, rt tools.Runtime) (string, error) {
 	skill := s.findSkill(name)
 	if skill == nil {
 		return "", fmt.Errorf("skill %q not found", name)
 	}
 
-	// Inline skills carry their body in memory; there is no file to read and
-	// no command expansion (their content comes from the trusted agent config
-	// author, but we keep behaviour identical to remote skills for safety).
-	if skill.IsInline() {
-		return skill.InlineContent, nil
-	}
-
-	content, err := readFileContent(skill.FilePath)
-	if err != nil {
-		return "", err
-	}
-
-	if skill.Local {
-		if rt == nil {
-			rt = tools.NopRuntime{}
-		}
-		content, err = skills.ExpandCommandsWithError(ctx, content, s.confirmedRunner(rt, skill.Name))
-		if err != nil {
+	// Inline skills carry their body in memory; there is no file to read.
+	content := skill.InlineContent
+	if !skill.IsInline() {
+		var err error
+		if content, err = readFileContent(skill.FilePath); err != nil {
 			return "", err
 		}
 	}
 
-	return content, nil
+	if !skill.ExpandsCommands() {
+		return content, nil
+	}
+
+	if rt == nil {
+		rt = tools.NopRuntime{}
+	}
+	return skills.ExpandCommandsWithError(ctx, content, s.confirmedRunner(rt, skill.Name))
 }
 
-// confirmedRunner returns the [skills.Runner] used to expand a local skill:
-// each embedded command is presented to the user as a shell tool call and only
-// runs once approved.
+// confirmedRunner returns the [skills.Runner] used to expand a local or inline
+// skill: each embedded command is presented to the user as a shell tool call
+// and only runs once approved.
 func (s *ToolSet) confirmedRunner(rt tools.Runtime, skillName string) skills.Runner {
 	return func(ctx context.Context, command string) (string, error) {
 		return rt.ConfirmAndRun(ctx, tools.ConfirmedRun{

--- a/pkg/tools/builtin/skills/skills_test.go
+++ b/pkg/tools/builtin/skills/skills_test.go
@@ -434,16 +434,88 @@ func TestSkillsToolset_ReadSkillContent_Inline(t *testing.T) {
 	assert.Equal(t, "# Inline\nDo it.", content)
 }
 
-func TestSkillsToolset_ReadSkillContent_InlineSkipsExpansion(t *testing.T) {
+func TestSkillsToolset_ReadSkillContent_InlineExpandsConfirmedCommand(t *testing.T) {
 	t.Parallel()
-	// Inline content must never be shell-expanded, even when a working dir is set.
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping on windows")
+	}
+	// An inline body is authored in the agent config the user chose to run, so
+	// its commands expand like a local skill's — still gated by an approval.
 	st := New([]skills.Skill{
-		{Name: "inline", Description: "Inline", InlineContent: "Info: !`echo should-not-run`"},
+		{Name: "inline", Description: "Inline", InlineContent: "Info: !`echo expanded`"},
 	}, t.TempDir())
 
-	content, err := st.ReadSkillContent(t.Context(), "inline", &confirmingRuntime{})
+	rt := &confirmingRuntime{}
+	content, err := st.ReadSkillContent(t.Context(), "inline", rt)
+	require.NoError(t, err)
+	assert.Equal(t, "Info: expanded", content)
+
+	require.Len(t, rt.runs, 1)
+	assert.Equal(t, safety.ShellToolName, rt.runs[0].ToolName)
+	assert.Equal(t, "echo expanded", rt.runs[0].Args["cmd"])
+	assert.Equal(t, "inline", rt.runs[0].Metadata[metaSkill])
+}
+
+func TestSkillsToolset_ReadSkillContent_InlineRejectedCommandIsNotRun(t *testing.T) {
+	t.Parallel()
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping on windows")
+	}
+	tmpDir := t.TempDir()
+	marker := filepath.Join(tmpDir, "marker")
+	st := New([]skills.Skill{
+		{Name: "inline", Description: "Inline", InlineContent: "Out: !`touch " + marker + "`"},
+	}, tmpDir)
+
+	rt := &confirmingRuntime{deny: true, reason: tools.ErrConfirmationDenied}
+	content, err := st.ReadSkillContent(t.Context(), "inline", rt)
+	require.NoError(t, err)
+	assert.Contains(t, content, "error executing")
+	assert.NoFileExists(t, marker)
+}
+
+func TestSkillsToolset_ReadSkillContent_InlineFailsClosedWithoutApprover(t *testing.T) {
+	t.Parallel()
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping on windows")
+	}
+	// A host with no way to prompt (direct /<name> resolution, standalone fork)
+	// must not run an inline skill's commands. Both the nil and the explicit
+	// NopRuntime spelling have to fail closed.
+	for name, rt := range map[string]tools.Runtime{"nil": nil, "nop": tools.NopRuntime{}} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			tmpDir := t.TempDir()
+			marker := filepath.Join(tmpDir, "marker")
+			st := New([]skills.Skill{
+				{Name: "inline", Description: "Inline", InlineContent: "Out: !`touch " + marker + "`"},
+			}, tmpDir)
+
+			content, err := st.ReadSkillContent(t.Context(), "inline", rt)
+			require.NoError(t, err)
+			assert.Contains(t, content, "error executing")
+			assert.NoFileExists(t, marker)
+		})
+	}
+}
+
+func TestSkillsToolset_ReadSkillContent_RemoteSkipsExpansion(t *testing.T) {
+	t.Parallel()
+	tmpDir := t.TempDir()
+	skillFile := filepath.Join(tmpDir, "SKILL.md")
+	require.NoError(t, os.WriteFile(skillFile, []byte("Info: !`echo should-not-run`"), 0o644))
+
+	// Local is false: the body came from a third-party server, so its commands
+	// are never offered for approval in the first place.
+	st := New([]skills.Skill{
+		{Name: "remote", Description: "Remote", FilePath: skillFile, BaseDir: tmpDir},
+	}, tmpDir)
+
+	rt := &confirmingRuntime{}
+	content, err := st.ReadSkillContent(t.Context(), "remote", rt)
 	require.NoError(t, err)
 	assert.Equal(t, "Info: !`echo should-not-run`", content)
+	assert.Empty(t, rt.runs)
 }
 
 func TestSkillsToolset_ReadSkillFile_InlineRejected(t *testing.T) {


### PR DESCRIPTION
## What this changes

Skill bodies can embed shell commands with the `` !`command` `` syntax. #4093 made
those commands go through the normal approval path (`tools.Runtime.ConfirmAndRun`)
for filesystem-loaded skills: they surface as `shell` tool calls, subject to
classification, permission rules and safety mode.

Inline skills — those defined directly in the agent YAML — were still excluded
from expansion entirely, mirroring remote skills, and returned their body
verbatim.

That exclusion predates the approval gate. This PR enables expansion for inline
bodies through exactly the same gated path.

**Why inline is safe to expand, and remote still isn't.** The agent config is the
trusted control plane: it already dictates the agent's `instruction`, its
`toolsets` and its `permissions` rules. A command embedded in that same config
grants it nothing it couldn't already do via a shell toolset plus an allow rule.
A remote skill body is different — it's data fetched from a third-party server at
runtime, and never earns that authority.

## Implementation

- New `Skill.ExpandsCommands()` predicate in `pkg/skills/skills.go` (true for
  `Local` or inline).
- `ReadSkillContent` in `pkg/tools/builtin/skills/skills.go` restructured to
  source the body from either `InlineContent` or the file, then run it through
  the same `confirmedRunner`.
- Behaviour for local and remote skills is unchanged.

## Docs

- The Embedded Commands section now covers inline skills.
- The "Inline vs. file-based skills" note no longer lists command expansion as an
  inline limitation; bundled supporting files remain the one real limitation.
- A new warning documents that an inline skill's commands come from the agent
  config itself, so a third-party agent YAML — e.g. one run via
  `docker-agent run myorg/agent:tag` — can carry them, and should be read before
  running.
- `examples/skills_inline.yaml` gains a `release-notes` skill demonstrating
  embedded commands.

## Tests

- Inline command expands after confirmation, asserting the shell tool name, `cmd`
  arg and skill metadata on the approval request.
- A denied inline command leaves an error note and produces no side effect.
- Remote skills still skip expansion.
- **Fail-closed:** both a `nil` Runtime and an explicit `tools.NopRuntime` refuse
  to run an inline command and leave no marker file. This covers the direct
  `/<name>` slash-command path and standalone fork execution, neither of which
  has any way to prompt.

`task build`, `task test` and `task lint` all pass.

## Related

Completes a set addressing gaps between file-based and inline skills:

- #4093 — gate embedded skill commands behind approval (merged)
- #4094 — inline skills override discovered ones (merged)
- #4095 — reject whitespace in inline skill names (merged)
- **this PR** — embedded command expansion for inline skills

Assisted-By: docker-agent
