### PR TITLE
fix: persist lean TUI prompt history

### DIFF
--- a/pkg/leantui/leantui.go
+++ b/pkg/leantui/leantui.go
@@ -3,6 +3,7 @@ package leantui
 import (
 	"context"
 	"io"
+	"log/slog"
 	"os"
 	"strings"
 	"time"
@@ -11,6 +12,7 @@ import (
 
 	"github.com/docker/docker-agent/pkg/app"
 	"github.com/docker/docker-agent/pkg/gitbranch"
+	"github.com/docker/docker-agent/pkg/history"
 	"github.com/docker/docker-agent/pkg/leantui/ui"
 	"github.com/docker/docker-agent/pkg/tui/service"
 )
@@ -20,6 +22,7 @@ type Config struct {
 	App        *app.App
 	WorkingDir string
 	Cleanup    func()
+	History    *history.History
 
 	FirstMessage           *string
 	FirstMessageAttachment string
@@ -49,6 +52,13 @@ func Run(ctx context.Context, cfg Config) error {
 
 	loopCtx, loopCancel := context.WithCancel(ctx)
 	defer loopCancel()
+
+	if cfg.History == nil {
+		cfg.History, err = history.New("")
+		if err != nil {
+			slog.WarnContext(ctx, "Failed to initialize command history", "error", err)
+		}
+	}
 
 	m := newModel(term, cfg)
 	m.commitWelcome()
@@ -203,7 +213,7 @@ func newModel(term *ui.Terminal, cfg Config) *model {
 		r:                ui.NewRenderer(term.Writer(), w, h),
 		width:            w,
 		height:           h,
-		screen:           ui.NewScreen(cfg.WorkingDir, gitbranch.Current(cfg.WorkingDir), "Type a message, / for commands"),
+		screen:           ui.NewScreen(cfg.WorkingDir, gitbranch.Current(cfg.WorkingDir), "Type a message, / for commands", cfg.History),
 		status:           ui.StatusModel{WorkingDir: cfg.WorkingDir, Branch: gitbranch.Current(cfg.WorkingDir)},
 		sessionState:     sessionState,
 		usage:            ui.NewUsageTracker(),

--- a/pkg/leantui/ui/editor.go
+++ b/pkg/leantui/ui/editor.go
@@ -1,6 +1,10 @@
 package ui
 
-import "strings"
+import (
+	"strings"
+
+	"github.com/docker/docker-agent/pkg/history"
+)
 
 // rowSpan identifies the slice of the editor buffer [start, end) shown on a
 // single visual row.
@@ -19,13 +23,19 @@ type Editor struct {
 
 	placeholder string
 
-	history   []string
-	histIndex int
-	draft     string
+	historyStore *history.History
+	history      []string
+	histIndex    int
+	draft        string
 }
 
-func NewEditor(placeholder string) *Editor {
-	return &Editor{placeholder: placeholder, histIndex: 0}
+func NewEditor(placeholder string, historyStore ...*history.History) *Editor {
+	e := &Editor{placeholder: placeholder}
+	if len(historyStore) > 0 {
+		e.historyStore = historyStore[0]
+	}
+	e.histIndex = len(e.historyMessages())
+	return e
 }
 
 func (e *Editor) Text() string { return string(e.value) }
@@ -35,7 +45,7 @@ func (e *Editor) IsEmpty() bool { return len(e.value) == 0 }
 func (e *Editor) Reset() {
 	e.value = nil
 	e.cursor = 0
-	e.histIndex = len(e.history)
+	e.histIndex = len(e.historyMessages())
 	e.draft = ""
 }
 
@@ -144,39 +154,55 @@ func (e *Editor) Down(termWidth int) bool {
 }
 
 // RememberHistory records a submitted entry and resets the history cursor.
-func (e *Editor) RememberHistory(s string) {
+func (e *Editor) RememberHistory(s string) error {
 	s = strings.TrimRight(s, "\n")
 	if s == "" {
-		return
+		return nil
 	}
-	if n := len(e.history); n == 0 || e.history[n-1] != s {
+	if e.historyStore != nil {
+		if err := e.historyStore.Add(s); err != nil {
+			e.histIndex = len(e.historyStore.Messages)
+			e.draft = ""
+			return err
+		}
+	} else if n := len(e.history); n == 0 || e.history[n-1] != s {
 		e.history = append(e.history, s)
 	}
-	e.histIndex = len(e.history)
+	e.histIndex = len(e.historyMessages())
 	e.draft = ""
+	return nil
+}
+
+func (e *Editor) historyMessages() []string {
+	if e.historyStore != nil {
+		return e.historyStore.Messages
+	}
+	return e.history
 }
 
 func (e *Editor) HistoryPrev() {
+	historyMessages := e.historyMessages()
 	if e.histIndex == 0 {
 		return
 	}
-	if e.histIndex == len(e.history) {
+	if e.histIndex == len(historyMessages) {
 		e.draft = e.Text()
 	}
 	e.histIndex--
-	e.SetText(e.history[e.histIndex])
+	e.SetText(historyMessages[e.histIndex])
 }
 
 func (e *Editor) HistoryNext() {
-	if e.histIndex >= len(e.history) {
+	historyMessages := e.historyMessages()
+	if e.histIndex >= len(historyMessages) {
 		return
 	}
 	e.histIndex++
-	if e.histIndex == len(e.history) {
+	if e.histIndex == len(historyMessages) {
 		e.SetText(e.draft)
 		return
 	}
-	e.SetText(e.history[e.histIndex])
+	e.SetText(historyMessages[e.histIndex])
 }
 
 // Layout renders the editor for the given terminal width, returning one styled

--- a/pkg/leantui/ui/editor_test.go
+++ b/pkg/leantui/ui/editor_test.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/docker/docker-agent/pkg/history"
 )
 
 func TestEditorInsertAndText(t *testing.T) {
@@ -108,8 +110,8 @@ func TestEditorVerticalMovement(t *testing.T) {
 func TestEditorHistory(t *testing.T) {
 	t.Parallel()
 	e := NewEditor("")
-	e.RememberHistory("first")
-	e.RememberHistory("second")
+	require.NoError(t, e.RememberHistory("first"))
+	require.NoError(t, e.RememberHistory("second"))
 
 	e.SetText("draft")
 	e.HistoryPrev()
@@ -125,10 +127,27 @@ func TestEditorHistory(t *testing.T) {
 	assert.Equal(t, "draft", e.Text()) // restored draft
 }
 
+func TestEditorPersistentHistory(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	store, err := history.New(dir)
+	require.NoError(t, err)
+	require.NoError(t, store.Add("from full tui"))
+
+	e := NewEditor("", store)
+	e.HistoryPrev()
+	assert.Equal(t, "from full tui", e.Text())
+
+	require.NoError(t, e.RememberHistory("from lean tui"))
+	reloaded, err := history.New(dir)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"from full tui", "from lean tui"}, reloaded.Messages)
+}
+
 func TestEditorHistoryDeduplicates(t *testing.T) {
 	t.Parallel()
 	e := NewEditor("")
-	e.RememberHistory("same")
-	e.RememberHistory("same")
+	require.NoError(t, e.RememberHistory("same"))
+	require.NoError(t, e.RememberHistory("same"))
 	assert.Len(t, e.history, 1)
 }

--- a/pkg/leantui/ui/screen.go
+++ b/pkg/leantui/ui/screen.go
@@ -1,6 +1,9 @@
 package ui
 
-import "github.com/docker/docker-agent/pkg/tui/service"
+import (
+	"github.com/docker/docker-agent/pkg/history"
+	"github.com/docker/docker-agent/pkg/tui/service"
+)
 
 // Screen aggregates the lean TUI presentation models and lays out a full frame.
 type Screen struct {
@@ -11,10 +14,10 @@ type Screen struct {
 	Confirm      *ConfirmModel
 }
 
-func NewScreen(workingDir, branch, editorPlaceholder string) *Screen {
+func NewScreen(workingDir, branch, editorPlaceholder string, historyStore ...*history.History) *Screen {
 	return &Screen{
 		Transcript:   NewTranscript(),
-		Editor:       NewEditor(editorPlaceholder),
+		Editor:       NewEditor(editorPlaceholder, historyStore...),
 		Autocomplete: NewAutocomplete(),
 		Status:       StatusModel{WorkingDir: workingDir, Branch: branch},
 	}

--- a/pkg/leantui/update.go
+++ b/pkg/leantui/update.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"path/filepath"
 	"strings"
 
@@ -219,7 +220,9 @@ func (m *model) submit(ctx context.Context, text string, opts submitOptions) {
 		return
 	}
 	if opts.fromEditor {
-		m.screen.Editor.RememberHistory(trimmed)
+		if err := m.screen.Editor.RememberHistory(trimmed); err != nil {
+			slog.WarnContext(ctx, "Failed to save command history", "error", err)
+		}
 		m.screen.Editor.Reset()
 		m.screen.Autocomplete.Dismiss()
 	}


### PR DESCRIPTION
## Summary
- load the shared global prompt history in the lean TUI
- persist prompts submitted from lean mode to the same history used by the normal TUI
- preserve in-memory history fallback and draft restoration
- log history initialization and persistence failures

## Validation
- `go test ./pkg/leantui/...`
- `task build`
- `task lint`
- `task test` (passes with isolated HOME; the default environment has a local `default` alias that causes `TestExtraWorkspace/built-in_name` to fail)