### PR TITLE
feat: live-update git branch in TUI footers

### DIFF
--- a/pkg/gitbranch/gitbranch.go
+++ b/pkg/gitbranch/gitbranch.go
@@ -13,6 +13,13 @@ import (
 // a .git entry is found. It returns "" when dir is empty or not inside a
 // repository.
 func Current(dir string) string {
+	if head := findHead(dir); head != "" {
+		return readHead(head)
+	}
+	return ""
+}
+
+func findHead(dir string) string {
 	if dir == "" {
 		return ""
 	}
@@ -22,11 +29,11 @@ func Current(dir string) string {
 		info, err := os.Stat(gitPath)
 		switch {
 		case err == nil && info.IsDir():
-			return readHead(filepath.Join(gitPath, "HEAD"))
+			return filepath.Join(gitPath, "HEAD")
 		case err == nil:
 			// A .git file points at the real git dir (submodule or worktree).
 			if gd := parseGitdir(gitPath, d); gd != "" {
-				return readHead(filepath.Join(gd, "HEAD"))
+				return filepath.Join(gd, "HEAD")
 			}
 		}
 

--- a/pkg/gitbranch/watcher.go
+++ b/pkg/gitbranch/watcher.go
@@ -1,0 +1,159 @@
+package gitbranch
+
+import (
+	"context"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"github.com/fsnotify/fsnotify"
+)
+
+const watchDebounce = 100 * time.Millisecond
+
+// Watcher reports changes to the current branch of a working directory.
+type Watcher struct {
+	mu      sync.RWMutex
+	dir     string
+	current string
+	changes chan string
+	setDir  chan setDirRequest
+	done    <-chan struct{}
+}
+
+type setDirRequest struct {
+	dir  string
+	done chan string
+}
+
+// Watch starts watching Git metadata until ctx is canceled.
+func Watch(ctx context.Context, dir string) (*Watcher, error) {
+	fsWatcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		return nil, err
+	}
+
+	w := &Watcher{
+		dir:     dir,
+		current: Current(dir),
+		changes: make(chan string, 1),
+		setDir:  make(chan setDirRequest),
+		done:    ctx.Done(),
+	}
+	w.watchHeadDir(fsWatcher)
+	go w.run(ctx, fsWatcher)
+	return w, nil
+}
+
+// Current returns the last observed branch.
+func (w *Watcher) Current() string {
+	w.mu.RLock()
+	defer w.mu.RUnlock()
+	return w.current
+}
+
+// Changes returns branch values when the observed branch changes.
+func (w *Watcher) Changes() <-chan string {
+	return w.changes
+}
+
+// SetDir switches the watcher to another working directory.
+func (w *Watcher) SetDir(dir string) string {
+	done := make(chan string, 1)
+	select {
+	case w.setDir <- setDirRequest{dir: dir, done: done}:
+		select {
+		case current := <-done:
+			return current
+		case <-w.done:
+			return Current(dir)
+		}
+	case <-w.done:
+		return Current(dir)
+	}
+}
+
+func (w *Watcher) run(ctx context.Context, fsWatcher *fsnotify.Watcher) {
+	defer fsWatcher.Close()
+	defer close(w.changes)
+
+	var debounce <-chan time.Time
+	var timer *time.Timer
+	for {
+		select {
+		case <-ctx.Done():
+			if timer != nil {
+				timer.Stop()
+			}
+			return
+		case req := <-w.setDir:
+			for _, path := range fsWatcher.WatchList() {
+				_ = fsWatcher.Remove(path)
+			}
+			w.mu.Lock()
+			w.dir = req.dir
+			w.current = Current(req.dir)
+			current := w.current
+			w.mu.Unlock()
+			w.watchHeadDir(fsWatcher)
+			select {
+			case <-w.changes:
+			default:
+			}
+			req.done <- current
+		case event, ok := <-fsWatcher.Events:
+			if !ok {
+				return
+			}
+			if filepath.Base(event.Name) != "HEAD" {
+				continue
+			}
+			if timer == nil {
+				timer = time.NewTimer(watchDebounce)
+			} else {
+				if !timer.Stop() {
+					select {
+					case <-timer.C:
+					default:
+					}
+				}
+				timer.Reset(watchDebounce)
+			}
+			debounce = timer.C
+		case <-debounce:
+			debounce = nil
+			w.refresh()
+		case _, ok := <-fsWatcher.Errors:
+			if !ok {
+				return
+			}
+		}
+	}
+}
+
+func (w *Watcher) watchHeadDir(fsWatcher *fsnotify.Watcher) {
+	w.mu.RLock()
+	dir := w.dir
+	w.mu.RUnlock()
+	if head := findHead(dir); head != "" {
+		_ = fsWatcher.Add(filepath.Dir(head))
+	}
+}
+
+func (w *Watcher) refresh() {
+	w.mu.Lock()
+	branch := Current(w.dir)
+	if branch == w.current {
+		w.mu.Unlock()
+		return
+	}
+	w.current = branch
+	w.mu.Unlock()
+
+	select {
+	case w.changes <- branch:
+	default:
+		<-w.changes
+		w.changes <- branch
+	}
+}

--- a/pkg/gitbranch/watcher_test.go
+++ b/pkg/gitbranch/watcher_test.go
@@ -1,0 +1,50 @@
+package gitbranch
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWatcherReportsBranchChanges(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	gitDir := filepath.Join(dir, ".git")
+	require.NoError(t, os.Mkdir(gitDir, 0o755))
+	head := filepath.Join(gitDir, "HEAD")
+	require.NoError(t, os.WriteFile(head, []byte("ref: refs/heads/main\n"), 0o644))
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	watcher, err := Watch(ctx, dir)
+	require.NoError(t, err)
+	assert.Equal(t, "main", watcher.Current())
+
+	require.NoError(t, os.WriteFile(head, []byte("ref: refs/heads/feature/live-footer\n"), 0o644))
+	select {
+	case branch := <-watcher.Changes():
+		assert.Equal(t, "feature/live-footer", branch)
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for branch change")
+	}
+}
+
+func TestWatcherSetDir(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	watcher, err := Watch(ctx, t.TempDir())
+	require.NoError(t, err)
+
+	dir := t.TempDir()
+	require.NoError(t, os.Mkdir(filepath.Join(dir, ".git"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, ".git", "HEAD"), []byte("ref: refs/heads/other\n"), 0o644))
+
+	assert.Equal(t, "other", watcher.SetDir(dir))
+	assert.Equal(t, "other", watcher.Current())
+}

--- a/pkg/leantui/leantui.go
+++ b/pkg/leantui/leantui.go
@@ -61,6 +61,11 @@ func Run(ctx context.Context, cfg Config) error {
 	}
 
 	m := newModel(term, cfg)
+	branchWatcher, err := gitbranch.Watch(loopCtx, cfg.WorkingDir)
+	if err != nil {
+		return err
+	}
+	m.status.Branch = branchWatcher.Current()
 	m.commitWelcome()
 	m.refreshCommands(loopCtx)
 
@@ -108,8 +113,9 @@ func Run(ctx context.Context, cfg Config) error {
 		m.enqueueFollowUp(msg, msg)
 	}
 
-	ticker := time.NewTicker(100 * time.Millisecond)
-	defer ticker.Stop()
+	animationTicker := time.NewTicker(100 * time.Millisecond)
+	defer animationTicker.Stop()
+	branchChanges := branchWatcher.Changes()
 
 	m.render()
 	for !m.quitting {
@@ -126,11 +132,18 @@ func Run(ctx context.Context, cfg Config) error {
 			m.width, m.height = sz[0], sz[1]
 			m.r.SetSize(sz[0], sz[1])
 			m.render()
-		case <-ticker.C:
+		case <-animationTicker.C:
 			if m.busy {
 				m.spinnerFrame++
 				m.render()
 			}
+		case branch, ok := <-branchChanges:
+			if !ok {
+				branchChanges = nil
+				continue
+			}
+			m.status.Branch = branch
+			m.render()
 		}
 	}
 
@@ -208,14 +221,16 @@ func newModel(term *ui.Terminal, cfg Config) *model {
 
 	renderImages := cfg.RenderImages == nil || *cfg.RenderImages
 
+	branch := gitbranch.Current(cfg.WorkingDir)
+
 	return &model{
 		app:              cfg.App,
 		term:             term,
 		r:                ui.NewRenderer(term.Writer(), w, h),
 		width:            w,
 		height:           h,
-		screen:           ui.NewScreen(cfg.WorkingDir, gitbranch.Current(cfg.WorkingDir), "Type a message, / for commands", cfg.History),
-		status:           ui.StatusModel{WorkingDir: cfg.WorkingDir, Branch: gitbranch.Current(cfg.WorkingDir)},
+		screen:           ui.NewScreen(cfg.WorkingDir, branch, "Type a message, / for commands", cfg.History),
+		status:           ui.StatusModel{WorkingDir: cfg.WorkingDir, Branch: branch},
 		sessionState:     sessionState,
 		usage:            ui.NewUsageTracker(),
 		appName:          appName,

--- a/pkg/tui/components/sidebar/sidebar.go
+++ b/pkg/tui/components/sidebar/sidebar.go
@@ -159,6 +159,21 @@ type Model interface {
 	WorkingDirectory() string
 }
 
+type gitBranchChangedMsg string
+
+func waitForGitBranch(watcher *gitbranch.Watcher) tea.Cmd {
+	if watcher == nil {
+		return nil
+	}
+	return func() tea.Msg {
+		branch, ok := <-watcher.Changes()
+		if !ok {
+			return nil
+		}
+		return gitBranchChangedMsg(branch)
+	}
+}
+
 // ragIndexingState tracks per-strategy indexing progress
 type ragIndexingState struct {
 	current int
@@ -319,7 +334,8 @@ type model struct {
 	rootSessionID        string   // Main (top-level) session, shown when no stream is active
 	scrollview           *scrollview.Model
 	workingDirectory     string
-	gitBranchName        string   // current git branch, empty if not in a repo
+	gitBranchName        string // current git branch, empty if not in a repo
+	gitBranchWatcher     *gitbranch.Watcher
 	queuedMessages       []string // Truncated preview of queued messages
 	streamCancelled      bool     // true after ESC cancel until next StreamStartedEvent
 	compacting           bool     // true while a session compaction runs (started → completed)
@@ -381,7 +397,9 @@ func New(ar *animation.Runtime, ctx context.Context, sessionState *service.Sessi
 	ti.CharLimit = 50
 	ti.Prompt = "" // No prompt to maximize usable width in collapsed sidebar
 
-	wd, branch := getCurrentWorkingDirectory()
+	rawDir, _ := os.Getwd()
+	wd, branch := formatWorkingDirectory(rawDir)
+	branchWatcher, _ := gitbranch.Watch(ctx, rawDir)
 
 	m := &model{
 		ctx:               func() context.Context { return context.WithoutCancel(ctx) },
@@ -402,6 +420,7 @@ func New(ar *animation.Runtime, ctx context.Context, sessionState *service.Sessi
 		),
 		workingDirectory: wd,
 		gitBranchName:    branch,
+		gitBranchWatcher: branchWatcher,
 		preferredWidth:   DefaultWidth,
 		sectionGap:       defaultSectionGap,
 		titleInput:       ti,
@@ -413,7 +432,7 @@ func New(ar *animation.Runtime, ctx context.Context, sessionState *service.Sessi
 }
 
 func (m *model) Init() tea.Cmd {
-	return nil
+	return waitForGitBranch(m.gitBranchWatcher)
 }
 
 // needsSpinner returns true if any spinner-driving state is active.
@@ -1001,7 +1020,12 @@ func (m *model) LoadFromSession(sess *session.Session) {
 
 	// Load working directory from session
 	if sess.WorkingDir != "" {
-		m.workingDirectory, m.gitBranchName = formatWorkingDirectory(sess.WorkingDir)
+		m.workingDirectory = pathx.ShortenHome(sess.WorkingDir)
+		if m.gitBranchWatcher != nil {
+			m.gitBranchName = m.gitBranchWatcher.SetDir(sess.WorkingDir)
+		} else {
+			m.gitBranchName = gitbranch.Current(sess.WorkingDir)
+		}
 	}
 
 	// Session has content if it has messages or token usage
@@ -1135,17 +1159,6 @@ func formatWorkingDirectory(rawDir string) (display, branch string) {
 	return pathx.ShortenHome(rawDir), gitbranch.Current(rawDir)
 }
 
-// getCurrentWorkingDirectory returns the current working directory with home directory
-// replaced by ~/, along with the current git branch name.
-func getCurrentWorkingDirectory() (string, string) {
-	pwd, err := os.Getwd()
-	if err != nil {
-		return "", ""
-	}
-
-	return formatWorkingDirectory(pwd)
-}
-
 // workingDirWithBranch returns the working directory path with the git branch
 // appended in muted style, suitable for rendering in the sidebar.
 func (m *model) workingDirWithBranch() string {
@@ -1172,6 +1185,10 @@ func (m *model) workingDirLine() string {
 // Update handles messages and updates the component state.
 func (m *model) Update(msg tea.Msg) (layout.Model, tea.Cmd) {
 	switch msg := msg.(type) {
+	case gitBranchChangedMsg:
+		m.gitBranchName = string(msg)
+		m.invalidateCache()
+		return m, waitForGitBranch(m.gitBranchWatcher)
 	case tea.WindowSizeMsg:
 		cmd := m.SetSize(msg.Width, msg.Height)
 		return m, cmd

--- a/pkg/tui/handlers.go
+++ b/pkg/tui/handlers.go
@@ -30,6 +30,7 @@ import (
 	"github.com/docker/docker-agent/pkg/tui/dialog"
 	tuiimage "github.com/docker/docker-agent/pkg/tui/image"
 	"github.com/docker/docker-agent/pkg/tui/messages"
+	"github.com/docker/docker-agent/pkg/tui/page/chat"
 	"github.com/docker/docker-agent/pkg/tui/service"
 	"github.com/docker/docker-agent/pkg/tui/styles"
 	"github.com/docker/docker-agent/pkg/userconfig"
@@ -97,14 +98,17 @@ func (m *appModel) handleBranchFromEdit(msg messages.BranchFromEditMsg) (tea.Mod
 
 	m.reapplyKeyboardEnhancements()
 
-	return m, tea.Sequence(
-		m.chatPage.Init(),
-		m.resizeAll(),
-		m.editor.Focus(),
-		core.CmdHandler(messages.SendMsg{
-			Content:     msg.Content,
-			Attachments: msg.Attachments,
-		}),
+	return m, tea.Batch(
+		tea.Sequence(
+			m.chatPage.Init(),
+			m.resizeAll(),
+			m.editor.Focus(),
+			core.CmdHandler(messages.SendMsg{
+				Content:     msg.Content,
+				Attachments: msg.Attachments,
+			}),
+		),
+		chat.WatchGitBranch(m.chatPage),
 	)
 }
 

--- a/pkg/tui/page/chat/chat.go
+++ b/pkg/tui/page/chat/chat.go
@@ -214,6 +214,7 @@ type chatPage struct {
 	sendMode       msgtypes.SendMode
 
 	msgCancel       context.CancelFunc
+	cancel          context.CancelFunc
 	streamCancelled bool
 	// streamDepth is the nesting depth of active streams (StreamStarted++,
 	// StreamStopped--). >0 during a root compaction marks it as automatic
@@ -381,10 +382,12 @@ func defaultKeyMap() KeyMap {
 
 // New creates a new chat page
 func New(ar *animation.Runtime, ctx context.Context, a *app.App, sessionState *service.SessionState, opts ...PageOption) Page {
+	pageCtx, cancel := context.WithCancel(ctx)
 	p := &chatPage{
 		ar:                ar,
+		cancel:            cancel,
 		ctx:               func() context.Context { return context.WithoutCancel(ctx) },
-		sidebar:           sidebar.New(ar, ctx, sessionState),
+		sidebar:           sidebar.New(ar, pageCtx, sessionState),
 		messages:          messages.New(ar, sessionState),
 		app:               a,
 		keyMap:            defaultKeyMap(),
@@ -484,10 +487,7 @@ func agentInfoMode(mode msgtypes.SidebarInfoMode) sidebar.AgentInfoMode {
 func (p *chatPage) Init() tea.Cmd {
 	var cmds []tea.Cmd
 
-	cmds = append(cmds,
-		p.sidebar.Init(),
-		p.messages.Init(),
-	)
+	cmds = append(cmds, p.messages.Init())
 
 	// Load state from existing session (for session restore and branching)
 	if sess := p.app.Session(); sess != nil {
@@ -498,6 +498,19 @@ func (p *chatPage) Init() tea.Cmd {
 	}
 
 	return tea.Batch(cmds...)
+}
+
+func WatchGitBranch(page Page) tea.Cmd {
+	if p, ok := page.(*chatPage); ok {
+		return p.sidebar.Init()
+	}
+	return nil
+}
+
+func Cleanup(page Page) {
+	if p, ok := page.(*chatPage); ok {
+		p.cancel()
+	}
 }
 
 // Update handles messages and updates the page state

--- a/pkg/tui/session_load_click_test.go
+++ b/pkg/tui/session_load_click_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/docker/docker-agent/pkg/runtime"
 	"github.com/docker/docker-agent/pkg/session"
 	"github.com/docker/docker-agent/pkg/tui/messages"
+	"github.com/docker/docker-agent/pkg/tui/tuitest"
 	"github.com/docker/docker-agent/pkg/tui/types"
 )
 
@@ -28,29 +29,6 @@ type storeRuntime struct {
 }
 
 func (r storeRuntime) SessionStore() session.Store { return r.store }
-
-// feedCmds executes cmd trees and feeds the resulting msgs back into the
-// model, mimicking the bubbletea loop, up to a few rounds.
-func feedCmds(t *testing.T, m tea.Model, cmd tea.Cmd) tea.Model {
-	t.Helper()
-	msgs := collectMsgs(cmd)
-	for range 5 {
-		var next []tea.Msg
-		for _, msg := range msgs {
-			if msg == nil {
-				continue
-			}
-			var c tea.Cmd
-			m, c = m.Update(msg)
-			next = append(next, collectMsgs(c)...)
-		}
-		msgs = next
-		if len(msgs) == 0 {
-			break
-		}
-	}
-	return m
-}
 
 func TestLoadSessionThenClickEditLabel(t *testing.T) {
 	t.Run("in-place", func(t *testing.T) { testLoadSessionThenClickEditLabel(t, false, 120) })
@@ -104,28 +82,23 @@ func testLoadSessionThenClickEditLabel(t *testing.T, newTab bool, width int) {
 	// file on Windows.
 	t.Cleanup(m.cleanupManagedResources)
 
-	var cmd tea.Cmd
-	var mm tea.Model = m
-	mm, cmd = mm.Update(tea.WindowSizeMsg{Width: width, Height: 40})
-	mm = feedCmds(t, mm, cmd)
+	driver := tuitest.New(t, model, width, 40)
 
 	// Load the past session (what the /sessions browser emits).
-	mm, cmd = mm.Update(messages.LoadSessionMsg{SessionID: past.ID})
-	mm = feedCmds(t, mm, cmd)
+	driver.Send(messages.LoadSessionMsg{SessionID: past.ID})
+	driver.WaitFor(tuitest.Contains("hello there"))
 
 	// Simulate the async startup info that App.ReplaceSession re-emits after
 	// the load completed: it changes the collapsed sidebar band's height.
-	mm, cmd = mm.Update(&runtime.TeamInfoEvent{
+	driver.Send(&runtime.TeamInfoEvent{
 		AvailableAgents: []runtime.AgentDetails{
 			{Name: "root", Model: "gpt-4", Description: "root agent"},
 			{Name: "helper", Model: "gpt-4", Description: "helper agent"},
 		},
 		CurrentAgent: "root",
 	})
-	mm = feedCmds(t, mm, cmd)
 
-	m = mm.(*appModel)
-	frame := m.View().Content
+	frame := driver.Frame()
 	t.Logf("frame after load:\n%s", ansi.Strip(frame))
 
 	// Find the user message on screen.
@@ -140,10 +113,8 @@ func testLoadSessionThenClickEditLabel(t *testing.T, newTab bool, width int) {
 	require.GreaterOrEqual(t, userLine, 0, "user message must be visible")
 
 	// Hover over the user message to reveal the action labels.
-	mm, cmd = mm.Update(tea.MouseMotionMsg{X: 10, Y: userLine})
-	mm = feedCmds(t, mm, cmd)
-	m = mm.(*appModel)
-	frame = m.View().Content
+	driver.Send(tea.MouseMotionMsg{X: 10, Y: userLine})
+	frame = driver.Frame()
 	lines = strings.Split(ansi.Strip(frame), "\n")
 
 	editLine, editCol := -1, -1
@@ -156,15 +127,7 @@ func testLoadSessionThenClickEditLabel(t *testing.T, newTab bool, width int) {
 	require.GreaterOrEqual(t, editLine, 0, "edit label should be visible after hover:\n%s", ansi.Strip(frame))
 	t.Logf("edit label at screen line=%d col=%d", editLine, editCol)
 
-	// Click on the edit label.
-	_, cmd = mm.Update(tea.MouseClickMsg{X: editCol + 1, Y: editLine, Button: tea.MouseLeft})
-	msgs := collectMsgs(cmd)
-	found := false
-	for _, msg := range msgs {
-		t.Logf("click produced msg: %T", msg)
-		if _, ok := msg.(messages.EditUserMessageMsg); ok {
-			found = true
-		}
-	}
-	require.True(t, found, "clicking the edit label must start an inline edit")
+	// Click on the edit label and wait for the asynchronously delivered edit command.
+	driver.Send(tea.MouseClickMsg{X: editCol + 1, Y: editLine, Button: tea.MouseLeft})
+	driver.WaitFor(tuitest.Contains("[editing]"))
 }

--- a/pkg/tui/tui.go
+++ b/pkg/tui/tui.go
@@ -719,6 +719,9 @@ func (m *appModel) editorOpts() []editor.Option {
 // the given app and stores them in the per-session maps under tabID. The active
 // convenience pointers (m.chatPage, m.sessionState, m.editor) are also updated.
 func (m *appModel) initSessionComponents(tabID string, a *app.App, sess *session.Session) {
+	if old := m.chatPages[tabID]; old != nil {
+		chat.Cleanup(old)
+	}
 	ss := service.NewSessionState(sess)
 	cp := chat.New(m.ar, m.ctx(), a, ss, m.chatPageOpts()...)
 	cp.SetRoutingID(tabID)
@@ -740,6 +743,7 @@ func (m *appModel) initAndFocusComponents() tea.Cmd {
 	m.reapplyKeyboardEnhancements()
 	return tea.Batch(
 		m.chatPage.Init(),
+		chat.WatchGitBranch(m.chatPage),
 		m.editor.Init(),
 		m.editor.Focus(),
 		m.resizeAll(),
@@ -843,6 +847,7 @@ func (m *appModel) init() tea.Cmd {
 		shutdownCmd,
 		m.dialogMgr.Init(),
 		m.chatPage.Init(),
+		chat.WatchGitBranch(m.chatPage),
 		m.editor.Init(),
 		m.editor.Focus(),
 		m.application.SendFirstMessage(),
@@ -1814,10 +1819,13 @@ func (m *appModel) handleClearSession() (tea.Model, tea.Cmd) {
 
 	m.reapplyKeyboardEnhancements()
 
-	return m, tea.Sequence(
-		m.chatPage.Init(),
-		m.resizeAll(),
-		m.editor.Focus(),
+	return m, tea.Batch(
+		tea.Sequence(
+			m.chatPage.Init(),
+			m.resizeAll(),
+			m.editor.Focus(),
+		),
+		chat.WatchGitBranch(m.chatPage),
 	)
 }
 
@@ -2026,7 +2034,7 @@ func (m *appModel) handleSwitchTab(sessionID string) (tea.Model, tea.Cmd) {
 
 	if !pageExists || !editorExists {
 		if !pageExists {
-			cmds = append(cmds, m.chatPage.Init())
+			cmds = append(cmds, m.chatPage.Init(), chat.WatchGitBranch(m.chatPage))
 		}
 		if !editorExists {
 			cmds = append(cmds, m.editor.Init())
@@ -2213,6 +2221,9 @@ func (m *appModel) handleCloseTab(sessionID string) (tea.Model, tea.Cmd) {
 	nextActiveID := m.supervisor.CloseSession(sessionID)
 
 	// Clean up per-session state
+	if page, ok := m.chatPages[sessionID]; ok {
+		chat.Cleanup(page)
+	}
 	delete(m.chatPages, sessionID)
 	if ed, ok := m.editors[sessionID]; ok {
 		ed.Cleanup()
@@ -3266,6 +3277,9 @@ func (m *appModel) cleanupAll() {
 		m.closeTranscriptCh()
 		for _, ed := range m.editors {
 			ed.Cleanup()
+		}
+		for _, page := range m.chatPages {
+			chat.Cleanup(page)
 		}
 
 		// Shut down managed resources (supervisor, TUI state store) in the


### PR DESCRIPTION
## Summary
- add a shared event-driven Git branch watcher using fsnotify
- update the lean TUI footer when HEAD changes
- reuse the watcher in the full TUI sidebar
- support repositories and linked worktrees without polling

## Testing
- task build
- task lint
- go test ./pkg/gitbranch ./pkg/leantui/... ./pkg/tui/components/sidebar

## Notes
- The full `task test` run has an environment-dependent failure in `pkg/sandbox` (`TestExtraWorkspace/built-in_name` resolves the main worktree examples path). All other packages passed.