### PR TITLE
feat: wire assertion runner into runSingleEval execution pipeline

### DIFF
--- a/pkg/evaluation/assertions.go
+++ b/pkg/evaluation/assertions.go
@@ -1,0 +1,88 @@
+package evaluation
+
+import (
+	"fmt"
+	"regexp"
+	"slices"
+	"strconv"
+	"strings"
+
+	"github.com/docker/docker-agent/pkg/session"
+)
+
+// AssertionResult records the outcome of a single assertion evaluation.
+type AssertionResult struct {
+	Name   string `json:"name"`
+	Type   string `json:"type"`
+	Passed bool   `json:"passed"`
+	Reason string `json:"reason,omitempty"`
+}
+
+// runAssertions evaluates all assertions against the agent response and
+// auxiliary data (cost, tool calls).
+func runAssertions(assertions []session.Assertion, response string, cost float64, toolCalls []string) []AssertionResult {
+	results := make([]AssertionResult, len(assertions))
+	for i, a := range assertions {
+		results[i] = evalAssertion(a, response, cost, toolCalls)
+	}
+	return results
+}
+
+func evalAssertion(a session.Assertion, response string, cost float64, toolCalls []string) AssertionResult {
+	r := AssertionResult{Name: a.Name, Type: a.Type}
+	switch strings.ToLower(a.Type) {
+	case "contains":
+		r.Passed = strings.Contains(response, a.Value)
+		if !r.Passed {
+			r.Reason = fmt.Sprintf("response does not contain %q", a.Value)
+		}
+	case "not_contains":
+		r.Passed = !strings.Contains(response, a.Value)
+		if !r.Passed {
+			r.Reason = fmt.Sprintf("response contains %q", a.Value)
+		}
+	case "equals":
+		r.Passed = strings.TrimSpace(response) == strings.TrimSpace(a.Value)
+		if !r.Passed {
+			r.Reason = "response does not equal expected value"
+		}
+	case "starts_with":
+		r.Passed = strings.HasPrefix(response, a.Value)
+		if !r.Passed {
+			r.Reason = fmt.Sprintf("response does not start with %q", a.Value)
+		}
+	case "ends_with":
+		r.Passed = strings.HasSuffix(strings.TrimSpace(response), a.Value)
+		if !r.Passed {
+			r.Reason = fmt.Sprintf("response does not end with %q", a.Value)
+		}
+	case "regex":
+		re, err := regexp.Compile(a.Value)
+		if err != nil {
+			r.Reason = fmt.Sprintf("invalid regex %q: %v", a.Value, err)
+		} else {
+			r.Passed = re.MatchString(response)
+			if !r.Passed {
+				r.Reason = fmt.Sprintf("response does not match pattern %q", a.Value)
+			}
+		}
+	case "cost_threshold":
+		threshold, err := strconv.ParseFloat(a.Value, 64)
+		if err != nil {
+			r.Reason = fmt.Sprintf("invalid cost threshold %q: %v", a.Value, err)
+		} else {
+			r.Passed = cost <= threshold
+			if !r.Passed {
+				r.Reason = fmt.Sprintf("cost $%.6f exceeds threshold $%.6f", cost, threshold)
+			}
+		}
+	case "tool_called":
+		r.Passed = slices.Contains(toolCalls, a.Value)
+		if !r.Passed {
+			r.Reason = fmt.Sprintf("tool %q was not called", a.Value)
+		}
+	default:
+		r.Reason = fmt.Sprintf("unknown assertion type %q", a.Type)
+	}
+	return r
+}

