### PR TITLE
feat(shell): name PowerShell substitutes for the POSIX utilities models reach for

### DIFF
--- a/pkg/tools/builtin/shell/shell.go
+++ b/pkg/tools/builtin/shell/shell.go
@@ -419,17 +419,23 @@ func shellToolDescription(shellPath string) string {
 
 // shellSyntaxHint returns a dialect warning for shells that models
 // commonly mistake for a POSIX shell. Empty for shells where the name
-// alone is enough of a cue.
+// alone is enough of a cue. The substitution list names the utilities
+// that actually show up in observed failure traces, not a hypothetical
+// full mapping — 'grep'/'head'/'tail'/'wc'/'cat'/'gunzip' plus 'ls -la'
+// and '&&' cover the dominant error signatures.
 func shellSyntaxHint(name string) string {
 	switch name {
 	case "powershell":
-		// Windows PowerShell 5.1: '&&' / '||' are parse errors and
-		// POSIX flags don't exist ('ls -la' fails on the alias).
-		return `Use Windows PowerShell 5.1 syntax: chain commands with ";" (not "&&"), and avoid POSIX commands/flags like "ls -la".`
+		// Windows PowerShell: '&&' / '||' are parse errors before v7,
+		// and POSIX utilities are not available. Version is not
+		// asserted here — the binary name alone can't tell us which.
+		return `Windows PowerShell dialect. Chain commands with ";" (not "&&"; "&&" is a parse error on 5.1). POSIX utilities are not available — use Select-String (not grep), Select-Object -First N (not head), -Last N (not tail), Measure-Object -Line (not wc -l), Get-Content (not cat), Expand-Archive (not gunzip/tar). "ls -la" fails — use "ls" or "Get-ChildItem".`
 	case "pwsh":
-		return `Use PowerShell syntax; POSIX commands/flags like "ls -la" are not available.`
+		// PowerShell 7+: '&&' / '||' work, but POSIX utilities still
+		// don't exist as cmdlets.
+		return `PowerShell 7+ dialect. POSIX utilities are not available as cmdlets — use Select-String (not grep), Select-Object -First N (not head), -Last N (not tail), Measure-Object -Line (not wc -l), Get-Content (not cat), Expand-Archive (not gunzip/tar). "ls -la" fails — use "ls" or "Get-ChildItem".`
 	case "cmd":
-		return `Use cmd.exe syntax, not POSIX shell syntax.`
+		return `cmd.exe syntax, not POSIX. No POSIX utilities (grep, head, tail, wc, cat), no POSIX flags on built-ins, and variable expansion uses %VAR% (not $VAR).`
 	default:
 		return ""
 	}

--- a/pkg/tools/builtin/shell/shell_test.go
+++ b/pkg/tools/builtin/shell/shell_test.go
@@ -224,6 +224,72 @@ func TestShellTool_DescriptionNamesInterpreter(t *testing.T) {
 	assert.Contains(t, description, displayOS())
 }
 
+// TestShellSyntaxHint_NamesPOSIXSubstitutes anchors the substitution list
+// against regression: the hint's whole point is to tell the model which
+// PowerShell cmdlet replaces each POSIX utility models reach for by habit.
+// Dropping any of these substitutions has been observed to bring the
+// corresponding wrong command back on turn 1.
+func TestShellSyntaxHint_NamesPOSIXSubstitutes(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		shell    string
+		mustHave []string
+	}{
+		{
+			name:  "powershell hint chains the utilities models actually emit",
+			shell: "powershell",
+			mustHave: []string{
+				`";"`, `"&&"`, // separator
+				"Select-String", "grep",
+				"Select-Object", "head", "tail",
+				"Measure-Object", "wc",
+				"Get-Content", "cat",
+				"Expand-Archive", "gunzip",
+				"ls -la",
+			},
+		},
+		{
+			name:  "pwsh hint names the utility substitutes but not the && rule",
+			shell: "pwsh",
+			mustHave: []string{
+				"Select-String", "grep",
+				"Select-Object", "head", "tail",
+				"Measure-Object", "wc",
+				"Get-Content", "cat",
+				"Expand-Archive", "gunzip",
+				"ls -la",
+			},
+		},
+		{
+			name:     "cmd hint names the POSIX utilities and the variable-expansion trap",
+			shell:    "cmd",
+			mustHave: []string{"grep", "head", "tail", "wc", "cat", "%VAR%"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			hint := shellSyntaxHint(tt.shell)
+			require.NotEmpty(t, hint, "hint for %q must be non-empty", tt.shell)
+			for _, needle := range tt.mustHave {
+				assert.Contains(t, hint, needle, "%q hint must mention %q", tt.shell, needle)
+			}
+		})
+	}
+}
+
+// TestShellSyntaxHint_pwshDoesNotClaimAmpAmpFails guards against copy-pasting
+// the powershell (5.1) `&&`-is-a-parse-error clause into the pwsh (7+) hint:
+// pipeline-chain operators shipped in PowerShell 7, and telling a pwsh session
+// to avoid them is actively wrong.
+func TestShellSyntaxHint_pwshDoesNotClaimAmpAmpFails(t *testing.T) {
+	t.Parallel()
+	assert.NotContains(t, shellSyntaxHint("pwsh"), "&&")
+}
+
 func TestResolveWorkDir(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Why

The shell tool description already tells the model which interpreter runs its command, and on Windows it appends a dialect hint. Today that hint stops at:

> avoid POSIX commands/flags like "ls -la"

Observed session traces show the dominant Windows failures are not `ls -la` — they are POSIX **utilities** the model reaches for by habit:

```
Output: grep : The term 'grep' is not recognized as the name of a cmdlet...
Output: tail : The term 'tail' is not recognized as the name of a cmdlet...
Output: gunzip: The term 'gunzip' is not recognized as a name of a cmdlet...
Output: Get-ChildItem : A parameter cannot be found that matches parameter name 'la'.
The token '&&' is not a valid statement separator in this version.
```

Naming only `ls -la` left the model to invent substitutions turn after turn — often re-emitting the same utility on the very next attempt.

## What changes for the model

The `powershell` / `pwsh` / `cmd` hints now name each substitution explicitly, so the model sees the correct cmdlet in the same string that tells it which shell will run the command:

- `Select-String` (not `grep`)
- `Select-Object -First N` (not `head`), `-Last N` (not `tail`)
- `Measure-Object -Line` (not `wc -l`)
- `Get-Content` (not `cat`)
- `Expand-Archive` (not `gunzip` / `tar`)
- `ls` or `Get-ChildItem` (not `ls -la`)

Two smaller corrections rolled in:

- `powershell` (5.1) and `pwsh` (7+) split — telling `pwsh` to avoid `&&` would be actively wrong since pipeline-chain operators shipped in PowerShell 7.
- Guessed `"Windows PowerShell 5.1"` version claim dropped from the `powershell` hint — the binary name alone doesn't tell us the version.
