### PR TITLE
fix(deferred): don't fail to start when a source is still starting

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -606,9 +606,8 @@ func (a *Agent) tryStartToolSet(ctx context.Context, toolSet *tools.StartableToo
 // bounded via tryStartToolSet, so neither a start already in flight nor a
 // wedged start initiated here can stall the turn, and warnings are
 // recorded in configuration order afterwards. Peer-dependent toolsets
-// (e.g. the deferred aggregator, whose Start lists its source toolsets'
-// tools) start in a second wave, after the toolsets they depend on have
-// settled.
+// start in a second wave, after the toolsets they depend on have been
+// attempted.
 func (a *Agent) ensureToolSetsAreStarted(ctx context.Context) {
 	var independent, dependent []int
 	for i, toolSet := range a.toolsets {

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -1753,9 +1753,8 @@ func (r *LocalRuntime) emitToolsProgressively(ctx context.Context, a *agent.Agen
 	// already in flight is skipped rather than joined, a wedged start is
 	// abandoned at the timeout, and outcomes are consumed in configuration
 	// order below so an early fast toolset is listed (and counted) without
-	// waiting for a slow later one. Peer-dependent toolsets (e.g. the
-	// deferred aggregator, whose Start lists its source toolsets' tools)
-	// start in a second wave, after the others have settled.
+	// waiting for a slow later one. Peer-dependent toolsets start in a
+	// second wave, after the others have been attempted.
 	type startOutcome struct {
 		started bool
 		err     error

--- a/pkg/teamloader/deferred_integration_test.go
+++ b/pkg/teamloader/deferred_integration_test.go
@@ -1,0 +1,169 @@
+package teamloader
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/docker/docker-agent/pkg/agent"
+	"github.com/docker/docker-agent/pkg/config"
+	"github.com/docker/docker-agent/pkg/config/latest"
+	"github.com/docker/docker-agent/pkg/js"
+	"github.com/docker/docker-agent/pkg/tools"
+	"github.com/docker/docker-agent/pkg/tools/builtin/deferred"
+	"github.com/docker/docker-agent/pkg/tools/lifecycle"
+)
+
+// slowSourceToolSet behaves like an MCP toolset: Tools fails with
+// ErrNotStarted until Start completes, and Start blocks until released.
+type slowSourceToolSet struct {
+	starting chan struct{} // closed when Start is entered
+	release  chan struct{}
+	started  atomic.Bool
+	once     sync.Once
+}
+
+func (s *slowSourceToolSet) Tools(context.Context) ([]tools.Tool, error) {
+	if !s.started.Load() {
+		return nil, lifecycle.ErrNotStarted
+	}
+	return []tools.Tool{{
+		Name:        "remote_echo",
+		Description: "Echoes its input",
+		Handler: func(context.Context, tools.ToolCall, tools.Runtime) (*tools.ToolCallResult, error) {
+			return tools.ResultSuccess(`{"echo":"hi"}`), nil
+		},
+	}}, nil
+}
+
+func (s *slowSourceToolSet) Start(ctx context.Context) error {
+	s.once.Do(func() { close(s.starting) })
+	select {
+	case <-s.release:
+		s.started.Store(true)
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func (s *slowSourceToolSet) Stop(context.Context) error { return nil }
+
+func namesOf(ts []tools.Tool) []string {
+	names := make([]string, 0, len(ts))
+	for _, t := range ts {
+		names = append(names, t.Name)
+	}
+	return names
+}
+
+func callTool(t *testing.T, ts []tools.Tool, name string, args any) string {
+	t.Helper()
+	raw, err := json.Marshal(args)
+	require.NoError(t, err)
+	for _, tool := range ts {
+		if tool.Name == name {
+			res, err := tool.Handler(t.Context(), tools.ToolCall{Function: tools.FunctionCall{Name: name, Arguments: string(raw)}}, tools.NopRuntime{})
+			require.NoError(t, err)
+			return res.Output
+		}
+	}
+	t.Fatalf("tool %q not found in %v", name, namesOf(ts))
+	return ""
+}
+
+// Reproduces the original bug end to end through the real loader pipeline: a
+// message arrives (agent.Tools) while a deferred MCP-like source is still
+// starting. The deferred toolset must come up without a warning, and the
+// source's tools must become discoverable once the source is ready.
+func TestDeferredToolsSurviveSlowSourceStart(t *testing.T) {
+	t.Parallel()
+
+	slow := &slowSourceToolSet{starting: make(chan struct{}), release: make(chan struct{})}
+	registry := NewToolsetRegistry(map[string]ToolsetCreator{
+		"slow": func(context.Context, latest.Toolset, string, *config.RuntimeConfig, string) (tools.ToolSet, error) {
+			return slow, nil
+		},
+	})
+	a := &latest.AgentConfig{
+		Instruction: "test",
+		Toolsets: []latest.Toolset{{
+			Type:  "slow",
+			Defer: latest.DeferConfig{DeferAll: true},
+			Toon:  "remote_.*",
+		}},
+	}
+	runConfig := config.RuntimeConfig{EnvProviderForTests: &noEnvProvider{}}
+	toolSets, warnings := getToolsForAgent(t.Context(), a, ".", &runConfig, registry, "test-config", js.NewJsExpander(runConfig.EnvProvider()))
+	require.Empty(t, warnings)
+	require.Len(t, toolSets, 2, "source (with all tools hidden) + deferred aggregator")
+	_, isDeferred := toolSets[1].(*deferred.ToolSet)
+	require.True(t, isDeferred)
+
+	ag := agent.New("root", "test", agent.WithToolSets(toolSets...))
+
+	// Like the runtime's startup probe: kick off the source's start in the
+	// background so that it is in flight when the first message arrives.
+	sourceStartable, ok := ag.ToolSets()[0].(*tools.StartableToolSet)
+	require.True(t, ok)
+	go func() {
+		_, _ = sourceStartable.TryStartWithTimeout(t.Context(), time.Minute)
+	}()
+	select {
+	case <-slow.starting:
+	case <-time.After(5 * time.Second):
+		t.Fatal("source start never began")
+	}
+
+	// Turn 1: the source's Start is in flight (blocked); the turn must skip
+	// it rather than wait, must not warn, and must still offer search_tool/add_tool.
+	turn1 := make(chan []tools.Tool, 1)
+	go func() {
+		got, err := ag.Tools(t.Context())
+		assert.NoError(t, err)
+		turn1 <- got
+	}()
+	var got []tools.Tool
+	select {
+	case got = <-turn1:
+	case <-time.After(10 * time.Second):
+		t.Fatal("turn 1 blocked on the slow source start")
+	}
+	assert.ElementsMatch(t, []string{deferred.ToolNameSearchTool, deferred.ToolNameAddTool}, namesOf(got))
+	assert.Empty(t, ag.DrainWarnings(), "deferred toolset must not fail to start while its source is starting")
+
+	// While the source is still starting, its tools are simply not discoverable yet.
+	out := callTool(t, got, deferred.ToolNameSearchTool, deferred.SearchToolArgs{Query: "echo"})
+	assert.Contains(t, out, "No deferred tools found")
+
+	// Source finishes starting; the abandoned Start goroutine completes.
+	close(slow.release)
+	require.Eventually(t, slow.started.Load, 5*time.Second, 10*time.Millisecond)
+
+	// Turn 2: the source is now discoverable and activatable.
+	require.Eventually(t, func() bool {
+		got, err := ag.Tools(t.Context())
+		require.NoError(t, err)
+		return strings.Contains(callTool(t, got, deferred.ToolNameSearchTool, deferred.SearchToolArgs{Query: "echo"}), "remote_echo")
+	}, 5*time.Second, 20*time.Millisecond)
+
+	got, err := ag.Tools(t.Context())
+	require.NoError(t, err)
+	out = callTool(t, got, deferred.ToolNameAddTool, deferred.AddToolArgs{Name: "remote_echo"})
+	assert.Contains(t, out, "has been activated")
+
+	// Turn 3: the activated tool is listed, and runs through the source's
+	// wrappers (TOON was configured for it).
+	got, err = ag.Tools(t.Context())
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{deferred.ToolNameSearchTool, deferred.ToolNameAddTool, "remote_echo"}, namesOf(got))
+	assert.Equal(t, "echo: hi", callTool(t, got, "remote_echo", nil))
+	assert.Empty(t, ag.DrainWarnings())
+}

--- a/pkg/teamloader/toon.go
+++ b/pkg/teamloader/toon.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"regexp"
+	"slices"
 	"strings"
 
 	"github.com/alpkeskin/gotoon"
@@ -26,38 +27,47 @@ func (f *toonTools) Tools(ctx context.Context) ([]tools.Tool, error) {
 		return nil, err
 	}
 
-	for i, tool := range allTools {
-		for _, regex := range f.toolRegexps {
-			if !regex.MatchString(tool.Name) {
-				continue
-			}
-
-			handler := tool.Handler
-			tool.Handler = func(ctx context.Context, toolCall tools.ToolCall, rt tools.Runtime) (*tools.ToolCallResult, error) {
-				res, err := handler(ctx, toolCall, rt)
-				if err != nil {
-					return res, err
-				}
-
-				var o map[string]any
-				err = json.Unmarshal([]byte(res.Output), &o)
-				if err != nil {
-					return res, nil
-				}
-
-				tooned, err := gotoon.Encode(o)
-				if err != nil {
-					return res, err
-				}
-
-				res.Output = tooned
-				return res, nil
-			}
-			allTools[i] = tool
+	// Clone: inner toolsets (e.g. MCP) may hand out their cached slice, and
+	// mutating it would re-wrap the same handlers on every listing.
+	result := slices.Clone(allTools)
+	for i := range result {
+		if f.matches(result[i].Name) {
+			result[i].Handler = toonHandler(result[i].Handler)
 		}
 	}
 
-	return allTools, nil
+	return result, nil
+}
+
+func (f *toonTools) matches(name string) bool {
+	for _, regex := range f.toolRegexps {
+		if regex.MatchString(name) {
+			return true
+		}
+	}
+	return false
+}
+
+func toonHandler(handler tools.ToolHandler) tools.ToolHandler {
+	return func(ctx context.Context, toolCall tools.ToolCall, rt tools.Runtime) (*tools.ToolCallResult, error) {
+		res, err := handler(ctx, toolCall, rt)
+		if err != nil {
+			return res, err
+		}
+
+		var o map[string]any
+		if err := json.Unmarshal([]byte(res.Output), &o); err != nil {
+			return res, nil
+		}
+
+		tooned, err := gotoon.Encode(o)
+		if err != nil {
+			return res, err
+		}
+
+		res.Output = tooned
+		return res, nil
+	}
 }
 
 // Unwrap implements tools.Unwrapper.

--- a/pkg/teamloader/toon_test.go
+++ b/pkg/teamloader/toon_test.go
@@ -72,3 +72,36 @@ func TestToon(t *testing.T) {
 		})
 	}
 }
+
+// The inner toolset's slice must be left untouched: MCP hands out its cached
+// slice, and mutating it would re-wrap the handlers on every listing.
+func TestToonDoesNotMutateInnerSlice(t *testing.T) {
+	t.Parallel()
+
+	var calls int
+	cached := []tools.Tool{{
+		Name: "test_tool",
+		Handler: func(context.Context, tools.ToolCall, tools.Runtime) (*tools.ToolCallResult, error) {
+			calls++
+			return tools.ResultSuccess(`{"key": "value"}`), nil
+		},
+	}}
+	inner := &mockToolSet{
+		toolsFunc: func(context.Context) ([]tools.Tool, error) { return cached, nil },
+	}
+	wrapped := WithToon(inner, "test_.*,.*_tool")
+
+	for range 3 {
+		resultTools, err := wrapped.Tools(t.Context())
+		require.NoError(t, err)
+		result, err := resultTools[0].Handler(t.Context(), tools.ToolCall{}, tools.NopRuntime{})
+		require.NoError(t, err)
+		assert.Equal(t, "key: value", result.Output)
+	}
+
+	// The original handler is still unwrapped and was invoked exactly once per call.
+	res, err := cached[0].Handler(t.Context(), tools.ToolCall{}, tools.NopRuntime{})
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"key": "value"}`, res.Output)
+	assert.Equal(t, 4, calls)
+}

--- a/pkg/tools/builtin/deferred/deferred.go
+++ b/pkg/tools/builtin/deferred/deferred.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"slices"
 	"sort"
 	"strings"
@@ -22,36 +23,41 @@ const (
 	ToolNameAddTool    = "add_tool"
 )
 
-type deferredToolEntry struct {
-	tool   tools.Tool
-	source tools.ToolSet
-}
-
+// ToolSet exposes search_tool/add_tool over the deferred tools of its
+// sources. Each source is snapshotted lazily, on the first search/add after
+// it can be listed, rather than at start: the sources are the agent's other
+// toolsets and may still be starting when the first turn runs, so a
+// start-time snapshot would race them and fail the whole toolset.
 type ToolSet struct {
 	mu             sync.RWMutex
-	deferredTools  map[string]deferredToolEntry
 	activatedTools map[string]tools.Tool
-	sources        []deferredSource
+	sources        []*deferredSource
 }
 
 // Verify interface compliance
 var (
-	_ tools.ToolSet       = (*ToolSet)(nil)
-	_ tools.Startable     = (*ToolSet)(nil)
-	_ tools.Instructable  = (*ToolSet)(nil)
-	_ tools.Named         = (*ToolSet)(nil)
-	_ tools.PeerDependent = (*ToolSet)(nil)
+	_ tools.ToolSet      = (*ToolSet)(nil)
+	_ tools.Instructable = (*ToolSet)(nil)
+	_ tools.Named        = (*ToolSet)(nil)
 )
 
 type deferredSource struct {
 	toolset  tools.ToolSet
 	deferAll bool
 	tools    []string
+
+	// snapshot holds the source's deferred tools once listed successfully;
+	// listed stays false while the source is unavailable so it is retried.
+	snapshot []tools.Tool
+	listed   bool
+}
+
+func (s *deferredSource) defers(name string) bool {
+	return s.deferAll || slices.Contains(s.tools, name)
 }
 
 func New() *ToolSet {
 	return &ToolSet{
-		deferredTools:  make(map[string]deferredToolEntry),
 		activatedTools: make(map[string]tools.Tool),
 	}
 }
@@ -61,15 +67,11 @@ func (d *ToolSet) Name() string {
 	return "deferred"
 }
 
-// StartsAfterPeers implements tools.PeerDependent: Start lists the source
-// toolsets' tools, so they must be started first.
-func (d *ToolSet) StartsAfterPeers() {}
-
 func (d *ToolSet) AddSource(toolset tools.ToolSet, deferAll bool, toolNames []string) {
 	d.mu.Lock()
 	defer d.mu.Unlock()
 
-	d.sources = append(d.sources, deferredSource{
+	d.sources = append(d.sources, &deferredSource{
 		toolset:  toolset,
 		deferAll: deferAll,
 		tools:    toolNames,
@@ -101,11 +103,70 @@ type AddToolArgs struct {
 	Name string `json:"name" jsonschema:"The name of the tool to activate"`
 }
 
-func (d *ToolSet) handleSearchTool(ctx context.Context, args SearchToolArgs) (*tools.ToolCallResult, error) {
-	queryRunes := []rune(strings.ToLower(strings.TrimSpace(args.Query)))
+// snapshotPendingSources lists every source not yet snapshotted. Sources are
+// listed without holding d.mu (an MCP list may be a network round-trip);
+// a source that cannot list yet (typically still starting) is skipped and
+// retried on the next call, so its tools show up once it is ready.
+func (d *ToolSet) snapshotPendingSources(ctx context.Context) {
+	d.mu.RLock()
+	var pending []*deferredSource
+	for _, source := range d.sources {
+		if !source.listed {
+			pending = append(pending, source)
+		}
+	}
+	d.mu.RUnlock()
+
+	for _, source := range pending {
+		allTools, err := source.toolset.Tools(ctx)
+		if err != nil {
+			slog.DebugContext(ctx, "Deferred source unavailable; skipping", "source", tools.DescribeToolSet(source.toolset), "error", err)
+			continue
+		}
+
+		var snapshot []tools.Tool
+		for _, tool := range allTools {
+			if source.defers(tool.Name) {
+				snapshot = append(snapshot, tool)
+			}
+		}
+
+		d.mu.Lock()
+		// A concurrent call may have snapshotted the same source; first wins.
+		if !source.listed {
+			source.snapshot = snapshot
+			source.listed = true
+		}
+		d.mu.Unlock()
+	}
+}
+
+// deferredTools returns the not-yet-activated deferred tools across all
+// listed sources, first source winning on duplicate names.
+func (d *ToolSet) deferredTools(ctx context.Context) map[string]tools.Tool {
+	d.snapshotPendingSources(ctx)
 
 	d.mu.RLock()
 	defer d.mu.RUnlock()
+
+	result := make(map[string]tools.Tool)
+	for _, source := range d.sources {
+		for _, tool := range source.snapshot {
+			if _, active := d.activatedTools[tool.Name]; active {
+				continue
+			}
+			if _, exists := result[tool.Name]; !exists {
+				result[tool.Name] = tool
+			}
+		}
+	}
+	return result
+}
+
+func (d *ToolSet) handleSearchTool(ctx context.Context, args SearchToolArgs) (*tools.ToolCallResult, error) {
+	queryRunes := []rune(strings.ToLower(strings.TrimSpace(args.Query)))
+
+	deferredTools := d.deferredTools(ctx)
 
 	type scoredDeferredTool struct {
 		result SearchToolResult
@@ -113,19 +174,19 @@ func (d *ToolSet) handleSearchTool(ctx context.Context, args SearchToolArgs) (*t
 	}
 
 	var matches []scoredDeferredTool
-	for name, entry := range d.deferredTools {
+	for name, tool := range deferredTools {
 		if len(queryRunes) == 0 {
 			matches = append(matches, scoredDeferredTool{
 				result: SearchToolResult{
 					Name:        name,
-					Description: entry.tool.Description,
+					Description: tool.Description,
 				},
 				score: 0,
 			})
 			continue
 		}
 
-		chars := util.ToChars([]byte(name + " " + entry.tool.Description))
+		chars := util.ToChars([]byte(name + " " + tool.Description))
 		res, _ := algo.FuzzyMatchV2(
 			false, // caseSensitive
 			true,  // normalize
@@ -140,7 +201,7 @@ func (d *ToolSet) handleSearchTool(ctx context.Context, args SearchToolArgs) (*t
 			matches = append(matches, scoredDeferredTool{
 				result: SearchToolResult{
 					Name:        name,
-					Description: entry.tool.Description,
+					Description: tool.Description,
 				},
 				score: res.Score,
 			})
@@ -161,7 +222,7 @@ func (d *ToolSet) handleSearchTool(ctx context.Context, args SearchToolArgs) (*t
 			attribute.String("cagent.tool.deferred.op", "search_tool"),
 			attribute.String("cagent.tool.deferred.query", args.Query),
 			attribute.Int("cagent.tool.deferred.match_count", len(results)),
-			attribute.Int("cagent.tool.deferred.pool_size", len(d.deferredTools)),
+			attribute.Int("cagent.tool.deferred.pool_size", len(deferredTools)),
 		)
 	}
 
@@ -177,39 +238,58 @@ func (d *ToolSet) handleSearchTool(ctx context.Context, args SearchToolArgs) (*t
 	return tools.ResultSuccess(fmt.Sprintf("Found %d deferred tool(s):\n%s", len(results), string(output))), nil
 }
 
-func (d *ToolSet) handleAddTool(ctx context.Context, args AddToolArgs) (*tools.ToolCallResult, error) {
-	d.mu.Lock()
-	defer d.mu.Unlock()
+type addOutcome string
 
-	span := trace.SpanFromContext(ctx)
-	annotate := func(outcome string) {
-		if !span.IsRecording() {
-			return
-		}
+const (
+	outcomeActivated     addOutcome = "activated"
+	outcomeAlreadyActive addOutcome = "already_active"
+	outcomeNotFound      addOutcome = "not_found"
+)
+
+func (d *ToolSet) handleAddTool(ctx context.Context, args AddToolArgs) (*tools.ToolCallResult, error) {
+	d.snapshotPendingSources(ctx)
+
+	// Decide and apply under one lock so concurrent add_tool calls for the
+	// same name report exactly one activation.
+	d.mu.Lock()
+	outcome, tool := d.activateLocked(args.Name)
+	activatedCount := len(d.activatedTools)
+	d.mu.Unlock()
+
+	if span := trace.SpanFromContext(ctx); span.IsRecording() {
 		span.SetAttributes(
 			attribute.String("cagent.tool.deferred.op", "add_tool"),
 			attribute.String("cagent.tool.deferred.tool_name", args.Name),
-			attribute.String("cagent.tool.deferred.outcome", outcome),
-			attribute.Int("cagent.tool.deferred.activated_count", len(d.activatedTools)),
+			attribute.String("cagent.tool.deferred.outcome", string(outcome)),
+			attribute.Int("cagent.tool.deferred.activated_count", activatedCount),
 		)
 	}
 
-	if _, exists := d.activatedTools[args.Name]; exists {
-		annotate("already_active")
+	switch outcome {
+	case outcomeAlreadyActive:
 		return tools.ResultSuccess(fmt.Sprintf("Tool '%s' is already active", args.Name)), nil
-	}
-
-	entry, exists := d.deferredTools[args.Name]
-	if !exists {
-		annotate("not_found")
+	case outcomeActivated:
+		return tools.ResultSuccess(fmt.Sprintf("Tool '%s' has been activated and is now available for use.\n\nDescription: %s", args.Name, tool.Description)), nil
+	default:
 		return tools.ResultError(fmt.Sprintf("Tool '%s' not found.", args.Name)), nil
 	}
+}
 
-	delete(d.deferredTools, args.Name)
-	d.activatedTools[args.Name] = entry.tool
-	annotate("activated")
-
-	return tools.ResultSuccess(fmt.Sprintf("Tool '%s' has been activated and is now available for use.\n\nDescription: %s", args.Name, entry.tool.Description)), nil
+// activateLocked activates name from the first listed source that defers it.
+// d.mu must be held for writing.
+func (d *ToolSet) activateLocked(name string) (addOutcome, tools.Tool) {
+	if tool, active := d.activatedTools[name]; active {
+		return outcomeAlreadyActive, tool
+	}
+	for _, source := range d.sources {
+		for _, tool := range source.snapshot {
+			if tool.Name == name {
+				d.activatedTools[name] = tool
+				return outcomeActivated, tool
+			}
+		}
+	}
+	return outcomeNotFound, tools.Tool{}
 }
 
 func (d *ToolSet) Tools(context.Context) ([]tools.Tool, error) {
@@ -248,36 +328,4 @@ func (d *ToolSet) Tools(context.Context) ([]tools.Tool, error) {
 	}
 
 	return result, nil
-}
-
-func (d *ToolSet) Start(ctx context.Context) error {
-	// Note: we are not responsible for starting the underlying toolsets here
-	d.mu.Lock()
-	defer d.mu.Unlock()
-
-	for _, source := range d.sources {
-		allTools, err := source.toolset.Tools(ctx)
-		if err != nil {
-			return fmt.Errorf("failed to get tools from source: %w", err)
-		}
-
-		for _, tool := range allTools {
-			if !source.deferAll && !slices.Contains(source.tools, tool.Name) {
-				continue
-			}
-
-			if _, exists := d.deferredTools[tool.Name]; !exists {
-				d.deferredTools[tool.Name] = deferredToolEntry{
-					tool:   tool,
-					source: source.toolset,
-				}
-			}
-		}
-	}
-
-	return nil
-}
-
-func (d *ToolSet) Stop(context.Context) error {
-	return nil
 }

--- a/pkg/tools/builtin/deferred/deferred_test.go
+++ b/pkg/tools/builtin/deferred/deferred_test.go
@@ -2,19 +2,30 @@ package deferred
 
 import (
 	"context"
+	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/docker/docker-agent/pkg/tools"
+	"github.com/docker/docker-agent/pkg/tools/lifecycle"
 )
 
 type mockToolSet struct {
 	toolList []tools.Tool
+	// notStarted makes Tools fail like an MCP toolset that is still starting.
+	notStarted atomic.Bool
+	calls      atomic.Int32
 }
 
 func (m *mockToolSet) Tools(_ context.Context) ([]tools.Tool, error) {
+	m.calls.Add(1)
+	if m.notStarted.Load() {
+		return nil, lifecycle.ErrNotStarted
+	}
 	return m.toolList, nil
 }
 
@@ -31,10 +42,8 @@ func TestDeferredToolset_SearchTool(t *testing.T) {
 
 	dt := New()
 	dt.AddSource(mockTools, true, nil)
-	err := dt.Start(ctx)
-	require.NoError(t, err)
 
-	_, err = dt.Tools(ctx)
+	_, err := dt.Tools(ctx)
 	require.NoError(t, err)
 
 	t.Run("search by name", func(t *testing.T) {
@@ -82,8 +91,6 @@ func TestDeferredToolset_AddTool(t *testing.T) {
 
 	dt := New()
 	dt.AddSource(mockTools, true, nil)
-	err := dt.Start(ctx)
-	require.NoError(t, err)
 
 	initialTools, err := dt.Tools(ctx)
 	require.NoError(t, err)
@@ -115,4 +122,130 @@ func TestDeferredToolset_AddTool(t *testing.T) {
 		require.NoError(t, err)
 		assert.Contains(t, result.Output, "not found")
 	})
+
+	t.Run("activated tool no longer listed by search", func(t *testing.T) {
+		result, err := dt.handleSearchTool(ctx, SearchToolArgs{Query: "tool"})
+		require.NoError(t, err)
+		assert.Contains(t, result.Output, "tool2")
+		assert.NotContains(t, result.Output, "tool1")
+	})
+}
+
+func TestDeferredToolset_PartialDefer(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+	mockTools := &mockToolSet{
+		toolList: []tools.Tool{
+			{Name: "kept", Description: "Always exposed"},
+			{Name: "deferred", Description: "Only on demand"},
+		},
+	}
+
+	dt := New()
+	dt.AddSource(mockTools, false, []string{"deferred"})
+
+	result, err := dt.handleSearchTool(ctx, SearchToolArgs{})
+	require.NoError(t, err)
+	assert.Contains(t, result.Output, "deferred")
+	assert.NotContains(t, result.Output, "kept")
+
+	result, err = dt.handleAddTool(ctx, AddToolArgs{Name: "kept"})
+	require.NoError(t, err)
+	assert.Contains(t, result.Output, "not found")
+}
+
+// A source that has not finished starting (e.g. an MCP server still coming up
+// when the first turn runs) must not break the deferred toolset: its tools are
+// simply absent until it is ready, while other sources stay searchable.
+func TestDeferredToolset_SourceNotStartedYet(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	slow := &mockToolSet{toolList: []tools.Tool{{Name: "slow_tool", Description: "From the slow source"}}}
+	slow.notStarted.Store(true)
+	ready := &mockToolSet{toolList: []tools.Tool{{Name: "ready_tool", Description: "From the ready source"}}}
+
+	dt := New()
+	dt.AddSource(slow, true, nil)
+	dt.AddSource(ready, true, nil)
+
+	result, err := dt.handleSearchTool(ctx, SearchToolArgs{Query: "tool"})
+	require.NoError(t, err)
+	assert.Contains(t, result.Output, "ready_tool")
+	assert.NotContains(t, result.Output, "slow_tool")
+
+	result, err = dt.handleAddTool(ctx, AddToolArgs{Name: "slow_tool"})
+	require.NoError(t, err)
+	assert.Contains(t, result.Output, "not found")
+
+	slow.notStarted.Store(false)
+
+	result, err = dt.handleSearchTool(ctx, SearchToolArgs{Query: "slow"})
+	require.NoError(t, err)
+	assert.Contains(t, result.Output, "slow_tool")
+
+	result, err = dt.handleAddTool(ctx, AddToolArgs{Name: "slow_tool"})
+	require.NoError(t, err)
+	assert.Contains(t, result.Output, "has been activated")
+
+	currentTools, err := dt.Tools(ctx)
+	require.NoError(t, err)
+	assert.Len(t, currentTools, 3) // search_tool, add_tool, slow_tool
+
+	// Each source is listed until it succeeds, then snapshotted: slow failed
+	// twice then succeeded once; ready succeeded on the first call.
+	assert.Equal(t, int32(3), slow.calls.Load())
+	assert.Equal(t, int32(1), ready.calls.Load())
+}
+
+func TestDeferredToolset_FirstSourceWinsOnDuplicateName(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	first := &mockToolSet{toolList: []tools.Tool{{Name: "dup", Description: "from first"}}}
+	second := &mockToolSet{toolList: []tools.Tool{{Name: "dup", Description: "from second"}}}
+
+	dt := New()
+	dt.AddSource(first, true, nil)
+	dt.AddSource(second, true, nil)
+
+	result, err := dt.handleAddTool(ctx, AddToolArgs{Name: "dup"})
+	require.NoError(t, err)
+	assert.Contains(t, result.Output, "from first")
+}
+
+func TestDeferredToolset_ConcurrentAddTool(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	source := &mockToolSet{toolList: []tools.Tool{{Name: "tool1", Description: "First tool"}}}
+	dt := New()
+	dt.AddSource(source, true, nil)
+
+	var activated, alreadyActive atomic.Int32
+	var wg sync.WaitGroup
+	for range 16 {
+		wg.Go(func() {
+			result, err := dt.handleAddTool(ctx, AddToolArgs{Name: "tool1"})
+			if err != nil {
+				t.Error(err)
+				return
+			}
+			switch {
+			case strings.Contains(result.Output, "has been activated"):
+				activated.Add(1)
+			case strings.Contains(result.Output, "already active"):
+				alreadyActive.Add(1)
+			default:
+				t.Errorf("unexpected outcome: %s", result.Output)
+			}
+		})
+	}
+	wg.Wait()
+
+	assert.Equal(t, int32(1), activated.Load(), "exactly one call must report the activation")
+	assert.Equal(t, int32(15), alreadyActive.Load())
+	currentTools, err := dt.Tools(ctx)
+	require.NoError(t, err)
+	assert.Len(t, currentTools, 3) // search_tool, add_tool, tool1 — never duplicated
 }

--- a/pkg/tools/capabilities.go
+++ b/pkg/tools/capabilities.go
@@ -24,10 +24,14 @@ type StartReporter interface {
 }
 
 // PeerDependent is implemented by toolsets whose Start reads from the
-// agent's other toolsets (e.g. the deferred aggregator lists its source
-// toolsets' tools). Callers that start an agent's toolsets concurrently
-// must start these only after every other toolset has settled, or their
-// Start would race the very toolsets it depends on.
+// agent's other toolsets. Callers that start an agent's toolsets
+// concurrently must start these only after every other toolset has
+// settled, or their Start would race the very toolsets it depends on.
+//
+// Note the guarantee is best-effort: a peer whose start is already in
+// flight elsewhere is skipped, not awaited, so a PeerDependent Start must
+// still tolerate a peer that is not ready yet. Prefer resolving peer state
+// lazily, as the deferred toolset does.
 type PeerDependent interface {
 	StartsAfterPeers()
 }


### PR DESCRIPTION
When a message arrived while the runtime's startup probe was still initialising an MCP source, the agent's per-turn start skipped that in-flight source (`TryStart` never joins an already-running attempt) and immediately called the deferred toolset's `Start`. That call snapshot the source's tools via `Tools()`, which returned `ErrNotStarted`, so the whole deferred toolset failed with `deferred start failed: failed to get tools from source: toolset not started`. The `PeerDependent` second-wave mechanism couldn't close the gap: a source that was skipped as "already in flight" had not yet settled, so there was nothing ready to observe.

The fix removes `Start` and `PeerDependent` from the deferred toolset entirely and moves to lazy resolution. Each call to `search_tool` or `add_tool` walks the sources that are ready to list at that moment; sources that are still starting are silently skipped and retried on the next call, so their tools appear naturally once they come up. If a source never becomes available the model simply sees "No deferred tools found" for that source rather than the entire toolset aborting. `add_tool` now also evaluates and applies its outcome under a single lock, eliminating a race where two concurrent calls for the same tool name could both report a successful activation.

A pre-existing bug in `pkg/teamloader/toon.go` was surfaced during review: the TOON wrapper rewrote handlers in place on the inner toolset's cached slice, so each turn re-wrapped the same handlers rather than the originals. The slice is now cloned before wrapping. `tools.PeerDependent` is retained for Go SDK compatibility; its doc comment now notes that the second wave is best-effort.