--- a/pkg/evaluation/assertions_test.go
+++ b/pkg/evaluation/assertions_test.go
@@ -1,0 +1,203 @@
+package evaluation
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/docker/docker-agent/pkg/session"
+)
+
+func TestRunAssertions(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		assertions []session.Assertion
+		response   string
+		cost       float64
+		toolCalls  []string
+		wantPass   []bool
+	}{
+		{
+			name: "contains pass",
+			assertions: []session.Assertion{
+				{Name: "has hello", Type: "contains", Value: "hello"},
+			},
+			response: "hello world",
+			wantPass: []bool{true},
+		},
+		{
+			name: "contains fail",
+			assertions: []session.Assertion{
+				{Name: "has goodbye", Type: "contains", Value: "goodbye"},
+			},
+			response: "hello world",
+			wantPass: []bool{false},
+		},
+		{
+			name: "not_contains pass",
+			assertions: []session.Assertion{
+				{Name: "no error", Type: "not_contains", Value: "error"},
+			},
+			response: "all good",
+			wantPass: []bool{true},
+		},
+		{
+			name: "not_contains fail",
+			assertions: []session.Assertion{
+				{Name: "no error", Type: "not_contains", Value: "error"},
+			},
+			response: "there was an error",
+			wantPass: []bool{false},
+		},
+		{
+			name: "equals pass with whitespace trimming",
+			assertions: []session.Assertion{
+				{Name: "exact", Type: "equals", Value: "hello"},
+			},
+			response: "  hello  ",
+			wantPass: []bool{true},
+		},
+		{
+			name: "equals fail",
+			assertions: []session.Assertion{
+				{Name: "exact", Type: "equals", Value: "hello"},
+			},
+			response: "hello world",
+			wantPass: []bool{false},
+		},
+		{
+			name: "starts_with pass",
+			assertions: []session.Assertion{
+				{Name: "prefix", Type: "starts_with", Value: "hello"},
+			},
+			response: "hello world",
+			wantPass: []bool{true},
+		},
+		{
+			name: "starts_with fail",
+			assertions: []session.Assertion{
+				{Name: "prefix", Type: "starts_with", Value: "world"},
+			},
+			response: "hello world",
+			wantPass: []bool{false},
+		},
+		{
+			name: "ends_with pass",
+			assertions: []session.Assertion{
+				{Name: "suffix", Type: "ends_with", Value: "world"},
+			},
+			response: "hello world",
+			wantPass: []bool{true},
+		},
+		{
+			name: "ends_with fail",
+			assertions: []session.Assertion{
+				{Name: "suffix", Type: "ends_with", Value: "hello"},
+			},
+			response: "hello world",
+			wantPass: []bool{false},
+		},
+		{
+			name: "regex pass",
+			assertions: []session.Assertion{
+				{Name: "pattern", Type: "regex", Value: `\d+ files`},
+			},
+			response: "found 42 files",
+			wantPass: []bool{true},
+		},
+		{
+			name: "regex fail",
+			assertions: []session.Assertion{
+				{Name: "pattern", Type: "regex", Value: `\d+ files`},
+			},
+			response: "no files found",
+			wantPass: []bool{false},
+		},
+		{
+			name: "regex invalid pattern",
+			assertions: []session.Assertion{
+				{Name: "bad regex", Type: "regex", Value: `[invalid`},
+			},
+			response: "anything",
+			wantPass: []bool{false},
+		},
+		{
+			name: "cost_threshold pass",
+			assertions: []session.Assertion{
+				{Name: "cheap", Type: "cost_threshold", Value: "0.10"},
+			},
+			cost:     0.05,
+			wantPass: []bool{true},
+		},
+		{
+			name: "cost_threshold fail",
+			assertions: []session.Assertion{
+				{Name: "cheap", Type: "cost_threshold", Value: "0.01"},
+			},
+			cost:     0.05,
+			wantPass: []bool{false},
+		},
+		{
+			name: "cost_threshold invalid value",
+			assertions: []session.Assertion{
+				{Name: "bad cost", Type: "cost_threshold", Value: "not-a-number"},
+			},
+			cost:     0.05,
+			wantPass: []bool{false},
+		},
+		{
+			name: "tool_called pass",
+			assertions: []session.Assertion{
+				{Name: "used search", Type: "tool_called", Value: "search"},
+			},
+			toolCalls: []string{"read_file", "search", "write_file"},
+			wantPass:  []bool{true},
+		},
+		{
+			name: "tool_called fail",
+			assertions: []session.Assertion{
+				{Name: "used search", Type: "tool_called", Value: "search"},
+			},
+			toolCalls: []string{"read_file", "write_file"},
+			wantPass:  []bool{false},
+		},
+		{
+			name: "unknown type fails",
+			assertions: []session.Assertion{
+				{Name: "unknown", Type: "magic", Value: "xyz"},
+			},
+			wantPass: []bool{false},
+		},
+		{
+			name: "multiple assertions mixed results",
+			assertions: []session.Assertion{
+				{Name: "has hello", Type: "contains", Value: "hello"},
+				{Name: "no error", Type: "not_contains", Value: "error"},
+				{Name: "used search", Type: "tool_called", Value: "search"},
+			},
+			response:  "hello world",
+			toolCalls: []string{"read_file"},
+			wantPass:  []bool{true, true, false},
+		},
+		{
+			name:       "empty assertions",
+			assertions: nil,
+			wantPass:   []bool{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			results := runAssertions(tt.assertions, tt.response, tt.cost, tt.toolCalls)
+			assert.Len(t, results, len(tt.wantPass))
+			for i, want := range tt.wantPass {
+				assert.Equal(t, want, results[i].Passed,
+					"assertion %d (%s): expected pass=%v, got pass=%v, reason=%s",
+					i, results[i].Name, want, results[i].Passed, results[i].Reason)
+			}
+		})
+	}
+}

