### PR TITLE
docs: auto-update for merged PRs (2026-09-02)

### DIFF
--- a/docs/features/evaluation/index.md
+++ b/docs/features/evaluation/index.md
@@ -237,6 +237,13 @@ $ docker agent eval ./agent.yaml --baseline results/2026-08-01-run.json
 The baseline is the run JSON written by a previous invocation —
 `<output>/<run-name>.json` — so there is no separate artifact to produce.
 
+The comparison covers every aggregate quality rate that both runs have data
+for: size pass rate, tool F1 mean, relevance rate, and — since
+docker/docker-agent#4103 — assertion rate. When both runs used `--repeat`,
+`pass@k` and `pass^k` are also reported as deltas, but purely
+**informationally**: they never gate, since they derive from the same
+per-eval pass/fail that the other metrics already gate on.
+
 Four rules decide the verdict, and they are worth knowing before wiring this
 into CI:
 

--- a/docs/features/evaluation/index.md
+++ b/docs/features/evaluation/index.md
@@ -123,11 +123,38 @@ Each eval file is a JSON session that captures a complete conversation. The key 
 The `evals` object inside each session controls what gets scored:
 
 | Field         | Type     | Description                                                                               |
-| ------------- | -------- | ----------------------------------------------------------------------------------------- |
+| ------------- | -------- | ------------------------------------------------------------------------------------------- |
 | `relevance`   | string[] | Statements that must be true about the agent's response. Scored by an LLM judge.          |
+| `assertions`  | object[] | Code-based checks evaluated against the agent's output. See [Assertions](#assertions).    |
 | `size`        | string   | Expected response size: `S`, `M`, `L`, or `XL`. Compared against actual output length.    |
 | `working_dir` | string   | Subdirectory under `evals/working_dirs/` to mount as the container's working directory.   |
 | `setup`       | string   | Shell script to run in the container before the agent executes (e.g., create test files). |
+
+### Assertions
+
+Each entry in `assertions` is a code-based check evaluated deterministically against the agent's output, without an LLM judge:
+
+```json
+"assertions": [
+  { "name": "mentions file count", "type": "contains", "value": "2 files" },
+  { "name": "no error message", "type": "not_contains", "value": "error" },
+  { "name": "used list_directory", "type": "tool_called", "value": "list_directory" },
+  { "name": "under budget", "type": "cost_threshold", "value": "0.05" }
+]
+```
+
+Each assertion has a `name` (shown in results), a `type`, and a `value` checked against the agent's response, cost, or tool calls:
+
+| Type             | Checks that...                                                     |
+| ---------------- | -------------------------------------------------------------------- |
+| `contains`       | the response contains `value`                                       |
+| `not_contains`   | the response does not contain `value`                                |
+| `equals`         | the (trimmed) response equals `value`                                |
+| `starts_with`    | the response starts with `value`                                     |
+| `ends_with`      | the (trimmed) response ends with `value`                             |
+| `regex`          | the response matches the regular expression `value`                  |
+| `cost_threshold` | the eval's cost is less than or equal to `value` (a dollar amount)   |
+| `tool_called`    | the agent called a tool named `value`                                |
 
 ## Scoring Metrics
 

--- a/docs/features/evaluation/index.md
+++ b/docs/features/evaluation/index.md
@@ -158,13 +158,14 @@ Each assertion has a `name` (shown in results), a `type`, and a `value` checked 
 
 ## Scoring Metrics
 
-Docker Agent evaluates agents across three dimensions:
+Docker Agent evaluates agents across four dimensions:
 
 | Metric              | How It's Measured                                                                                                         |
 | ------------------- | ------------------------------------------------------------------------------------------------------------------------- |
 | **Tool Calls (F1)** | F1 score between the expected tool call sequence (from the recorded session) and the actual tool calls made by the agent. |
 | **Relevance**       | An LLM judge (configurable via `--judge-model`) evaluates whether each relevance statement is satisfied by the response.  |
 | **Size**            | Whether the response length matches the expected size category (S/M/L/XL).                                                |
