### PR TITLE
feat(leantui): add sessions command

### DIFF
--- a/pkg/leantui/commands.go
+++ b/pkg/leantui/commands.go
@@ -6,6 +6,7 @@ import "github.com/docker/docker-agent/pkg/leantui/ui"
 func builtinCommands() []ui.Command {
 	return []ui.Command{
 		{Name: "new", Desc: "Start a new session", Kind: ui.CmdBuiltin},
+		{Name: "sessions", Desc: "Resume a session from the current directory", Kind: ui.CmdBuiltin},
 		{Name: "compact", Desc: "Summarize and compact the conversation", Kind: ui.CmdBuiltin},
 		{Name: "model", Desc: "Change the model for the current agent", Kind: ui.CmdBuiltin},
 		{Name: "effort", Desc: "Set the model's reasoning effort (usage: /effort <level>)", Kind: ui.CmdBuiltin},

--- a/pkg/leantui/update.go
+++ b/pkg/leantui/update.go
@@ -9,11 +9,14 @@ import (
 
 	"charm.land/lipgloss/v2"
 
+	"github.com/docker/docker-agent/pkg/chat"
 	"github.com/docker/docker-agent/pkg/effort"
 	"github.com/docker/docker-agent/pkg/leantui/ui"
 	"github.com/docker/docker-agent/pkg/modelpicker"
 	"github.com/docker/docker-agent/pkg/runtime"
+	"github.com/docker/docker-agent/pkg/session"
 	"github.com/docker/docker-agent/pkg/tui/messages"
+	"github.com/docker/docker-agent/pkg/tui/service"
 )
 
 func (m *model) handleKey(ctx context.Context, k ui.Key) {
@@ -247,6 +250,9 @@ func (m *model) handleSlash(ctx context.Context, text string, mode busySubmitMod
 	case "help":
 		m.commitHelp()
 		return true
+	case "sessions":
+		m.handleSessionsCommand(ctx, rest)
+		return true
 	case "compact":
 		m.addUserEcho(text)
 		m.startCompact(ctx, rest)
@@ -276,6 +282,126 @@ func (m *model) handleSlash(ctx context.Context, text string, mode busySubmitMod
 	}
 
 	return false
+}
+
+func (m *model) handleSessionsCommand(ctx context.Context, sessionID string) {
+	if m.busy {
+		m.addNotice("", "Wait for the current response to finish before switching sessions", ui.StMuted())
+		return
+	}
+	if m.app == nil || m.app.SessionStore() == nil {
+		m.addNotice("", "No session store configured", ui.StMuted())
+		return
+	}
+
+	if sessionID != "" {
+		m.resumeSession(ctx, sessionID)
+		return
+	}
+
+	summaries, err := m.app.SessionStore().GetSessionSummaries(ctx)
+	if err != nil {
+		m.addNotice("✗ ", "Failed to load sessions: "+err.Error(), ui.StError())
+		return
+	}
+
+	currentDir := cleanDirectory(m.app.Session().WorkingDir)
+	currentID := m.app.Session().ID
+	cmds := make([]ui.Command, 0, len(summaries))
+	for _, summary := range summaries {
+		if summary.ID == currentID || cleanDirectory(summary.WorkingDir) != currentDir {
+			continue
+		}
+		title := strings.TrimSpace(summary.Title)
+		if title == "" {
+			title = "Untitled"
+		}
+		s := summary
+		cmds = append(cmds, ui.Command{
+			Name:  title,
+			Desc:  fmt.Sprintf("%s · %d messages", s.CreatedAt.Local().Format("Jan 2 15:04"), s.NumMessages),
+			Value: s.ID,
+			MatchScore: func(query string) (int, bool) {
+				query = strings.ToLower(strings.TrimSpace(query))
+				if query == "" {
+					return 0, true
+				}
+				if strings.Contains(strings.ToLower(title), query) || strings.Contains(strings.ReplaceAll(strings.ToLower(s.ID), "-", ""), strings.ReplaceAll(query, "-", "")) {
+					return 1, true
+				}
+				return 0, false
+			},
+			Kind: ui.CmdBuiltin,
+		})
+	}
+	if len(cmds) == 0 {
+		m.addNotice("", "No previous sessions found in this directory", ui.StMuted())
+		return
+	}
+
+	m.screen.Autocomplete.SetScopedCommands("sessions ", cmds)
+	m.screen.Editor.SetText("/sessions ")
+	m.screen.Autocomplete.Sync(m.screen.Editor.Text())
+}
+
+func cleanDirectory(dir string) string {
+	if dir == "" {
+		return ""
+	}
+	abs, err := filepath.Abs(dir)
+	if err != nil {
+		return filepath.Clean(dir)
+	}
+	if resolved, err := filepath.EvalSymlinks(abs); err == nil {
+		abs = resolved
+	}
+	return filepath.Clean(abs)
+}
+
+func (m *model) resumeSession(ctx context.Context, sessionID string) {
+	sess, err := m.app.SessionStore().GetSession(ctx, sessionID)
+	if err != nil {
+		m.addNotice("✗ ", "Failed to load session: "+err.Error(), ui.StError())
+		return
+	}
+	if cleanDirectory(sess.WorkingDir) != cleanDirectory(m.app.Session().WorkingDir) {
+		m.addNotice("✗ ", "Session is not from the current directory", ui.StError())
+		return
+	}
+
+	m.app.ReplaceSession(ctx, sess)
+	m.resetConversation()
+	m.screen.Transcript = ui.NewTranscript()
+	m.sessionState = service.NewSessionState(sess)
+	m.loadSessionTranscript(sess)
+	m.refreshCommands(ctx)
+	title := strings.TrimSpace(sess.Title)
+	if title == "" {
+		title = sess.ID
+	}
+	m.addNotice("", "Resumed session: "+title, ui.StMuted())
+}
+
+func (m *model) loadSessionTranscript(sess *session.Session) {
+	for _, msg := range sess.OwnMessages() {
+		if msg.Implicit {
+			continue
+		}
+		content := msg.Message.Content
+		switch msg.Message.Role {
+		case chat.MessageRoleUser:
+			m.addUserEcho(content)
+		case chat.MessageRoleAssistant:
+			if msg.Message.ReasoningContent != "" {
+				reasoning := msg.Message.ReasoningContent
+				m.screen.Transcript.AddBlock(func(w int) []string { return ui.RenderReasoningLines(reasoning, w) })
+			}
+			if content != "" {
+				answer := content
+				m.screen.Transcript.AddBlock(func(w int) []string { return ui.RenderAssistantLines(answer, w) })
+			}
+		}
+	}
 }
 
 func (m *model) handleModelCommand(ctx context.Context, modelRef string) {
@@ -549,6 +675,7 @@ func (m *model) commitHelp() {
 		return []string{
 			ui.StBold().Render("Commands"),
 			ui.StMuted().Render("  /new       start a new session"),
+			ui.StMuted().Render("  /sessions  resume a session from this directory"),
 			ui.StMuted().Render("  /compact   summarize and compact the conversation"),
 			ui.StMuted().Render("  /model     change the model for the current agent"),
 			ui.StMuted().Render("  /effort    set the model's reasoning effort (e.g. /effort high)"),

--- a/pkg/leantui/update_test.go
+++ b/pkg/leantui/update_test.go
@@ -4,10 +4,13 @@ import (
 	"context"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/docker/docker-agent/pkg/app"
+	"github.com/docker/docker-agent/pkg/chat"
 	"github.com/docker/docker-agent/pkg/effort"
 	"github.com/docker/docker-agent/pkg/leantui/ui"
 	"github.com/docker/docker-agent/pkg/runtime"
@@ -16,6 +19,7 @@ import (
 	"github.com/docker/docker-agent/pkg/tools"
 	skillstool "github.com/docker/docker-agent/pkg/tools/builtin/skills"
 	mcptools "github.com/docker/docker-agent/pkg/tools/mcp"
+	"github.com/docker/docker-agent/pkg/tui/service"
 )
 
 type cycleThinkingRuntime struct {
@@ -31,6 +35,7 @@ type cycleThinkingRuntime struct {
 	models     []runtime.ModelChoice
 	modelRef   string
 	modelErr   error
+	store      session.Store
 }
 
 func (r *cycleThinkingRuntime) CurrentAgentInfo(context.Context) runtime.CurrentAgentInfo {
@@ -63,7 +68,7 @@ func (r *cycleThinkingRuntime) Resume(context.Context, runtime.ResumeRequest) {}
 func (r *cycleThinkingRuntime) ResumeElicitation(context.Context, tools.ElicitationAction, map[string]any, ...string) error {
 	return nil
 }
-func (r *cycleThinkingRuntime) SessionStore() session.Store { return nil }
+func (r *cycleThinkingRuntime) SessionStore() session.Store { return r.store }
 func (r *cycleThinkingRuntime) Summarize(context.Context, *session.Session, string, runtime.EventSink) {
 }
 func (r *cycleThinkingRuntime) PermissionsInfo() *runtime.PermissionsInfo { return nil }
@@ -141,6 +146,72 @@ func (r *cycleThinkingRuntime) OnBackgroundEvent(func(runtime.Event))    {}
 func (r *cycleThinkingRuntime) OnElicitationRequest(func(runtime.Event)) {}
 
 var _ runtime.Runtime = (*cycleThinkingRuntime)(nil)
+
+func TestSessionsCommandListsCurrentDirectoryAndResumesSelection(t *testing.T) {
+	t.Parallel()
+	store := session.NewInMemorySessionStore()
+	workingDir := t.TempDir()
+	current := session.New(session.WithWorkingDir(workingDir))
+	resumable := session.New(session.WithWorkingDir(workingDir))
+	resumable.Title = "Previous work"
+	resumable.CreatedAt = time.Date(2026, time.September, 2, 14, 30, 0, 0, time.Local)
+	resumable.AddMessage(session.UserMessage("continue this task"))
+	resumable.AddMessage(session.NewAgentMessage("coder", &chat.Message{Role: chat.MessageRoleAssistant, Content: "previous answer"}))
+	other := session.New(session.WithWorkingDir(t.TempDir()))
+	other.Title = "Other directory"
+	require.NoError(t, store.AddSession(t.Context(), resumable))
+	require.NoError(t, store.AddSession(t.Context(), other))
+
+	rt := &cycleThinkingRuntime{store: store}
+	m := bareModel(80)
+	m.app = app.New(t.Context(), rt, current)
+	m.sessionState = service.NewSessionState(current)
+
+	assert.True(t, m.handleSlash(t.Context(), "/sessions", busySubmitSteer))
+	assert.Equal(t, "/sessions ", m.screen.Editor.Text())
+	assert.True(t, m.screen.Autocomplete.Active)
+	cmd, ok := m.screen.Autocomplete.Current()
+	require.True(t, ok)
+	assert.Equal(t, "Previous work", cmd.Name)
+	assert.Equal(t, "/sessions "+resumable.ID, m.screen.Autocomplete.Completion(cmd))
+
+	assert.True(t, m.handleSlash(t.Context(), m.screen.Autocomplete.Completion(cmd), busySubmitSteer))
+	assert.Equal(t, resumable.ID, m.app.Session().ID)
+	transcript := strings.Join(m.screen.Transcript.Lines(80, 0, false, m.sessionState, nil), "\n")
+	assert.Contains(t, transcript, "continue this task")
+	assert.Contains(t, transcript, "previous answer")
+	assert.NotContains(t, transcript, "Other directory")
+}
+
+func TestSessionsCommandReportsNoSessionsInCurrentDirectory(t *testing.T) {
+	t.Parallel()
+	store := session.NewInMemorySessionStore()
+	other := session.New(session.WithWorkingDir(t.TempDir()))
+	require.NoError(t, store.AddSession(t.Context(), other))
+
+	current := session.New(session.WithWorkingDir(t.TempDir()))
+	m := bareModel(80)
+	m.app = app.New(t.Context(), &cycleThinkingRuntime{store: store}, current)
+
+	assert.True(t, m.handleSlash(t.Context(), "/sessions", busySubmitSteer))
+	transcript := strings.Join(m.screen.Transcript.Lines(80, 0, false, m.sessionState, nil), "\n")
+	assert.Contains(t, transcript, "No previous sessions found in this directory")
+	assert.False(t, m.screen.Autocomplete.Active)
+}
+
+func TestSessionsCommandDoesNotSwitchWhileBusy(t *testing.T) {
+	t.Parallel()
+	store := session.NewInMemorySessionStore()
+	current := session.New(session.WithWorkingDir(t.TempDir()))
+	m := bareModel(80)
+	m.app = app.New(t.Context(), &cycleThinkingRuntime{store: store}, current)
+	m.busy = true
+
+	assert.True(t, m.handleSlash(t.Context(), "/sessions", busySubmitSteer))
+	assert.Equal(t, current.ID, m.app.Session().ID)
+	transcript := strings.Join(m.screen.Transcript.Lines(80, 0, true, m.sessionState, nil), "\n")
+	assert.Contains(t, transcript, "Wait for the current response to finish")
+}
 
 func TestShiftTabCyclesThinkingLevel(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
## Summary

- add a `/sessions` command to the lean TUI
- list and search previous sessions from the current directory
- restore the selected conversation in place so it can be resumed
- prevent session switching while a response is running

## Validation

- `go test ./pkg/leantui/...`
- `task lint`
- `go build ./...`
- `task test` (all packages passed except the unrelated `pkg/sandbox` `TestExtraWorkspace/built-in_name`, which is affected by the local user alias named `default`; it passes with a clean home/config)