--- a/pkg/evaluation/eval.go
+++ b/pkg/evaluation/eval.go
@@ -330,6 +330,7 @@ func (r *Runner) runSingleEval(ctx context.Context, evalSess *InputSession) (Res
 		Question:          strings.Join(userMessages, "\n"),
 		SizeExpected:      evals.Size,
 		RelevanceExpected: float64(len(evals.Relevance)),
+		AssertionsTotal:   len(evals.Assertions),
 	}
 
 	expectedToolCalls := extractToolCalls(evalSess.Messages)
@@ -382,6 +383,17 @@ func (r *Runner) runSingleEval(ctx context.Context, evalSess *InputSession) (Res
 		}
 		result.RelevancePassed = passed
 		result.RelevanceResults = results
+	}
+
+	// Run code-based assertions against the agent output.
+	if len(evals.Assertions) > 0 {
+		assertionResults := runAssertions(evals.Assertions, response, cost, actualToolCalls)
+		result.AssertionResults = assertionResults
+		for _, ar := range assertionResults {
+			if ar.Passed {
+				result.AssertionsPassed++
+			}
+		}
 	}
 
 	slog.DebugContext(ctx, "Evaluation complete", "title", title, "duration", time.Since(startTime))

--- a/pkg/evaluation/eval_test.go
+++ b/pkg/evaluation/eval_test.go
@@ -1485,3 +1485,43 @@ func TestPrintSummary_NoRepeatMetricsWhenNil(t *testing.T) {
 	assert.NotContains(t, output, "pass@")
 	assert.NotContains(t, output, "Repeat")
 }
+
+func TestResultCheckResults_AssertionsAllPass(t *testing.T) {
+	t.Parallel()
+	r := Result{
+		AssertionsTotal:  2,
+		AssertionsPassed: 2,
+		AssertionResults: []AssertionResult{
+			{Name: "a", Passed: true},
+			{Name: "b", Passed: true},
+		},
+	}
+	successes, failures := r.checkResults()
+	assert.Contains(t, successes, "assertions 2/2")
+	assert.Empty(t, failures)
+}
+
+func TestResultCheckResults_AssertionsPartialFail(t *testing.T) {
+	t.Parallel()
+	r := Result{
+		AssertionsTotal:  2,
+		AssertionsPassed: 1,
+		AssertionResults: []AssertionResult{
+			{Name: "has greeting", Type: "contains", Passed: true},
+			{Name: "no error", Type: "not_contains", Passed: false, Reason: `response contains "error"`},
+		},
+	}
+	successes, failures := r.checkResults()
+	assert.Empty(t, successes)
+	assert.Len(t, failures, 1)
+	assert.Contains(t, failures[0], "no error")
+	assert.Contains(t, failures[0], `response contains "error"`)
+}
+
+func TestResultCheckResults_AssertionsDoNotFireWhenZero(t *testing.T) {
+	t.Parallel()
+	r := Result{AssertionsTotal: 0}
+	successes, failures := r.checkResults()
+	assert.Empty(t, successes)
+	assert.Empty(t, failures)
+}

--- a/pkg/evaluation/progress.go
+++ b/pkg/evaluation/progress.go
@@ -25,6 +25,7 @@ type progressBar struct {
 	relevanceFailed atomic.Int32                     // count of evals with relevance failures
 	sizeFailed      atomic.Int32                     // count of evals with size failures
 	toolCallsFailed atomic.Int32                     // count of evals with tool call failures
+	assertionFailed atomic.Int32                     // count of evals with assertion failures
 	running         concurrent.Map[string, struct{}] // titles of currently running evals
 	done            chan struct{}
 	stopped         chan struct{} // signals that the goroutine has finished
@@ -104,6 +105,8 @@ func (p *progressBar) printResult(result Result) {
 				p.sizeFailed.Add(1)
 			case strings.HasPrefix(f, "tool calls"):
 				p.toolCallsFailed.Add(1)
+			case strings.HasPrefix(f, "assertion"):
+				p.assertionFailed.Add(1)
 			}
 		}
 	}
