### PR TITLE
fix(leantui): restore shift-tab thinking cycle

### DIFF
--- a/pkg/leantui/ui/keys.go
+++ b/pkg/leantui/ui/keys.go
@@ -252,7 +252,13 @@ func parseCSI(b []byte) (int, Key) {
 			return consumed, Key{Typ: KeyNone}
 		}
 		mod := modifier()
-		if code == 13 {
+		switch code {
+		case 9:
+			if mod == "2" {
+				return consumed, Key{Typ: KeyShiftTab}
+			}
+			return consumed, Key{Typ: KeyTab}
+		case 13:
 			switch mod {
 			case "2":
 				return consumed, Key{Typ: KeyShiftEnter}

--- a/pkg/leantui/ui/keys_test.go
+++ b/pkg/leantui/ui/keys_test.go
@@ -64,6 +64,7 @@ func TestParseKittyKeyboardSequences(t *testing.T) {
 		sequence string
 		want     KeyType
 	}{
+		{sequence: "\x1b[9;2u", want: KeyShiftTab},
 		{sequence: "\x1b[13;2u", want: KeyShiftEnter},
 		{sequence: "\x1b[13;3u", want: KeyAltEnter},
 		{sequence: "\x1b[99;5u", want: KeyCtrlC},


### PR DESCRIPTION
## What changed

- decode Shift+Tab emitted by the Kitty keyboard protocol as `CSI 9;2u`
- retain support for the legacy `CSI Z` sequence
- add a regression test for the Kitty sequence

Enabling Kitty keyboard disambiguation for Shift+Enter changed the emitted Shift+Tab sequence, but the Lean TUI parser only recognized the legacy form.

## Validation

- `go test ./pkg/leantui/ui ./pkg/leantui`
- `task lint`
- `task build`
- `task test` *(unrelated existing failure: `pkg/sandbox` `TestExtraWorkspace/built-in_name` expects an empty path but receives the repository `examples` directory)*