### PR TITLE
fix(leantui): restore tool calls on session resume

### DIFF
--- a/pkg/leantui/update.go
+++ b/pkg/leantui/update.go
@@ -15,8 +15,10 @@ import (
 	"github.com/docker/docker-agent/pkg/modelpicker"
 	"github.com/docker/docker-agent/pkg/runtime"
 	"github.com/docker/docker-agent/pkg/session"
+	"github.com/docker/docker-agent/pkg/tools"
 	"github.com/docker/docker-agent/pkg/tui/messages"
 	"github.com/docker/docker-agent/pkg/tui/service"
+	tuitypes "github.com/docker/docker-agent/pkg/tui/types"
 )
 
 func (m *model) handleKey(ctx context.Context, k ui.Key) {
@@ -398,7 +400,15 @@ func (m *model) resumeSession(ctx context.Context, sessionID string) {
 }
 
 func (m *model) loadSessionTranscript(sess *session.Session) {
-	for _, msg := range sess.OwnMessages() {
+	storedMessages := sess.OwnMessages()
+	toolResults := make(map[string]chat.Message)
+	for _, msg := range storedMessages {
+		if msg.Message.Role == chat.MessageRoleTool && msg.Message.ToolCallID != "" {
+			toolResults[msg.Message.ToolCallID] = msg.Message
+		}
+	}
+
+	for _, msg := range storedMessages {
 		if msg.Implicit {
 			continue
 		}
@@ -414,6 +424,22 @@ func (m *model) loadSessionTranscript(sess *session.Session) {
 			if content != "" {
 				answer := content
 				m.screen.Transcript.AddBlock(func(w int) []string { return ui.RenderAssistantLines(answer, w) })
+			}
+			for i, toolCall := range msg.Message.ToolCalls {
+				toolDef := tools.Tool{}
+				if i < len(msg.Message.ToolDefinitions) {
+					toolDef = msg.Message.ToolDefinitions[i]
+				}
+				m.screen.Transcript.UpsertTool(msg.AgentName, toolCall, toolDef, tuitypes.ToolStatusCompleted)
+
+				result := toolResults[toolCall.ID]
+				toolResult := &tools.ToolCallResult{Output: result.Content, IsError: result.IsError}
+				m.screen.Transcript.FinishTool(toolCall.ID, ui.ToolResult{
+					Response:       result.Content,
+					Result:         toolResult,
+					AgentName:      msg.AgentName,
+					ToolDefinition: toolDef,
+				}, m.sessionState)
 			}
 		}
 	}

--- a/pkg/leantui/update_test.go
+++ b/pkg/leantui/update_test.go
@@ -234,6 +234,43 @@ func TestSessionsCommandListsCurrentDirectoryAndResumesSelection(t *testing.T) {
 	assert.NotContains(t, transcript, "Other directory")
 }
 
+func TestLoadSessionTranscriptRestoresToolCalls(t *testing.T) {
+	t.Parallel()
+	sess := session.New()
+	sess.AddMessage(session.UserMessage("inspect the repository"))
+	sess.AddMessage(session.NewAgentMessage("coder", &chat.Message{
+		Role:             chat.MessageRoleAssistant,
+		ReasoningContent: "I should inspect the files.",
+		Content:          "I found the issue.",
+		ToolCalls: []tools.ToolCall{{
+			ID: "call-1",
+			Function: tools.FunctionCall{
+				Name:      "inspect_files",
+				Arguments: `{"path":"pkg/leantui"}`,
+			},
+		}},
+		ToolDefinitions: []tools.Tool{{Name: "inspect_files"}},
+	}))
+	sess.AddMessage(session.NewAgentMessage("coder", &chat.Message{
+		Role:       chat.MessageRoleTool,
+		ToolCallID: "call-1",
+		Content:    "update.go\nview.go",
+	}))
+
+	m := bareModel(80)
+	m.sessionState = service.NewSessionState(sess)
+	m.loadSessionTranscript(sess)
+
+	transcript := strings.Join(m.screen.Transcript.Lines(80, 0, false, m.sessionState, nil), "\n")
+	assert.Contains(t, transcript, "inspect the repository")
+	assert.Contains(t, transcript, "I should inspect the files.")
+	assert.Contains(t, transcript, "I found the issue.")
+	assert.Contains(t, transcript, "inspect_files")
+	assert.Contains(t, transcript, "pkg/leantui")
+	assert.Contains(t, transcript, "update.go")
+	assert.Zero(t, m.screen.Transcript.ToolCount())
+}
+
 func TestSessionsCommandReportsNoSessionsInCurrentDirectory(t *testing.T) {
 	t.Parallel()
 	store := session.NewInMemorySessionStore()


### PR DESCRIPTION
## Summary

- rebuild completed tool-call blocks when loading a saved session in the lean TUI
- associate persisted tool results with calls by tool-call ID
- preserve tool definitions, arguments, output, agent attribution, and error state
- add regression coverage for restored user, reasoning, assistant, and tool content

## Validation

- `task build`
- `task lint`
- `go test ./pkg/leantui/...`
- `task test` *(unrelated existing failure: `pkg/sandbox` `TestExtraWorkspace/built-in_name` resolves the local `default` reference to the repository `examples` directory)*