### PR TITLE
refactor: update go version declaration format

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/docker/docker-agent
 
-go 1.27.0
+go 1.27
+
+toolchain go1.27.0
 
 require (
 	charm.land/bubbles/v2 v2.2.1


### PR DESCRIPTION
Update the go.mod file to use the modern Go version
declaration format. The go directive now specifies the
minimum version (1.27) while the toolchain directive
explicitly pins the exact toolchain version (1.27.0).
This separation allows better control over version
management and aligns with Go 1.21+ conventions.