### PR TITLE
docs: auto-update for merged PRs (2026-09-03)

### DIFF
--- a/docs/features/tui/index.md
+++ b/docs/features/tui/index.md
@@ -61,7 +61,7 @@ Omit `lean` or set it to `false` to keep the full TUI as the default. You can st
 
 The lean TUI supports **steering** and **follow-ups** while the agent is running. Press <kbd>Enter</kbd> to steer the active turn, or <kbd>Alt</kbd>+<kbd>Enter</kbd> to queue the message as a separate turn after the current one finishes. Pending messages appear with muted styling at the end of the live stream, labeled `Steering:` or `Follow-up:` so it's clear which turn each one will land on.
 
-The lean TUI supports a focused set of slash commands: `/new`, `/compact`, `/model`, `/effort`, `/clear`, `/help`, `/exit` (alias: `/quit`), plus any agent-defined commands. Type `/model` (or `/model <provider/model>`) to switch the active model inline — the command opens a fuzzy-searchable list of available models.
+The lean TUI supports a focused set of slash commands: `/new`, `/sessions`, `/compact`, `/model`, `/effort`, `/clear`, `/help`, `/exit` (alias: `/quit`), plus any agent-defined commands. Type `/model` (or `/model <provider/model>`) to switch the active model inline — the command opens a fuzzy-searchable list of available models. Type `/sessions` (or `/sessions <session-id>`) to browse and resume past sessions from the current working directory.
 
 ## Slash Commands
 

--- a/docs/features/tui/index.md
+++ b/docs/features/tui/index.md
@@ -59,7 +59,7 @@ settings:
 
 Omit `lean` or set it to `false` to keep the full TUI as the default. You can still use `--lean` for a single run, or `--lean=false` to use the full TUI when `settings.lean` is enabled. See [User Settings](../../configuration/user-settings/index.md) for the full precedence rules between flags and user config.
 
-The lean TUI supports **steering** and **follow-ups** while the agent is running. Press <kbd>Enter</kbd> to steer the active turn, or <kbd>Alt</kbd>+<kbd>Enter</kbd> to queue the message as a separate turn after the current one finishes. Pending messages appear with muted styling at the end of the live stream.
+The lean TUI supports **steering** and **follow-ups** while the agent is running. Press <kbd>Enter</kbd> to steer the active turn, or <kbd>Alt</kbd>+<kbd>Enter</kbd> to queue the message as a separate turn after the current one finishes. Pending messages appear with muted styling at the end of the live stream, labeled `Steering:` or `Follow-up:` so it's clear which turn each one will land on.
 
 The lean TUI supports a focused set of slash commands: `/new`, `/compact`, `/model`, `/effort`, `/clear`, `/help`, `/exit` (alias: `/quit`), plus any agent-defined commands. Type `/model` (or `/model <provider/model>`) to switch the active model inline — the command opens a fuzzy-searchable list of available models.
 


### PR DESCRIPTION
Updates the Lean TUI documentation in `docs/features/tui/index.md` to reflect two recently merged Lean TUI features that were not yet documented:

- **Pending message labels** (docker/docker-agent#4125): pending steering/follow-up messages in the Lean TUI now render with a `Steering:` or `Follow-up:` label. Updated the pending-message description accordingly.
- **`/sessions` command** (docker/docker-agent#4119): the Lean TUI gained a `/sessions` command to browse and resume past sessions from the current working directory. Added it to the documented list of Lean TUI slash commands, with a short usage note.

All other PRs merged in the last 36 hours were reviewed and did not require documentation changes (internal refactors/bug fixes with no user-facing doc impact, or changes whose docs were already updated as part of the source PR).

### Source PRs
- docker/docker-agent#4125
- docker/docker-agent#4119