### PR TITLE
fix(leantui): restore interrupt and editing shortcuts

### DIFF
--- a/pkg/leantui/events.go
+++ b/pkg/leantui/events.go
@@ -146,6 +146,10 @@ func (m *model) handleSessionCompaction(ctx context.Context, e *runtime.SessionC
 // queued message, if any. It reports whether a queued run was started.
 func (m *model) finishBusy(ctx context.Context) bool {
 	m.screen.Transcript.FlushPending()
+	if m.cancelMarkerPending {
+		m.screen.Transcript.AddBlock(func(int) []string { return []string{ui.StWarning().Render("⏹ Cancelled")} })
+		m.cancelMarkerPending = false
+	}
 	m.busy = false
 	m.runCancel = nil
 

--- a/pkg/leantui/leantui.go
+++ b/pkg/leantui/leantui.go
@@ -163,12 +163,13 @@ type model struct {
 	sessionState *service.SessionState
 	usage        *ui.UsageTracker
 
-	busy         bool
-	spinnerFrame int
-	runCancel    context.CancelFunc
-	queue        []ui.PendingUserMessage
-	pendingUsers []ui.PendingUserMessage
-	ignoredUsers []string
+	busy                bool
+	spinnerFrame        int
+	runCancel           context.CancelFunc
+	cancelMarkerPending bool
+	queue               []ui.PendingUserMessage
+	pendingUsers        []ui.PendingUserMessage
+	ignoredUsers        []string
 
 	quitting         bool
 	appName          string

--- a/pkg/leantui/ui/keys.go
+++ b/pkg/leantui/ui/keys.go
@@ -267,6 +267,8 @@ func parseCSI(b []byte) (int, Key) {
 			default:
 				return consumed, Key{Typ: KeyEnter}
 			}
+		case 27:
+			return consumed, Key{Typ: KeyEsc}
 		}
 		if mod == "5" {
 			switch code {

--- a/pkg/leantui/ui/keys.go
+++ b/pkg/leantui/ui/keys.go
@@ -252,6 +252,9 @@ func parseCSI(b []byte) (int, Key) {
 			return consumed, Key{Typ: KeyNone}
 		}
 		mod := modifier()
+		if (code == 127 || code == 8) && mod == "3" {
+			return consumed, Key{Typ: KeyCtrlW}
+		}
 		switch code {
 		case 9:
 			if mod == "2" {

--- a/pkg/leantui/ui/keys_test.go
+++ b/pkg/leantui/ui/keys_test.go
@@ -69,6 +69,8 @@ func TestParseKittyKeyboardSequences(t *testing.T) {
 		{sequence: "\x1b[13;3u", want: KeyAltEnter},
 		{sequence: "\x1b[27u", want: KeyEsc},
 		{sequence: "\x1b[27;1u", want: KeyEsc},
+		{sequence: "\x1b[127;3u", want: KeyCtrlW},
+		{sequence: "\x1b[8;3u", want: KeyCtrlW},
 		{sequence: "\x1b[99;5u", want: KeyCtrlC},
 		{sequence: "\x1b[100;5u", want: KeyCtrlD},
 		{sequence: "\x1b[117;5u", want: KeyCtrlU},

--- a/pkg/leantui/ui/keys_test.go
+++ b/pkg/leantui/ui/keys_test.go
@@ -67,6 +67,8 @@ func TestParseKittyKeyboardSequences(t *testing.T) {
 		{sequence: "\x1b[9;2u", want: KeyShiftTab},
 		{sequence: "\x1b[13;2u", want: KeyShiftEnter},
 		{sequence: "\x1b[13;3u", want: KeyAltEnter},
+		{sequence: "\x1b[27u", want: KeyEsc},
+		{sequence: "\x1b[27;1u", want: KeyEsc},
 		{sequence: "\x1b[99;5u", want: KeyCtrlC},
 		{sequence: "\x1b[100;5u", want: KeyCtrlD},
 		{sequence: "\x1b[117;5u", want: KeyCtrlU},

--- a/pkg/leantui/update.go
+++ b/pkg/leantui/update.go
@@ -21,7 +21,11 @@ import (
 
 func (m *model) handleKey(ctx context.Context, k ui.Key) {
 	if m.screen.Confirm != nil {
-		m.handleConfirmKey(k)
+		if k.Typ == ui.KeyEsc || k.Typ == ui.KeyCtrlC {
+			m.handleInterrupt()
+		} else {
+			m.handleConfirmKey(k)
+		}
 		return
 	}
 
@@ -79,7 +83,11 @@ func (m *model) handleKey(ctx context.Context, k ui.Key) {
 	case ui.KeyCtrlW:
 		m.screen.Editor.DeleteWordBack()
 	case ui.KeyEsc:
-		m.screen.Autocomplete.Dismiss()
+		if m.busy || m.runCancel != nil {
+			m.handleInterrupt()
+		} else {
+			m.screen.Autocomplete.Dismiss()
+		}
 	case ui.KeyCtrlL:
 		m.clearScreen()
 	case ui.KeyRune, ui.KeyPaste:
@@ -98,6 +106,7 @@ func (m *model) handleInterrupt() {
 		m.queue = nil
 		m.pendingUsers = nil
 		m.ignoredUsers = nil
+		m.screen.Confirm = nil
 		m.cancelMarkerPending = true
 	case !m.screen.Editor.IsEmpty():
 		m.screen.Editor.Reset()
@@ -709,7 +718,8 @@ func (m *model) commitHelp() {
 			ui.StMuted().Render("  Enter      send             Shift+Enter insert newline"),
 			ui.StMuted().Render("  Alt+Enter  follow up        Up/Down     history"),
 			ui.StMuted().Render("  Tab        complete command Shift+Tab   cycle thinking"),
-			ui.StMuted().Render("  Ctrl+C     cancel / quit    Ctrl+W      delete previous word"),
+			ui.StMuted().Render("  Esc        interrupt         Ctrl+C     cancel / quit"),
+			ui.StMuted().Render("  Ctrl+W     delete previous word"),
 		}
 	})
 }

--- a/pkg/leantui/update.go
+++ b/pkg/leantui/update.go
@@ -98,7 +98,7 @@ func (m *model) handleInterrupt() {
 		m.queue = nil
 		m.pendingUsers = nil
 		m.ignoredUsers = nil
-		m.screen.Transcript.AddBlock(func(int) []string { return []string{ui.StWarning().Render("⏹ Cancelled")} })
+		m.cancelMarkerPending = true
 	case !m.screen.Editor.IsEmpty():
 		m.screen.Editor.Reset()
 		m.screen.Autocomplete.Dismiss()
@@ -552,6 +552,7 @@ func (m *model) beginRun(ctx context.Context) (context.Context, context.CancelFu
 	runCtx, cancel := context.WithCancel(ctx)
 	m.runCancel = cancel
 	m.busy = true
+	m.cancelMarkerPending = false
 	return runCtx, cancel
 }
 
@@ -626,6 +627,7 @@ func (m *model) resetConversation() {
 	m.pendingUsers = nil
 	m.ignoredUsers = nil
 	m.busy = false
+	m.cancelMarkerPending = false
 	m.screen.Confirm = nil
 	m.usage.Reset()
 	m.status.ContextLength = 0

--- a/pkg/leantui/update_test.go
+++ b/pkg/leantui/update_test.go
@@ -358,6 +358,24 @@ func TestModelCommandOpensModelAutocomplete(t *testing.T) {
 	}
 }
 
+func TestCtrlCCancelMarkerFollowsBufferedResponse(t *testing.T) {
+	t.Parallel()
+	m := bareModel(24)
+	m.busy = true
+	m.runCancel = func() {}
+
+	m.handleKey(t.Context(), ui.Key{Typ: ui.KeyCtrlC})
+	m.screen.Transcript.AppendAssistant("partial response")
+	m.handleEvent(t.Context(), runtime.StreamStopped("session", "coder", "canceled"))
+
+	transcript := strings.Join(m.screen.Transcript.Lines(80, 0, false, m.sessionState, nil), "\n")
+	responseAt := strings.Index(transcript, "partial response")
+	cancelledAt := strings.Index(transcript, "Cancelled")
+	assert.NotEqual(t, -1, responseAt)
+	assert.NotEqual(t, -1, cancelledAt)
+	assert.Less(t, responseAt, cancelledAt)
+}
+
 func TestShiftEnterInsertsNewline(t *testing.T) {
 	t.Parallel()
 	m := bareModel(24)

--- a/pkg/leantui/update_test.go
+++ b/pkg/leantui/update_test.go
@@ -358,6 +358,39 @@ func TestModelCommandOpensModelAutocomplete(t *testing.T) {
 	}
 }
 
+func TestEscapeInterruptsActiveRun(t *testing.T) {
+	t.Parallel()
+	m := bareModel(24)
+	runCtx, cancel := context.WithCancel(t.Context())
+	m.busy = true
+	m.runCancel = cancel
+	m.queue = []ui.PendingUserMessage{{Content: "queued"}}
+	m.pendingUsers = []ui.PendingUserMessage{{Content: "pending"}}
+	m.ignoredUsers = []string{"ignored"}
+	m.screen.Confirm = &ui.ConfirmModel{}
+	m.screen.Autocomplete.SetCommands([]ui.Command{{Name: "help"}})
+	m.screen.Autocomplete.Sync("/h")
+
+	m.handleKey(t.Context(), ui.Key{Typ: ui.KeyEsc})
+
+	require.ErrorIs(t, runCtx.Err(), context.Canceled)
+	assert.Empty(t, m.queue)
+	assert.Empty(t, m.pendingUsers)
+	assert.Empty(t, m.ignoredUsers)
+	assert.Nil(t, m.screen.Confirm)
+	assert.NotContains(t, strings.Join(m.screen.Transcript.Lines(80, 0, true, m.sessionState, nil), "\n"), "Cancelled")
+
+	m.screen.Transcript.AppendAssistant("partial response")
+	m.handleEvent(t.Context(), runtime.StreamStopped("session", "coder", "canceled"))
+
+	transcript := strings.Join(m.screen.Transcript.Lines(80, 0, false, m.sessionState, nil), "\n")
+	responseAt := strings.Index(transcript, "partial response")
+	cancelledAt := strings.Index(transcript, "Cancelled")
+	assert.NotEqual(t, -1, responseAt)
+	assert.NotEqual(t, -1, cancelledAt)
+	assert.Less(t, responseAt, cancelledAt)
+}
+
 func TestCtrlCCancelMarkerFollowsBufferedResponse(t *testing.T) {
 	t.Parallel()
 	m := bareModel(24)
@@ -374,6 +407,18 @@ func TestCtrlCCancelMarkerFollowsBufferedResponse(t *testing.T) {
 	assert.NotEqual(t, -1, responseAt)
 	assert.NotEqual(t, -1, cancelledAt)
 	assert.Less(t, responseAt, cancelledAt)
+}
+
+func TestEscapeWhileIdleDismissesAutocomplete(t *testing.T) {
+	t.Parallel()
+	m := bareModel(24)
+	m.screen.Autocomplete.SetCommands([]ui.Command{{Name: "help"}})
+	require.True(t, m.screen.Autocomplete.Sync("/h"))
+
+	m.handleKey(t.Context(), ui.Key{Typ: ui.KeyEsc})
+
+	assert.False(t, m.screen.Autocomplete.Active)
+	assert.False(t, m.quitting)
 }
 
 func TestShiftEnterInsertsNewline(t *testing.T) {


### PR DESCRIPTION
## Summary

- place the cancellation marker after any buffered partial response
- make Escape cancel the active agent loop and pending tool calls
- decode Kitty keyboard Escape sequences used by the lean TUI
- restore Option+Backspace word deletion with Kitty keyboard mode enabled

## Testing

- `task build`
- `task lint`
- `go test ./pkg/leantui/...`