+| **Assertions**      | Code-based [assertions](#assertions) evaluated deterministically against the response, cost, and tool calls — no LLM judge involved. |
 
 ## Serve-safety verification and rollback
 

--- a/docs/features/evaluation/index.md
+++ b/docs/features/evaluation/index.md
@@ -167,6 +167,28 @@ Docker Agent evaluates agents across four dimensions:
 | **Size**            | Whether the response length matches the expected size category (S/M/L/XL).                                                |
 | **Assertions**      | Code-based [assertions](#assertions) evaluated deterministically against the response, cost, and tool calls — no LLM judge involved. |
 
+### Repeat Metrics (pass@k / pass^k)
+
+Running with `--repeat <k>` (k > 1) repeats each eval `k` times and, once the
+run completes, prints two additional consistency metrics alongside the
+regular summary:
+
+- **pass@k** — the fraction of unique evals that passed on *at least one* of
+  the `k` repetitions. Measures whether the agent can produce a correct
+  answer at all.
+- **pass^k** — the fraction of unique evals that passed on *every* one of the
+  `k` repetitions. Measures determinism / reliability.
+
+```console
+  Repeat metrics (k=5, 3 unique evals):
+   pass@5: 100.0% (passed at least once)
+   pass^5: 66.7% (passed every time)
+```
+
+These metrics are also included in the JSON results (`repeat_metrics`) and,
+when comparing against a `--baseline`, are reported as informational deltas
+(see [Regression gate](#regression-gate)).
+
 ## Serve-safety verification and rollback
 
 When changing an agent served over MCP HTTP, chat, or A2A, add an evaluation that attempts an approval-requiring tool call and verifies the resolved safety policy and authentication behavior. Run the evaluation with the same explicit `--safety` setting used in deployment. If a rollout must be reversed, stop the affected listener, restore the prior agent configuration and explicit safety flag, then restart only after confirming non-loopback listeners still require authentication. Do not restore an unauthenticated network listener as a rollback shortcut.


### PR DESCRIPTION
## Documentation changes

Brings `docs/features/evaluation/index.md` up to date with the evaluation
features merged into `main` over the last 36 hours. The `assertions`
(code-based grading) and `--repeat` pass@k/pass^k features landed across
several PRs but were never documented; the skills-related PRs and the
StartableToolSet backoff PR already carried their own doc updates and needed
no further changes.

- **Eval Criteria**: document the new `assertions` field and the supported
  assertion types (`contains`, `not_contains`, `equals`, `starts_with`,
  `ends_with`, `regex`, `cost_threshold`, `tool_called`).
- **Scoring Metrics**: add the Assertions row now that assertions are
  actually run and scored (not just accepted by the schema).
- **New "Repeat Metrics (pass@k / pass^k)" section**: explain what `--repeat`
  now prints and what the two metrics measure.
- **Regression gate**: note that assertion rate is now one of the aggregate
  metrics compared against `--baseline`, and that pass@k/pass^k are reported
  as informational (non-gating) deltas.

One commit per source PR:

- docker/docker-agent#4088 — assertions schema on `EvalCriteria`
- docker/docker-agent#4100 — assertion runner wired into the eval pipeline
- docker/docker-agent#4092 — pass@k / pass^k metrics for `--repeat`
- docker/docker-agent#4103 — assertion rate & pass@k in baseline regression comparison

### PRs reviewed with no doc changes needed

- docker/docker-agent#4089 (verify script runner) — fully removed again by #4103, never documented, no net doc change.
- docker/docker-agent#4091 (judge prompt rewrite) — internal prompt change, not user-facing/documented behavior.
- docker/docker-agent#4090, #4075 — no doc-relevant changes.
- docker/docker-agent#4093, #4094, #4095, #4096 (skills) — already updated `docs/features/skills/index.md` in the same PR; verified accurate against final code.
- docker/docker-agent#4062 (RAG/toolset backoff) — already updated `docs/tools/rag`, `docs/tools/lsp`, `docs/tools/mcp`, `docs/community/troubleshooting` in the same PR; verified accurate against final code.
- docker/docker-agent#4101 — CHANGELOG-only PR, already docs.
