### PR TITLE
feat: add get_environment_info read-only tool

### DIFF
--- a/docs/configuration/tools/index.md
+++ b/docs/configuration/tools/index.md
@@ -23,6 +23,7 @@ Built-in tools are included with Docker Agent and require no external dependenci
 | `shell` | Execute shell commands synchronously | [Shell](../../tools/shell/index.md) |
 | `background_jobs` | Run and manage long-running shell commands | [Background Jobs](../../tools/background-jobs/index.md) |
 | `scheduler` | Schedule instructions to run at a time or on a recurring interval | [Scheduler](../../tools/scheduler/index.md) |
+| `environment` | Report the OS and resolved shell (read-only, no arguments, auto-approved) | [Environment](../../tools/environment/index.md) |
 | `think` | Reasoning scratchpad | [Think](../../tools/think/index.md) |
 | `plan` | Shared persistent scratchpad for multi-agent collaboration | [Plan](../../tools/plan/index.md) |
 | `session_plan` | Per-session markdown plan for the draft-review-execute workflow | [Session Plan](../../tools/session_plan/index.md) |

--- a/docs/tools/environment/index.md
+++ b/docs/tools/environment/index.md
@@ -1,0 +1,44 @@
+---
+title: "Environment Tool"
+description: "Report the OS and resolved shell so the model can pick the right syntax."
+keywords: docker agent, ai agents, tools, toolsets, environment tool
+linkTitle: "Environment"
+weight: 145
+canonical: https://docs.docker.com/ai/docker-agent/tools/environment/
+---
+
+_Report the OS and resolved shell so the model can pick the right syntax._
+
+## Overview
+
+The environment tool exposes a single read-only call — `get_environment_info` — that returns the operating system and the resolved shell that will run shell-tool commands, e.g. `{"os":"Windows","shell":"powershell"}`.
+
+It takes no arguments, has no side effects, and reads only `runtime.GOOS` and the shell binary that the shell tool has already resolved. Because it carries the `ReadOnlyHint` annotation, the safety layer auto-approves it in every mode — the same treatment as `git status`, `list_directory`, and other pure-info tools.
+
+## When to use
+
+Pair with the shell toolset when the model may run on hosts with unfamiliar shells (Windows PowerShell, cmd.exe, fish, nushell). The shell tool description already names the resolved interpreter, but that hint sits in the tool schema; giving the model a callable tool provides a first-class fallback for edge cases such as multi-agent handoffs or long sessions where the schema hint has slid out of attention.
+
+## Configuration
+
+```yaml
+toolsets:
+  - type: environment
+  - type: shell
+```
+
+No configuration options.
+
+## Output shape
+
+```json
+{
+  "os": "Windows",
+  "shell": "powershell"
+}
+```
+
+- `os` — friendly label for `runtime.GOOS` (`Windows`, `macOS`, `Linux`, or the raw `GOOS` for anything exotic).
+- `shell` — lowercase basename of the resolved shell (`powershell`, `pwsh`, `cmd`, `bash`, `zsh`, `fish`, …).
+
+The output shape is fixed. No working directory, no full paths, no username — anything user-controlled would land in the conversation transcript.

