### PR TITLE
feat(leantui): label steering and follow-up messages

### DIFF
--- a/pkg/leantui/ui/render.go
+++ b/pkg/leantui/ui/render.go
@@ -14,9 +14,13 @@ func RenderUserLines(text string, width int) []string {
 	return RenderUserLinesWith(text, width, StAccent(), StPrimary())
 }
 
-func RenderPendingUserLines(text string, width int) []string {
+func RenderPendingUserLines(msg PendingUserMessage, width int) []string {
+	label := "Steering: "
+	if msg.Kind == PendingUserFollowUp {
+		label = "Follow-up: "
+	}
 	muted := StMuted()
-	return RenderUserLinesWith(text, width, muted, muted)
+	return RenderUserLinesWith(label+msg.Display, width, muted, muted)
 }
 
 func RenderUserLinesWith(text string, width int, promptStyle, textStyle lipgloss.Style) []string {

--- a/pkg/leantui/ui/transcript.go
+++ b/pkg/leantui/ui/transcript.go
@@ -159,7 +159,7 @@ func (t *Transcript) Lines(width, spinnerFrame int, busy bool, sessionState serv
 		lines = append(lines, spinnerLine(spinnerFrame), "")
 	}
 	for _, msg := range pendingUsers {
-		lines = append(lines, RenderPendingUserLines(msg.Display, width)...)
+		lines = append(lines, RenderPendingUserLines(msg, width)...)
 		lines = append(lines, "")
 	}
 	return lines

--- a/pkg/leantui/update_test.go
+++ b/pkg/leantui/update_test.go
@@ -333,6 +333,8 @@ func TestAltEnterWhileBusyQueuesRuntimeFollowUp(t *testing.T) {
 	assert.Empty(t, rt.steered)
 	assert.Empty(t, m.queue)
 	assert.Len(t, m.pendingUsers, 1)
+	joined := strings.Join(m.screen.Transcript.Lines(80, 0, true, m.sessionState, m.pendingUsers), "\n")
+	assert.Contains(t, joined, "Follow-up: do this next")
 	assert.True(t, m.screen.Editor.IsEmpty())
 }
 
@@ -354,6 +356,7 @@ func TestEditorSubmitWhileBusySteersAndRendersAtStreamEnd(t *testing.T) {
 	assert.Len(t, m.pendingUsers, 1)
 
 	joined := strings.Join(m.screen.Transcript.Lines(80, 0, true, m.sessionState, m.pendingUsers), "\n")
+	assert.Contains(t, joined, "Steering: turn left")
 	assistantAt := strings.Index(joined, "assistant is still streaming")
 	steerAt := strings.Index(joined, "turn left")
 	assert.NotEqual(t, -1, assistantAt)


### PR DESCRIPTION
## Summary

- label pending steering messages in the lean TUI
- label pending follow-up messages in the lean TUI
- cover both labels in submission-flow tests

## Validation

- `task build`
- `task lint`
- `go test ./pkg/leantui/...`
- `task test` *(one unrelated existing failure in `pkg/sandbox`: `TestExtraWorkspace/built-in_name` resolves the local `default` agent to the repository `examples` directory)*