@@ -160,6 +163,7 @@ func (p *progressBar) render(final bool) {
 	relevanceFailed := int(p.relevanceFailed.Load())
 	sizeFailed := int(p.sizeFailed.Load())
 	toolCallsFailed := int(p.toolCallsFailed.Load())
+	assertionFailed := int(p.assertionFailed.Load())
 
 	// Get current terminal width for dynamic sizing
 	termWidth := p.getTerminalWidth()
@@ -204,6 +208,9 @@ func (p *progressBar) render(final bool) {
 		}
 		if toolCallsFailed > 0 {
 			breakdown = append(breakdown, "tools "+p.red(fmt.Sprintf("✗%d", toolCallsFailed)))
+		}
+		if assertionFailed > 0 {
+			breakdown = append(breakdown, "assert "+p.red(fmt.Sprintf("✗%d", assertionFailed)))
 		}
 		if len(breakdown) > 0 {
 			counts += fmt.Sprintf(" (%s)", strings.Join(breakdown, ", "))

--- a/pkg/evaluation/save.go
+++ b/pkg/evaluation/save.go
@@ -498,6 +498,26 @@ func populateEvalResult(result *Result) {
 		}
 	}
 
+	// Populate assertions check if assertions were evaluated
+	if result.AssertionsTotal > 0 {
+		assertResults := make([]session.AssertionResult, 0, len(result.AssertionResults))
+		for _, ar := range result.AssertionResults {
+			assertResults = append(assertResults, session.AssertionResult{
+				Name:   ar.Name,
+				Type:   ar.Type,
+				Passed: ar.Passed,
+				Reason: ar.Reason,
+			})
+		}
+
+		evalResult.Checks.Assertions = &session.AssertionsCheck{
+			Passed:      result.AssertionsPassed >= result.AssertionsTotal,
+			PassedCount: result.AssertionsPassed,
+			Total:       result.AssertionsTotal,
+			Results:     assertResults,
+		}
+	}
+
 	result.Session.EvalResult = evalResult
 }
 

--- a/pkg/evaluation/types.go
+++ b/pkg/evaluation/types.go
@@ -48,6 +48,9 @@ type Result struct {
 	RelevancePassed   float64           `json:"relevance"`
 	RelevanceExpected float64           `json:"relevance_expected"`
 	RelevanceResults  []RelevanceResult `json:"relevance_results,omitempty"`
+	AssertionResults  []AssertionResult `json:"assertion_results,omitempty"`
+	AssertionsPassed  int               `json:"assertions_passed"`
+	AssertionsTotal   int               `json:"assertions_total"`
 	Error             string            `json:"error,omitempty"`
 	RawOutput         []map[string]any  `json:"raw_output,omitempty"`
 	Session           *session.Session  `json:"-"` // Full session for database storage (not in JSON)
@@ -88,6 +91,23 @@ func (r *Result) checkResults() (successes, failures []string) {
 						failures = append(failures, fmt.Sprintf("relevance: %s (reason: %s)", result.Criterion, result.Reason))
 					} else {
 						failures = append(failures, "relevance: "+result.Criterion)
+					}
+				}
+			}
+		}
+	}
+
+	// Check assertions
+	if r.AssertionsTotal > 0 {
+		if r.AssertionsPassed >= r.AssertionsTotal {
+			successes = append(successes, fmt.Sprintf("assertions %d/%d", r.AssertionsPassed, r.AssertionsTotal))
+		} else {
+			for _, ar := range r.AssertionResults {
+				if !ar.Passed {
+					if ar.Reason != "" {
+						failures = append(failures, fmt.Sprintf("assertion %s: %s", ar.Name, ar.Reason))
+					} else {
+						failures = append(failures, "assertion: "+ar.Name)
 					}
 				}
 			}


### PR DESCRIPTION
## Summary

Add a code-based assertion evaluator and wire it into the evaluation pipeline so that assertions declared in eval JSON files are executed after the agent run completes — alongside the existing size, tool-call, and relevance checks.

> **Depends on #4088 (#4082)** — this branch includes the schema commit from that PR. Merge #4088 first.

## New files

### `pkg/evaluation/assertions.go`
- **`runAssertions()`** — evaluates a list of `session.Assertion` against the agent response, cost, and tool calls
- **8 assertion types:**

| Type | What it checks |
|------|---------------|
| `contains` | Response contains the value |
| `not_contains` | Response does not contain the value |
| `equals` | Trimmed response equals trimmed value |
| `starts_with` | Response starts with the value |
| `ends_with` | Trimmed response ends with the value |
| `regex` | Response matches the regex pattern |
| `cost_threshold` | Run cost ≤ threshold |
| `tool_called` | Named tool was invoked |

### `pkg/evaluation/assertions_test.go`
- Pass/fail tests for every assertion type, invalid inputs, mixed results, empty list

## Modified files

| File | Change |
|------|--------|
| `types.go` | `AssertionResults`, `AssertionsPassed`, `AssertionsTotal` on `Result`; `checkResults()` reports assertion outcomes |
| `eval.go` | `runSingleEval()` calls `runAssertions()` after relevance checks |
| `save.go` | `populateEvalResult()` populates `AssertionsCheck` on the session |
| `progress.go` | Tracks and displays assertion failure count in the progress bar |
| `eval_test.go` | `checkResults` tests for all-pass, partial-fail, and zero-assertion cases |

Closes #4086