--- a/pkg/teamloader/toolsets/catalog.go
+++ b/pkg/teamloader/toolsets/catalog.go
@@ -13,6 +13,7 @@ var BuiltinToolsets = []BuiltinToolsetInfo{
 	builtinToolset("api", "api", "Create custom tools that call HTTP APIs"),
 	builtinToolset("background_agents", "background-agents", "Dispatch work to sub-agents concurrently and collect results"),
 	builtinToolset("background_jobs", "background-jobs", "Run and manage long-running shell commands"),
+	builtinToolset("environment", "environment", "Report the OS and resolved shell (read-only, no arguments)"),
 	builtinToolset("fetch", "fetch", "Read content from HTTP/HTTPS URLs"),
 	builtinToolset("file", "file", "Read, write, and edit individual files"),
 	builtinToolset("filesystem", "filesystem", "Read, write, list, search, and navigate files and directories"),

--- a/pkg/teamloader/toolsets/toolsets.go
+++ b/pkg/teamloader/toolsets/toolsets.go
@@ -11,6 +11,7 @@ import (
 	agenttool "github.com/docker/docker-agent/pkg/tools/builtin/agent"
 	"github.com/docker/docker-agent/pkg/tools/builtin/api"
 	"github.com/docker/docker-agent/pkg/tools/builtin/backgroundjobs"
+	"github.com/docker/docker-agent/pkg/tools/builtin/environment"
 	"github.com/docker/docker-agent/pkg/tools/builtin/fetch"
 	filetool "github.com/docker/docker-agent/pkg/tools/builtin/file"
 	"github.com/docker/docker-agent/pkg/tools/builtin/filesystem"
@@ -61,6 +62,9 @@ func DefaultToolsetCreators() map[string]teamloader.ToolsetCreator {
 		},
 		"think": func(_ context.Context, _ latest.Toolset, _ string, _ *config.RuntimeConfig, _ string) (tools.ToolSet, error) {
 			return think.CreateToolSet()
+		},
+		"environment": func(_ context.Context, _ latest.Toolset, _ string, _ *config.RuntimeConfig, _ string) (tools.ToolSet, error) {
+			return environment.CreateToolSet()
 		},
 		"scheduler": func(_ context.Context, _ latest.Toolset, _ string, _ *config.RuntimeConfig, _ string) (tools.ToolSet, error) {
 			return scheduler.CreateToolSet()

--- a/pkg/tools/builtin/environment/environment.go
+++ b/pkg/tools/builtin/environment/environment.go
@@ -1,0 +1,96 @@
+// Package environment exposes a single read-only tool the model can call
+// to learn which OS and shell will run its shell-tool commands. The tool
+// takes no arguments and returns a fixed shape — reads only runtime.GOOS
+// and the already-detected shell binary — so it earns the ReadOnlyHint
+// auto-approval used by other pure-info tools (git status, filesystem
+// reads, memory reads, …).
+package environment
+
+import (
+	"context"
+	"encoding/json"
+	"runtime"
+
+	"github.com/docker/docker-agent/pkg/shellpath"
+	"github.com/docker/docker-agent/pkg/tools"
+)
+
+const (
+	ToolNameGetEnvironmentInfo = "get_environment_info"
+	category                   = "environment"
+)
+
+// CreateToolSet is the registry entry point.
+func CreateToolSet() (tools.ToolSet, error) {
+	return New(), nil
+}
+
+type ToolSet struct{}
+
+// Args intentionally has no fields: the tool must not accept model- or
+// user-steered inputs, so the safety surface is what the code decides to
+// read, not what the caller asks for.
+type Args struct{}
+
+// Info is the tool's fixed output shape. Deliberately narrow: OS and
+// shell only, no working directory, no full paths, no username. Anything
+// user-controlled would land in the conversation transcript.
+type Info struct {
+	OS    string `json:"os"`
+	Shell string `json:"shell"`
+}
+
+func New() *ToolSet {
+	return &ToolSet{}
+}
+
+func (t *ToolSet) get(_ context.Context, _ Args) (*tools.ToolCallResult, error) {
+	shellPath, _ := shellpath.DetectShell()
+	info := Info{
+		OS:    displayOS(),
+		Shell: shellpath.ShellBaseName(shellPath),
+	}
+	payload, err := json.Marshal(info)
+	if err != nil {
+		return tools.ResultError("Error marshaling environment info: " + err.Error()), nil
+	}
+	return tools.ResultSuccess(string(payload)), nil
+}
+
+func (t *ToolSet) Instructions() string {
+	return `## Environment Info
+
+Call get_environment_info when you're unsure which shell syntax to use.
+Returns the OS and the resolved shell (e.g. {"os":"Windows","shell":"powershell"}),
+nothing else. Cheap: no arguments, no side effects, auto-approved.`
+}
+
+func (t *ToolSet) Tools(context.Context) ([]tools.Tool, error) {
+	return []tools.Tool{
+		{
+			Name:                    ToolNameGetEnvironmentInfo,
+			Category:                category,
+			Description:             `Returns the operating system and resolved shell that will run shell-tool commands (e.g. {"os":"Windows","shell":"powershell"}). No arguments, no side effects. Call this when unsure which shell syntax to use.`,
+			Parameters:              tools.MustSchemaFor[Args](),
+			OutputSchema:            tools.MustSchemaFor[Info](),
+			Handler:                 tools.NewHandler(t.get),
+			Annotations:             tools.ToolAnnotations{ReadOnlyHint: true, Title: "Environment Info"},
+			AddDescriptionParameter: true,
+		},
+	}, nil
+}
+
+// displayOS mirrors the labels used by the shell tool description so the
+// value the model sees here matches what it saw in the shell tool schema.
+func displayOS() string {
+	switch runtime.GOOS {
+	case "darwin":
+		return "macOS"
+	case "windows":
+		return "Windows"
+	case "linux":
+		return "Linux"
+	default:
+		return runtime.GOOS
+	}
+}

--- a/pkg/tools/builtin/environment/environment_test.go
+++ b/pkg/tools/builtin/environment/environment_test.go
@@ -1,0 +1,67 @@
+package environment
+
+import (
+	"encoding/json"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/docker/docker-agent/pkg/tools"
+)
+
+func TestGetEnvironmentInfo_ShapeAndValues(t *testing.T) {
+	t.Parallel()
+
+	ts := New()
+	res, err := ts.get(t.Context(), Args{})
+	require.NoError(t, err)
+	require.NotNil(t, res)
+
+	var got Info
+	require.NoError(t, json.Unmarshal([]byte(res.Output), &got))
+
+	assert.NotEmpty(t, got.OS, "os must be populated")
+	assert.NotEmpty(t, got.Shell, "shell must be populated")
+
+	switch runtime.GOOS {
+	case "windows":
+		assert.Equal(t, "Windows", got.OS)
+	case "darwin":
+		assert.Equal(t, "macOS", got.OS)
+	case "linux":
+		assert.Equal(t, "Linux", got.OS)
+	}
+}
+
+// TestGetEnvironmentInfo_ReadOnlyHint anchors the auto-approval contract:
+// the tool's whole reason to exist as a *tool* (instead of a hook) is that
+// it rides the ReadOnlyHint gate to skip user approval. Dropping the hint
+// would silently reintroduce a modal per call.
+func TestGetEnvironmentInfo_ReadOnlyHint(t *testing.T) {
+	t.Parallel()
+
+	toolList, err := New().Tools(t.Context())
+	require.NoError(t, err)
+	require.Len(t, toolList, 1)
+	assert.True(t, toolList[0].Annotations.ReadOnlyHint,
+		"get_environment_info must set ReadOnlyHint so the safety layer auto-approves it")
+	assert.Equal(t, ToolNameGetEnvironmentInfo, toolList[0].Name)
+}
+
+// TestGetEnvironmentInfo_NoArguments guards the "no user-controlled inputs"
+// promise the auto-approval relies on: adding fields to Args would let the
+// model steer what the tool reads, which invalidates the safety argument.
+func TestGetEnvironmentInfo_NoArguments(t *testing.T) {
+	t.Parallel()
+
+	toolList, err := New().Tools(t.Context())
+	require.NoError(t, err)
+	require.Len(t, toolList, 1)
+
+	schema, err := json.Marshal(tools.MustSchemaFor[Args]())
+	require.NoError(t, err)
+	assert.NotContains(t, string(schema), `"properties":{`,
+		"Args must remain a zero-field struct so the model cannot steer what the tool reads")
+}

--- a/pkg/tools/builtin/shell/shell.go
+++ b/pkg/tools/builtin/shell/shell.go
@@ -407,13 +407,16 @@ func (t *ToolSet) Stop(context.Context) error {
 // Models default to POSIX syntax when the description only says "the
 // user's default shell", which wastes turns on Windows where the
 // resolved shell is PowerShell or cmd.exe (e.g. "pwd && ls -la" is a
-// parse error under Windows PowerShell 5.1).
+// parse error under Windows PowerShell 5.1). The trailing nudge points
+// the model at get_environment_info for edge cases the static hint
+// does not cover (custom shells, multi-agent handoffs, etc.).
 func shellToolDescription(shellPath string) string {
 	name := shellpath.ShellBaseName(shellPath)
 	desc := fmt.Sprintf("Executes the given shell command with %s on %s.", name, displayOS())
 	if hint := shellSyntaxHint(name); hint != "" {
 		desc += " " + hint
 	}
+	desc += " If unsure which shell syntax to use, call get_environment_info first."
 	return desc
 }
 

--- a/pkg/tools/builtin/shell/shell_test.go
+++ b/pkg/tools/builtin/shell/shell_test.go
@@ -222,6 +222,8 @@ func TestShellTool_DescriptionNamesInterpreter(t *testing.T) {
 	description := allTools[0].Description
 	assert.Contains(t, description, shellpath.ShellBaseName(tool.handler.shell))
 	assert.Contains(t, description, displayOS())
+	assert.Contains(t, description, "get_environment_info",
+		"description must point the model at the environment tool for edge cases the static hint doesn't cover")
 }
 
 func TestResolveWorkDir(t *testing.T) {


### PR DESCRIPTION
## Why

The shell tool description already tells the model which interpreter runs its commands (`shellToolDescription`), and on Windows it appends a dialect hint. Both live in the tool schema — great for the common case, but two edge cases slip through:

- **Unfamiliar shells** — `fish`, `nushell`, custom shells. The description only carries specific guidance for `powershell`, `pwsh`, `cmd`; every other shell gets the interpreter name only.
- **Long sessions and multi-agent handoffs** where the schema hint has slid out of the model's attention, and re-reading a large tool schema is not what it will do.

Both cases want a first-class *callable* fallback the model can reach for on demand.

## What changes for the model

New builtin toolset `environment` exposes a single tool `get_environment_info` that returns the OS and resolved shell:

```json
{"os": "Windows", "shell": "powershell"}
```

No arguments. No side effects. Reads only `runtime.GOOS` and the already-resolved shell binary.

The shell tool description gets a one-sentence nudge — *"If unsure which shell syntax to use, call get_environment_info first"* — so the model knows the tool is available.
