### PR TITLE
feat(leantui): support bang commands

### DIFF
--- a/pkg/leantui/leantui.go
+++ b/pkg/leantui/leantui.go
@@ -91,6 +91,10 @@ func Run(ctx context.Context, cfg Config) error {
 		m.sendFirstMessage(loopCtx, first, cfg.FirstMessageAttachment)
 	}
 	for _, msg := range cfg.QueuedMessages {
+		if command, ok := strings.CutPrefix(strings.TrimSpace(msg), "!"); ok {
+			m.runBangCommand(loopCtx, command)
+			continue
+		}
 		m.enqueueFollowUp(msg, msg)
 	}
 

--- a/pkg/leantui/update.go
+++ b/pkg/leantui/update.go
@@ -224,11 +224,24 @@ func (m *model) submit(ctx context.Context, text string, opts submitOptions) {
 		m.screen.Autocomplete.Dismiss()
 	}
 
+	if command, ok := strings.CutPrefix(trimmed, "!"); ok {
+		m.runBangCommand(ctx, command)
+		return
+	}
+
 	if strings.HasPrefix(trimmed, "/") && m.handleSlash(ctx, trimmed, opts.busyMode) {
 		return
 	}
 
 	m.dispatchUserMessage(ctx, trimmed, trimmed, opts.busyMode)
+}
+
+func (m *model) runBangCommand(ctx context.Context, command string) {
+	if m.app.IsReadOnly() {
+		m.addNotice("⚠ ", "This session is read-only.", ui.StWarning())
+		return
+	}
+	m.app.RunBangCommand(ctx, command)
 }
 
 // handleSlash dispatches a slash command. It returns true when the command was
@@ -508,6 +521,11 @@ func (m *model) sendFirstMessage(ctx context.Context, msg, attachPath string) {
 	}
 
 	trimmed := strings.TrimSpace(msg)
+	if command, ok := strings.CutPrefix(trimmed, "!"); ok {
+		m.runBangCommand(ctx, command)
+		return
+	}
+
 	content := msg
 	if strings.HasPrefix(trimmed, "/") {
 		if resolved := m.app.ResolveInput(ctx, trimmed); resolved != "" {

--- a/pkg/leantui/update_test.go
+++ b/pkg/leantui/update_test.go
@@ -2,6 +2,8 @@ package leantui
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -29,6 +31,7 @@ type cycleThinkingRuntime struct {
 	cycleCalls int
 	setCalls   int
 	setLevel   effort.Level
+	runCalls   int
 	followUps  []runtime.QueuedMessage
 	steered    []runtime.QueuedMessage
 	steerErr   error
@@ -56,6 +59,7 @@ func (r *cycleThinkingRuntime) EmitAgentInfo(_ context.Context, sink runtime.Eve
 }
 func (r *cycleThinkingRuntime) ResetStartupInfo() {}
 func (r *cycleThinkingRuntime) RunStream(context.Context, *session.Session) <-chan runtime.Event {
+	r.runCalls++
 	ch := make(chan runtime.Event)
 	close(ch)
 	return ch
@@ -146,6 +150,53 @@ func (r *cycleThinkingRuntime) OnBackgroundEvent(func(runtime.Event))    {}
 func (r *cycleThinkingRuntime) OnElicitationRequest(func(runtime.Event)) {}
 
 var _ runtime.Runtime = (*cycleThinkingRuntime)(nil)
+
+func TestFirstMessageBangCommandRunsLocally(t *testing.T) {
+	outputPath := filepath.Join(t.TempDir(), "bang-output")
+	rt := &cycleThinkingRuntime{}
+	m := bareModel(80)
+	m.app = app.New(t.Context(), rt, session.New())
+
+	m.sendFirstMessage(t.Context(), `!printf bang > "`+outputPath+`"`, "")
+
+	output, err := os.ReadFile(outputPath)
+	require.NoError(t, err)
+	assert.Equal(t, "bang", string(output))
+	assert.Zero(t, rt.runCalls)
+}
+
+func TestSubmitBangCommandRunsImmediatelyWhileBusy(t *testing.T) {
+	outputPath := filepath.Join(t.TempDir(), "bang-output")
+	rt := &cycleThinkingRuntime{}
+	m := bareModel(80)
+	m.app = app.New(t.Context(), rt, session.New())
+	m.busy = true
+
+	m.submitEditor(t.Context(), `!printf bang > "`+outputPath+`"`)
+
+	output, err := os.ReadFile(outputPath)
+	require.NoError(t, err)
+	assert.Equal(t, "bang", string(output))
+	assert.Zero(t, rt.runCalls)
+	assert.Empty(t, rt.steered)
+	assert.Empty(t, m.queue)
+	assert.True(t, m.busy)
+}
+
+func TestSubmitBangCommandHonorsReadOnlySession(t *testing.T) {
+	outputPath := filepath.Join(t.TempDir(), "bang-output")
+	rt := &cycleThinkingRuntime{}
+	m := bareModel(80)
+	m.app = app.New(t.Context(), rt, session.New(), app.WithReadOnly())
+
+	m.submitEditor(t.Context(), `!printf bang > "`+outputPath+`"`)
+
+	_, err := os.Stat(outputPath)
+	require.ErrorIs(t, err, os.ErrNotExist)
+	assert.Zero(t, rt.runCalls)
+	transcript := strings.Join(m.screen.Transcript.Lines(80, 0, false, m.sessionState, nil), "\n")
+	assert.Contains(t, transcript, "This session is read-only.")
+}
 
 func TestSessionsCommandListsCurrentDirectoryAndResumesSelection(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
## Summary

- interpret lean TUI input starting with `!` as a local shell command
- reuse `App.RunBangCommand` so behavior and output match the full TUI
- run bang commands immediately without steering or queueing an active agent turn
- preserve read-only session protection

## Validation

- `go test ./pkg/leantui/...`
- `task build`
- `task lint`

The full `task test` run was otherwise green but hit the pre-existing environment-dependent `pkg/sandbox` `TestExtraWorkspace/built-in_name` failure because the local user config resolves `default` to `/Users/rumpl/dev/cagent/examples`.