### PR TITLE
chore: simplify built-in coder agent

### DIFF
--- a/pkg/config/builtin-agents/coder.yaml
+++ b/pkg/config/builtin-agents/coder.yaml
@@ -45,8 +45,7 @@ agents:
       - Make minimal, focused changes. Don't refactor unrelated code unless asked.
       - Match the project's existing style, conventions, and patterns.
       - Always validate your work by running tests or linters when available.
-      - Use the think tool to reason through complex problems step by step.
-      - Use the todo tool to track multi-step tasks and avoid losing context.
+      - Break complex work into clear steps and keep track of progress in the conversation.
       - Prefer tools over guessing. If you need to know something, look it up.
       - When you don't know the project's build/test/lint commands, look for Makefiles, Taskfile.yml, package.json, Cargo.toml, pyproject.toml, or similar.
       - Call multiple tools concurrently when the calls are independent.
@@ -67,39 +66,16 @@ agents:
       - For complex tasks, briefly outline your plan before starting.
       </communication>
 
-      <librarian>
-      You have access to a librarian sub-agent that can search the web and documentation.
-      Delegate to the librarian when you need:
-      - Documentation for an unfamiliar library, API, or framework
-      - Best practices or patterns you're not sure about
-      - Information about error messages or issues you can't resolve from context alone
-      Don't delegate for things you already know or can find in the local codebase.
-      </librarian>
-
-      <planner>
-      For non-trivial tasks where the user wants to design or plan before
-      implementation, suggest the /plan command. It switches the conversation
-      to the planner sub-agent, which gathers requirements and produces a
-      step-by-step plan without writing code.
-      </planner>
     skills: true
     add_date: true
     add_environment_info: true
     add_prompt_files:
       - AGENTS.md
-    sub_agents:
-      - librarian
-      - planner
     toolsets:
-      - type: filesystem
+      - type: file
       - type: shell
-      - type: background_jobs
-      - type: todo
       - type: fetch
     commands:
-      plan:
-        description: "Switch to plan mode (planner sub-agent)"
-        agent: planner
       commit:
         description: "Commit local changes with an appropriate message"
         instruction: |
@@ -149,65 +125,3 @@ agents:
           2. Run the tests
           3. If any fail, analyze the failures, fix the code, and re-run
           4. Continue until all tests pass
-
-  planner:
-    model: default
-    description: Planning Agent
-    instruction: |
-      You are a planning agent. You gather requirements and produce a
-      step-by-step plan before any code is written.
-
-      <workflow>
-      1. **Clarify**: Ask the user focused questions to remove ambiguity.
-         Prefer multiple-choice questions when possible. Don't guess.
-      2. **Investigate**: Explore the codebase with read-only tools to
-         understand the relevant code, conventions, and constraints.
-      3. **Plan**: Produce a numbered, step-by-step plan in markdown.
-         Identify the files to touch, the dependencies between steps, and
-         any risks. Save the plan to a markdown file in the working
-         directory when the user agrees with it.
-      4. **Hand off**: Once the plan is approved, use /back to return to
-         the root agent for execution. Mention the plan filename so the
-         root agent can pick it up.
-      </workflow>
-
-      <principles>
-      - Do not write or edit code. You plan, the root agent executes.
-      - Read the existing code before proposing changes — don't invent file
-        paths or APIs.
-      - Keep the plan concrete and actionable: each step should be small
-        enough to verify on its own.
-      - When you don't know something, delegate to the librarian sub-agent.
-      </principles>
-    add_date: true
-    add_environment_info: true
-    add_prompt_files:
-      - AGENTS.md
-    sub_agents:
-      - root
-      - librarian
-    toolsets:
-      - type: filesystem
-      - type: fetch
-      - type: todo
-      - type: user_prompt
-    commands:
-      back:
-        description: "Hand off back to the root coding agent"
-        agent: root
-
-  librarian:
-    model: fast
-    description: Web Researcher
-    instruction: |
-      You search the web for documentation, articles, and technical references.
-
-      When given a query:
-      1. Use context7 to search library/framework documentation
-      2. Use fetch to read specific URLs when needed
-
-      A good source of information, available to agents, is https://deepwiki.com/.
-
-      Return focused, relevant information. Include source URLs. Don't pad your response — just provide what was asked for.
-    toolsets:
-      - type: fetch


### PR DESCRIPTION
## Summary
- remove the planner and librarian sub-agents from the built-in coder
- limit the coder to the file, shell, and fetch toolsets
- preserve the existing model definitions

## Validation
- `task build`
- `task lint`
- `go test ./pkg/config -count=1`
- `task test` *(one unrelated existing failure: `pkg/sandbox` `TestExtraWorkspace/built-in_name` resolves `default` to the repository `examples` directory)*