### PR TITLE
fix(leantui): support shift-enter newlines

### DIFF
--- a/pkg/leantui/ui/keys.go
+++ b/pkg/leantui/ui/keys.go
@@ -14,7 +14,8 @@ const (
 	KeyRune
 	KeyPaste
 	KeyEnter
-	KeyAltEnter // insert a literal newline (multi-line input)
+	KeyShiftEnter // insert a literal newline (multi-line input)
+	KeyAltEnter   // submit an end-of-turn follow-up
 	KeyTab
 	KeyShiftTab
 	KeyBackspace
@@ -244,6 +245,40 @@ func parseCSI(b []byte) (int, Key) {
 		return consumed, Key{Typ: KeyEnd}
 	case 'Z':
 		return consumed, Key{Typ: KeyShiftTab}
+	case 'u':
+		parts := strings.Split(params, ";")
+		code, err := strconv.Atoi(strings.SplitN(parts[0], ":", 2)[0])
+		if err != nil {
+			return consumed, Key{Typ: KeyNone}
+		}
+		mod := modifier()
+		if code == 13 {
+			switch mod {
+			case "2":
+				return consumed, Key{Typ: KeyShiftEnter}
+			case "3":
+				return consumed, Key{Typ: KeyAltEnter}
+			default:
+				return consumed, Key{Typ: KeyEnter}
+			}
+		}
+		if mod == "5" {
+			switch code {
+			case 'c', 'C':
+				return consumed, Key{Typ: KeyCtrlC}
+			case 'd', 'D':
+				return consumed, Key{Typ: KeyCtrlD}
+			case 'u', 'U':
+				return consumed, Key{Typ: KeyCtrlU}
+			case 'k', 'K':
+				return consumed, Key{Typ: KeyCtrlK}
+			case 'w', 'W':
+				return consumed, Key{Typ: KeyCtrlW}
+			case 'l', 'L':
+				return consumed, Key{Typ: KeyCtrlL}
+			}
+		}
+		return consumed, Key{Typ: KeyNone}
 	case '~':
 		switch n, _ := strconv.Atoi(strings.SplitN(params, ";", 2)[0]); n {
 		case 1, 7:

--- a/pkg/leantui/ui/keys_test.go
+++ b/pkg/leantui/ui/keys_test.go
@@ -58,6 +58,26 @@ func TestParseEscapeSequences(t *testing.T) {
 	assert.Equal(t, KeyAltEnter, singleKey(t, "\x1b\r").Typ)
 }
 
+func TestParseKittyKeyboardSequences(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		sequence string
+		want     KeyType
+	}{
+		{sequence: "\x1b[13;2u", want: KeyShiftEnter},
+		{sequence: "\x1b[13;3u", want: KeyAltEnter},
+		{sequence: "\x1b[99;5u", want: KeyCtrlC},
+		{sequence: "\x1b[100;5u", want: KeyCtrlD},
+		{sequence: "\x1b[117;5u", want: KeyCtrlU},
+		{sequence: "\x1b[107;5u", want: KeyCtrlK},
+		{sequence: "\x1b[119;5u", want: KeyCtrlW},
+		{sequence: "\x1b[108;5u", want: KeyCtrlL},
+	}
+	for _, tt := range tests {
+		assert.Equal(t, tt.want, singleKey(t, tt.sequence).Typ)
+	}
+}
+
 func TestParseLoneEscape(t *testing.T) {
 	t.Parallel()
 	assert.Equal(t, KeyEsc, singleKey(t, "\x1b").Typ)

--- a/pkg/leantui/ui/terminal.go
+++ b/pkg/leantui/ui/terminal.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"charm.land/lipgloss/v2"
+	"github.com/charmbracelet/x/ansi"
 	"github.com/muesli/cancelreader"
 	"golang.org/x/term"
 )
@@ -57,6 +58,7 @@ func NewTerminal(in, out *os.File) (*Terminal, error) {
 
 	lipgloss.EnableLegacyWindowsANSI(out)
 	t.writeString(seqEnableBracketedPaste)
+	t.writeString(ansi.PushKittyKeyboard(ansi.KittyDisambiguateEscapeCodes))
 	t.flush()
 	t.startResizeWatcher()
 
@@ -155,6 +157,7 @@ func (t *Terminal) flush() {
 // the reader, restores the saved terminal state and stops watching for resizes.
 func (t *Terminal) Restore() {
 	t.writeString(seqDisableBracketedPaste)
+	t.writeString(ansi.PopKittyKeyboard(1))
 	t.writeString(seqShowCursor)
 	t.flush()
 

--- a/pkg/leantui/update.go
+++ b/pkg/leantui/update.go
@@ -33,6 +33,8 @@ func (m *model) handleKey(ctx context.Context, k ui.Key) {
 		}
 	case ui.KeyEnter:
 		m.handleEnter(ctx)
+	case ui.KeyShiftEnter:
+		m.screen.Editor.Insert([]rune{'\n'})
 	case ui.KeyAltEnter:
 		m.submitEditorMode(ctx, m.screen.Editor.Text(), busySubmitFollowUp)
 	case ui.KeyTab:
@@ -557,10 +559,10 @@ func (m *model) commitHelp() {
 			ui.StMuted().Render("  /exit      quit"),
 			"",
 			ui.StBold().Render("Shortcuts"),
-			ui.StMuted().Render("  Enter      send             Alt+Enter   insert newline"),
-			ui.StMuted().Render("  Up/Down    history           Tab         complete command"),
-			ui.StMuted().Render("  Shift+Tab  cycle thinking    Ctrl+C      cancel / quit"),
-			ui.StMuted().Render("  Ctrl+W     delete previous word"),
+			ui.StMuted().Render("  Enter      send             Shift+Enter insert newline"),
+			ui.StMuted().Render("  Alt+Enter  follow up        Up/Down     history"),
+			ui.StMuted().Render("  Tab        complete command Shift+Tab   cycle thinking"),
+			ui.StMuted().Render("  Ctrl+C     cancel / quit    Ctrl+W      delete previous word"),
 		}
 	})
 }

--- a/pkg/leantui/update_test.go
+++ b/pkg/leantui/update_test.go
@@ -236,6 +236,16 @@ func TestModelCommandOpensModelAutocomplete(t *testing.T) {
 	}
 }
 
+func TestShiftEnterInsertsNewline(t *testing.T) {
+	t.Parallel()
+	m := bareModel(24)
+	m.screen.Editor.SetText("first line")
+
+	m.handleKey(t.Context(), ui.Key{Typ: ui.KeyShiftEnter})
+
+	assert.Equal(t, "first line\n", m.screen.Editor.Text())
+}
+
 func TestAltEnterWhileBusyQueuesRuntimeFollowUp(t *testing.T) {
 	t.Parallel()
 	rt := &cycleThinkingRuntime{}


### PR DESCRIPTION
## Summary

- enable Kitty keyboard disambiguation in the lean TUI
- decode Shift+Enter as a literal newline while preserving Alt+Enter follow-ups
- decode Kitty CSI-u forms of existing Ctrl shortcuts, including Ctrl+C
- update shortcut help and add parser/controller regression tests

## Validation

- `go test ./pkg/leantui/...`
- `task lint`
- `task build`

The full `task test` run reaches an unrelated existing failure in `pkg/sandbox`: `TestExtraWorkspace/built-in_name` expects no extra workspace but finds the repository `examples` directory.