### PR TITLE
feat(shell): correct known shell-dialect errors in the tool output

### DIFF
--- a/pkg/tools/builtin/shell/shell.go
+++ b/pkg/tools/builtin/shell/shell.go
@@ -233,7 +233,7 @@ func (h *shellHandler) runNativeCommand(timeoutCtx, ctx context.Context, rt tool
 	case cmdErr = <-done:
 	}
 
-	formattedOutput := formatCommandOutput(timeoutCtx, ctx, cmdErr, output.String(), timeout)
+	formattedOutput := formatCommandOutput(timeoutCtx, ctx, cmdErr, output.String(), h.shell, timeout)
 	return tools.ResultSuccess(formattedOutput)
 }
 
@@ -342,7 +342,9 @@ func (h *shellHandler) resolveWorkDir(cwd string) string {
 }
 
 // formatCommandOutput formats command output handling timeout, cancellation, and errors.
-func formatCommandOutput(timeoutCtx, ctx context.Context, err error, rawOutput string, timeout time.Duration) string {
+// shellPath gates shellDialectHint: a raw substring match would false-positive on
+// macOS grep or docker logs from a Windows container.
+func formatCommandOutput(timeoutCtx, ctx context.Context, err error, rawOutput, shellPath string, timeout time.Duration) string {
 	var output string
 	if timeoutCtx.Err() != nil {
 		if ctx.Err() != nil {
@@ -356,7 +358,45 @@ func formatCommandOutput(timeoutCtx, ctx context.Context, err error, rawOutput s
 			output = fmt.Sprintf("Error executing command: %s\nOutput: %s", err, output)
 		}
 	}
-	return cmp.Or(strings.TrimSpace(output), "<no output>")
+	output = cmp.Or(strings.TrimSpace(output), "<no output>")
+	if hint := shellDialectHint(shellpath.ShellBaseName(shellPath), output); hint != "" {
+		output = "[shell-hint] " + hint + "\n\n" + output
+	}
+	return output
+}
+
+// shellDialectHint returns a corrective hint for known dialect errors. Gates on
+// shell because e.g. a "chain with &&" nudge is wrong when PowerShell is the
+// parent and a child cmd.exe fails.
+func shellDialectHint(shell, output string) string {
+	switch shell {
+	case "powershell":
+		switch {
+		case strings.Contains(output, "'&&' is not a valid statement separator"),
+			strings.Contains(output, "'||' is not a valid statement separator"):
+			return "You are on Windows PowerShell 5.1: chain commands with `;`, not `&&` or `||`. Retry with the corrected syntax."
+		case strings.Contains(output, `'C:\dev\null'`):
+			return "You are on Windows: redirect stderr with `2>$null` (PowerShell) or `2>nul` (cmd.exe), NOT `2>/dev/null`."
+		case strings.Contains(output, "is not recognized as the name of a cmdlet"):
+			return "You are on PowerShell: POSIX utilities are not available. Use `Select-String` (grep), `Select-Object -First N` (head), `Get-ChildItem` (ls), `Get-Content` (cat), `Test-Path` (test -f)."
+		case strings.Contains(output, "A parameter cannot be found that matches parameter name"):
+			return "You are on PowerShell: cmdlets do not accept POSIX-style short flags like `-la`. Use the cmdlet's own parameter names (e.g. `Get-ChildItem -Force -Recurse`, `Select-Object -First N`)."
+		}
+	case "pwsh":
+		switch {
+		case strings.Contains(output, `'C:\dev\null'`):
+			return "You are on Windows: redirect stderr with `2>$null` (PowerShell) or `2>nul` (cmd.exe), NOT `2>/dev/null`."
+		case strings.Contains(output, "is not recognized as a name of a cmdlet"):
+			return "You are on PowerShell: POSIX utilities are not available. Use `Select-String` (grep), `Select-Object -First N` (head), `Get-ChildItem` (ls), `Get-Content` (cat), `Test-Path` (test -f)."
+		case strings.Contains(output, "A parameter cannot be found that matches parameter name"):
+			return "You are on PowerShell: cmdlets do not accept POSIX-style short flags like `-la`. Use the cmdlet's own parameter names (e.g. `Get-ChildItem -Force -Recurse`, `Select-Object -First N`)."
+		}
+	case "cmd":
+		if strings.Contains(output, "is not recognized as an internal or external command") {
+			return "You are on cmd.exe: POSIX utilities are not available. Use `findstr` (grep), `type` (cat), `dir` (ls), and chain commands with `&` or `&&`."
+		}
+	}
+	return ""
 }
 
 func (t *ToolSet) Instructions() string {

--- a/pkg/tools/builtin/shell/shell_test.go
+++ b/pkg/tools/builtin/shell/shell_test.go
@@ -1,6 +1,7 @@
 package shell
 
 import (
+	"context"
 	"encoding/json"
 	"io"
 	"os"
@@ -224,59 +225,100 @@ func TestShellTool_DescriptionNamesInterpreter(t *testing.T) {
 	assert.Contains(t, description, displayOS())
 }
 
-// TestShellSyntaxHint_NamesPOSIXSubstitutes anchors the substitution list
-// against regression: the hint's whole point is to tell the model which
-// PowerShell cmdlet replaces each POSIX utility models reach for by habit.
-// Dropping any of these substitutions has been observed to bring the
-// corresponding wrong command back on turn 1.
-func TestShellSyntaxHint_NamesPOSIXSubstitutes(t *testing.T) {
+func TestShellDialectHint(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
 		name     string
 		shell    string
-		mustHave []string
+		output   string
+		wantHint string // substring the hint must contain; empty means no hint
 	}{
 		{
-			name:  "powershell hint chains the utilities models actually emit",
-			shell: "powershell",
-			mustHave: []string{
-				`";"`, `"&&"`, // separator
-				"Select-String", "grep",
-				"Select-Object", "head", "tail",
-				"Measure-Object", "wc",
-				"Get-Content", "cat",
-				"Expand-Archive", "gunzip",
-				"ls -la",
-			},
+			name:     "powershell 5.1 && parse error",
+			shell:    "powershell",
+			output:   "At line:1 char:17\n+ docker ps && docker images\n+                 ~~\nThe token '&&' is not a valid statement separator in this version.",
+			wantHint: "chain commands with `;`",
 		},
 		{
-			name:  "pwsh hint names the utility substitutes but not the && rule",
-			shell: "pwsh",
-			mustHave: []string{
-				"Select-String", "grep",
-				"Select-Object", "head", "tail",
-				"Measure-Object", "wc",
-				"Get-Content", "cat",
-				"Expand-Archive", "gunzip",
-				"ls -la",
-			},
+			name:     "powershell 5.1 || parse error",
+			shell:    "powershell",
+			output:   "The token '||' is not a valid statement separator in this version.",
+			wantHint: "chain commands with `;`",
 		},
 		{
-			name:     "cmd hint names the POSIX utilities and the variable-expansion trap",
+			name:     "powershell posix stderr redirection",
+			shell:    "powershell",
+			output:   `out-file : Could not find a part of the path 'C:\dev\null'.`,
+			wantHint: "2>$null",
+		},
+		{
+			name:     "powershell 5.1 grep not a cmdlet",
+			shell:    "powershell",
+			output:   "grep : The term 'grep' is not recognized as the name of a cmdlet, function, script file, or operable program.",
+			wantHint: "Select-String",
+		},
+		{
+			name:     "pwsh 7 head not a cmdlet",
+			shell:    "pwsh",
+			output:   "head : The term 'head' is not recognized as a name of a cmdlet, function, script file, or executable program.",
+			wantHint: "Select-Object -First",
+		},
+		{
+			name:     "cmd.exe unknown command",
 			shell:    "cmd",
-			mustHave: []string{"grep", "head", "tail", "wc", "cat", "%VAR%"},
+			output:   "'grep' is not recognized as an internal or external command,\noperable program or batch file.",
+			wantHint: "findstr",
+		},
+		{
+			name:     "powershell rejects posix short flag",
+			shell:    "powershell",
+			output:   "Get-ChildItem : A parameter cannot be found that matches parameter name 'la'.",
+			wantHint: "POSIX-style short flags",
+		},
+		{
+			name:     "zsh does not fire windows hints",
+			shell:    "zsh",
+			output:   "The token '&&' is not a valid statement separator in this version.",
+			wantHint: "",
+		},
+		{
+			name:     "powershell does not fire cmd.exe hint on child cmd failure",
+			shell:    "powershell",
+			output:   "'grep' is not recognized as an internal or external command,\noperable program or batch file.",
+			wantHint: "",
+		},
+		{
+			name:     "pwsh 7 does not fire powershell-5.1-only && hint",
+			shell:    "pwsh",
+			output:   "The token '&&' is not a valid statement separator in this version.",
+			wantHint: "",
+		},
+		{
+			name:     "benign output leaves no hint",
+			shell:    "powershell",
+			output:   "hello world",
+			wantHint: "",
+		},
+		{
+			name:     "docker error unrelated to shell dialect",
+			shell:    "powershell",
+			output:   "Error response from daemon: No such container: comfy-worker",
+			wantHint: "",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			hint := shellSyntaxHint(tt.shell)
-			require.NotEmpty(t, hint, "hint for %q must be non-empty", tt.shell)
-			for _, needle := range tt.mustHave {
-				assert.Contains(t, hint, needle, "%q hint must mention %q", tt.shell, needle)
+			got := shellDialectHint(tt.shell, tt.output)
+			if tt.wantHint == "" {
+				assert.Empty(t, got, "expected no hint for shell=%q output=%q", tt.shell, tt.output)
+				return
 			}
+			require.NotEmpty(t, got, "expected a hint for shell=%q output=%q", tt.shell, tt.output)
+			assert.Contains(t, got, tt.wantHint,
+				"hint for shell=%q output=%q missing %q; got %q", tt.shell, tt.output, tt.wantHint, got)
 		})
 	}
 }
@@ -288,6 +330,46 @@ func TestShellSyntaxHint_NamesPOSIXSubstitutes(t *testing.T) {
 func TestShellSyntaxHint_pwshDoesNotClaimAmpAmpFails(t *testing.T) {
 	t.Parallel()
 	assert.NotContains(t, shellSyntaxHint("pwsh"), "&&")
+}
+
+func TestFormatCommandOutput_PrependsHint(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	timeoutCtx, cancel := context.WithTimeout(ctx, time.Minute)
+	defer cancel()
+
+	raw := "The token '&&' is not a valid statement separator in this version."
+	got := formatCommandOutput(timeoutCtx, ctx, nil, raw, `C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe`, time.Minute)
+
+	assert.True(t, strings.HasPrefix(got, "[shell-hint] "),
+		"hint must lead the output so the model sees it first; got %q", got)
+	assert.Contains(t, got, raw, "original output must be preserved after the hint")
+}
+
+// TestFormatCommandOutput_NoHintOnPosixShell: raw output mentioning a Windows
+// error string on a POSIX host must not trigger the hint.
+func TestFormatCommandOutput_NoHintOnPosixShell(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	timeoutCtx, cancel := context.WithTimeout(ctx, time.Minute)
+	defer cancel()
+
+	raw := "The token '&&' is not a valid statement separator in this version."
+	got := formatCommandOutput(timeoutCtx, ctx, nil, raw, "/bin/zsh", time.Minute)
+	assert.Equal(t, raw, got)
+}
+
+func TestFormatCommandOutput_NoHintOnBenignOutput(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	timeoutCtx, cancel := context.WithTimeout(ctx, time.Minute)
+	defer cancel()
+
+	got := formatCommandOutput(timeoutCtx, ctx, nil, "hello world", `C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe`, time.Minute)
+	assert.Equal(t, "hello world", got)
 }
 
 func TestResolveWorkDir(t *testing.T) {


### PR DESCRIPTION
## Why

The shell tool description already tells the model which interpreter runs its commands (`shellToolDescription`), but observed session traces show the model still emits POSIX syntax turn after turn under Windows PowerShell — every attempt produces a fresh parse or parameter error, the model re-derives the dialect from scratch, and the same wrong syntax gets emitted again.

A representative trace across three consecutive turns in one session:

```
Turn 1: pwd && ls -la
        → The token '&&' is not a valid statement separator in this version.
Turn 2: docker ps | grep foo
        → grep : The term 'grep' is not recognized as the name of a cmdlet...
Turn 3: docker logs foo | tail -20
        → tail : The term 'tail' is not recognized as the name of a cmdlet...
```

The description hint prevents turn 1 in some sessions but does not recover the sessions where the model ignores it. Long agentic sessions burn many tool calls this way.

## What changes for the model

Scan the shell-tool output for well-known dialect-error signatures and prepend a terse imperative hint above the raw output:

```
[shell-hint] You are on PowerShell: POSIX utilities are not available.
Use `Select-String` (grep), `Select-Object -First N` (head), ...

grep : The term 'grep' is not recognized as the name of a cmdlet...
```

The hint lands at the top so the model sees it first; the original output is preserved verbatim below so nothing about the debugging path is hidden.

## Why gated on the resolved shell, not on a raw substring match

Without gating, a `docker logs` pull from a Windows container, a `grep` against a repo, or a `cat` of a docs page that quotes the error string would all trip false positives on macOS/Linux hosts. Gating also makes each hint truthful — a "chain with `;` not `&&`" nudge is actively wrong when the resolved shell is PowerShell 7 (`pwsh`) or when the failure came from a child `cmd.exe` invocation under a PowerShell parent.
