### PR TITLE
fix: highlight user messages in lean TUI

### DIFF
--- a/pkg/leantui/ui/render.go
+++ b/pkg/leantui/ui/render.go
@@ -6,12 +6,20 @@ import (
 	"charm.land/lipgloss/v2"
 
 	"github.com/docker/docker-agent/pkg/tui/components/markdown"
+	"github.com/docker/docker-agent/pkg/tui/styles"
 )
 
 // RenderUserLines renders a submitted user message as committed scrollback,
 // echoing it with the same prompt marker used by the input box.
 func RenderUserLines(text string, width int) []string {
-	return RenderUserLinesWith(text, width, StAccent(), StPrimary())
+	if width < 1 {
+		width = 1
+	}
+	boxStyle := StUserBox(width)
+	innerWidth := max(width-boxStyle.GetHorizontalFrameSize(), 1)
+	textStyle := lipgloss.NewStyle().Foreground(styles.AgentBadgeFg)
+	content := strings.Join(RenderUserLinesWith(text, innerWidth, textStyle.Bold(true), textStyle), "\n")
+	return splitRenderedLines(styles.RenderComposite(boxStyle, content), width)
 }
 
 func RenderPendingUserLines(text string, width int) []string {

--- a/pkg/leantui/ui/render_test.go
+++ b/pkg/leantui/ui/render_test.go
@@ -1,0 +1,36 @@
+package ui
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/docker/docker-agent/pkg/tui/styles"
+)
+
+func TestRenderUserLinesUsesDistinctFullWidthBackground(t *testing.T) {
+	t.Parallel()
+
+	const width = 24
+	lines := RenderUserLines("make this visible", width)
+	require.NotEmpty(t, lines)
+	for _, line := range lines {
+		assert.Equal(t, width, DisplayWidth(line))
+	}
+
+	style := StUserBox(width)
+	assert.Equal(t, styles.MobyBlue, style.GetBackground())
+	assert.NotEqual(t, StToolBox(width).GetBackground(), style.GetBackground())
+}
+
+func TestRenderUserLinesWrapsInsideBackgroundPadding(t *testing.T) {
+	t.Parallel()
+
+	const width = 12
+	lines := RenderUserLines("a user message that wraps", width)
+	require.Greater(t, len(lines), 1)
+	for _, line := range lines {
+		assert.LessOrEqual(t, DisplayWidth(line), width)
+	}
+}

--- a/pkg/leantui/ui/style.go
+++ b/pkg/leantui/ui/style.go
@@ -22,6 +22,21 @@ func StReasoning() lipgloss.Style {
 	return lipgloss.NewStyle().Foreground(styles.TextMutedGray).Italic(true)
 }
 
+func StUserBox(width int) lipgloss.Style {
+	if width < 1 {
+		width = 1
+	}
+	horizontalPadding := 1
+	if width < 3 {
+		horizontalPadding = 0
+	}
+	return lipgloss.NewStyle().
+		Foreground(styles.AgentBadgeFg).
+		Background(styles.MobyBlue).
+		Padding(1, horizontalPadding).
+		Width(width)
+}
+
 func StToolBox(width int) lipgloss.Style {
 	if width < 1 {
 		width = 1

--- a/pkg/leantui/ui/tool.go
+++ b/pkg/leantui/ui/tool.go
@@ -84,7 +84,7 @@ func RenderToolWithState(t *ToolView, width, frame int, sessionState service.Ses
 		defer animation.StopView(view)
 	}
 
-	lines := splitRenderedTool(renderToolBox(view.View(), width), width)
+	lines := splitRenderedLines(renderToolBox(view.View(), width), width)
 	for _, img := range t.images {
 		lines = append(lines, RenderInlineImage(img, width)...)
 	}
@@ -132,7 +132,7 @@ func totalContentWidth(lines []string) int {
 	return total
 }
 
-func splitRenderedTool(rendered string, width int) []string {
+func splitRenderedLines(rendered string, width int) []string {
 	if width < 1 {
 		width = 1
 	}


### PR DESCRIPTION
## Summary

- render submitted user messages on a full-width brand-colored background
- add horizontal and vertical padding for clearer separation from assistant and tool output
- use a contrast-safe foreground from the active theme
- keep pending user messages muted

## Validation

- `task build`
- `task lint`
- `go test ./pkg/leantui/ui ./pkg/leantui`

## Screenshot

![Lean TUI with a highlighted user message](https://github.com/user-attachments/assets/93115c58-8083-4301-87d8-fa63a8e23d74)