### PR TITLE
fix: update stale Fireworks kimi-k2-instruct model reference

### DIFF
--- a/docs/providers/fireworks/index.md
+++ b/docs/providers/fireworks/index.md
@@ -11,7 +11,7 @@ _Use Fireworks AI models with Docker Agent._
 ## Overview
 
 [Fireworks AI](https://fireworks.ai/) is a fast inference host for open-weight
-models, serving Kimi K2, Llama, Qwen, DeepSeek, GLM and others through an
+models, serving Kimi, Qwen, DeepSeek, GLM and others through an
 OpenAI-compatible API. Docker Agent includes built-in support for Fireworks AI
 as an alias provider.
 
@@ -33,7 +33,7 @@ The simplest way to use Fireworks AI:
 ```yaml
 agents:
   root:
-    model: fireworks/accounts/fireworks/models/kimi-k2-instruct
+    model: fireworks/accounts/fireworks/models/kimi-k3
     description: Assistant using Fireworks AI
     instruction: You are a helpful assistant.
 ```
@@ -46,7 +46,7 @@ For more control over parameters:
 models:
   fireworks_model:
     provider: fireworks
-    model: accounts/fireworks/models/kimi-k2-instruct
+    model: accounts/fireworks/models/kimi-k3
     temperature: 0.7
     max_tokens: 8192
 
@@ -66,9 +66,12 @@ limits, and pricing.
 
 | Model | Description |
 | --- | --- |
-| `accounts/fireworks/models/kimi-k2-instruct` | Kimi K2, large open MoE chat and tool-calling model |
-| `accounts/fireworks/models/llama-v3p3-70b-instruct` | Llama 3.3 70B instruct |
-| `accounts/fireworks/models/qwen3-235b-a22b` | Qwen 3 235B MoE |
+| `accounts/fireworks/models/kimi-k3` | Kimi K3, large open MoE chat and tool-calling model |
+| `accounts/fireworks/models/kimi-k2p7-code` | Kimi K2.7 Code, coding-focused variant |
+| `accounts/fireworks/models/glm-5p3` | GLM 5.3 |
+| `accounts/fireworks/models/qwen3p8-max` | Qwen 3.8 Max |
+| `accounts/fireworks/models/deepseek-v4-pro-0813` | DeepSeek V4 Pro |
+| `accounts/fireworks/models/gpt-oss-120b` | GPT OSS 120B |
 
 > Model IDs are case-sensitive and must be passed exactly as the catalogue lists
 > them.
@@ -90,8 +93,8 @@ messages into a single one for this provider.
 ```yaml
 agents:
   coder:
-    model: fireworks/accounts/fireworks/models/kimi-k2-instruct
-    description: Code assistant using Kimi K2 on Fireworks AI
+    model: fireworks/accounts/fireworks/models/kimi-k2p7-code
+    description: Code assistant using Kimi K2.7 Code on Fireworks AI
     instruction: |
       You are an expert programmer.
       Write clean, well-documented code and follow language best practices.

--- a/examples/fireworks.yaml
+++ b/examples/fireworks.yaml
@@ -3,7 +3,7 @@
 models:
   fireworks_model:
     provider: fireworks
-    model: accounts/fireworks/models/kimi-k2-instruct
+    model: accounts/fireworks/models/kimi-k3
 
 agents:
   root:

--- a/pkg/config/auto.go
+++ b/pkg/config/auto.go
@@ -160,7 +160,7 @@ var DefaultModels = map[string]string{
 	"baseten":        "deepseek-ai/DeepSeek-V4-Pro",
 	"ovhcloud":       "Qwen3.5-397B-A17B",
 	"groq":           "llama-3.3-70b-versatile",
-	"fireworks":      "accounts/fireworks/models/kimi-k2-instruct",
+	"fireworks":      "accounts/fireworks/models/kimi-k3",
 	"deepseek":       "deepseek-v4-pro",
 	"cerebras":       "gpt-oss-120b",
 	"together":       "meta-llama/Llama-3.3-70B-Instruct-Turbo",

--- a/pkg/config/auto_test.go
+++ b/pkg/config/auto_test.go
@@ -338,7 +338,7 @@ func TestAutoModelConfig(t *testing.T) {
 				"FIREWORKS_API_KEY": "test-key",
 			},
 			expectedProvider:  "fireworks",
-			expectedModel:     "accounts/fireworks/models/kimi-k2-instruct",
+			expectedModel:     "accounts/fireworks/models/kimi-k3",
 			expectedMaxTokens: 32000,
 		},
 		{
@@ -498,7 +498,7 @@ func TestDefaultModels(t *testing.T) {
 	assert.Equal(t, "deepseek-ai/DeepSeek-V4-Pro", DefaultModels["baseten"])
 	assert.Equal(t, "Qwen3.5-397B-A17B", DefaultModels["ovhcloud"])
 	assert.Equal(t, "llama-3.3-70b-versatile", DefaultModels["groq"])
-	assert.Equal(t, "accounts/fireworks/models/kimi-k2-instruct", DefaultModels["fireworks"])
+	assert.Equal(t, "accounts/fireworks/models/kimi-k3", DefaultModels["fireworks"])
 	assert.Equal(t, "deepseek-v4-pro", DefaultModels["deepseek"])
 	assert.Equal(t, "gpt-oss-120b", DefaultModels["cerebras"])
 	assert.Equal(t, "meta-llama/Llama-3.3-70B-Instruct-Turbo", DefaultModels["together"])
@@ -1185,9 +1185,10 @@ func TestCloudProviderEnvVars(t *testing.T) {
 // TestDefaultModelsExistInModelsDev is the regression test for issue #4133:
 // DefaultModels must reference models that actually exist in the models.dev
 // catalog, since AutoModelConfig hands them straight to real users with no
-// other validation. modelsDevAbsentProviders (defined in examples_test.go) is
-// reused so providers legitimately absent, or aliased, in the catalog don't
-// produce false failures.
+// other validation. modelsDevAbsentProviders and modelsDevCatalogProviders
+// (both defined in examples_test.go) are reused so providers legitimately
+// absent, or aliased under a different id, in the catalog don't produce
+// false failures.
 func TestDefaultModelsExistInModelsDev(t *testing.T) {
 	t.Parallel()
 
@@ -1202,7 +1203,12 @@ func TestDefaultModelsExistInModelsDev(t *testing.T) {
 				t.Skipf("provider %q is not expected to exist in the models.dev catalog", provider)
 			}
 
-			_, err := modelsStore.GetModel(t.Context(), modelsdev.NewID(provider, model))
+			catalogProvider := provider
+			if id, ok := modelsDevCatalogProviders[provider]; ok {
+				catalogProvider = id
+			}
+
+			_, err := modelsStore.GetModel(t.Context(), modelsdev.NewID(catalogProvider, model))
 			require.NoError(t, err, "DefaultModels[%q] = %q must exist in the models.dev catalog", provider, model)
 		})
 	}

--- a/pkg/config/examples_test.go
+++ b/pkg/config/examples_test.go
@@ -17,18 +17,25 @@ import (
 	"github.com/docker/docker-agent/pkg/modelsdev"
 )
 
+// modelsDevCatalogProviders maps a docker-agent provider name to the id
+// models.dev actually catalogs it under, for providers where the two
+// diverge. Resolving through this map (instead of skipping validation
+// outright) is what caught the stale Fireworks model reference in #4132.
+var modelsDevCatalogProviders = map[string]string{
+	"fireworks":    "fireworks-ai", // models.dev catalogs Fireworks under the "fireworks-ai" id, not "fireworks"
+	"together":     "togetherai",   // models.dev catalogs Together AI under the "togetherai" id, not "together"
+	"moonshot":     "moonshotai",   // models.dev catalogs Moonshot AI under the "moonshotai" id, not "moonshot"
+	"chatgpt":      "openai",       // ChatGPT subscription backend; models.dev catalogs its models under the "openai" id
+	"opencode-zen": "opencode",     // models.dev catalogs the OpenCode Zen router under the "opencode" id
+}
+
 // modelsDevAbsentProviders lists providers that are valid at runtime but
-// are not expected to exist in the remote models.dev catalog. The test
-// skips models.dev lookups for these to avoid false failures.
+// whose example model reference can't be validated against models.dev,
+// even via modelsDevCatalogProviders above. The test skips models.dev
+// lookups for these to avoid false failures.
 var modelsDevAbsentProviders = map[string]bool{
 	"dmr":                   true, // Docker Model Runner (local, not in catalog)
-	"chatgpt":               true, // ChatGPT subscription backend; models.dev catalogs its models under the "openai" id
-	"opencode-zen":          true, // not yet registered in models.dev
-	"ovhcloud":              true, // OVHcloud AI Endpoints (not yet in models.dev)
-	"fireworks":             true, // models.dev catalogs Fireworks under the "fireworks-ai" id, not "fireworks"
-	"together":              true, // models.dev catalogs Together AI under the "togetherai" id, not "together"
-	"moonshot":              true, // models.dev catalogs Moonshot AI under the "moonshotai" id, not "moonshot"
-	"vercel":                true, // Vercel AI Gateway is a multi-provider router, not a models.dev catalog id
+	"ovhcloud":              true, // models.dev lower-cases OVHcloud model ids (e.g. "qwen3.5-397b-a17b"); the provider API is case-sensitive and takes "Qwen3.5-397B-A17B"
 	"cloudflare-workers-ai": true, // example uses an @cf/... model id not present in the models.dev snapshot (only variant ids like -fp8 are listed)
 	"cloudflare-ai-gateway": true, // multi-provider router; example model ids use the gateway's provider/model form, not guaranteed to match a models.dev id
 }
@@ -60,8 +67,10 @@ func collectExamples(t *testing.T) []string {
 // skip rules to both: first_available selectors are resolved at runtime
 // from the environment's credentials, routed models span multiple
 // providers, custom providers are self-contained (already validated via
-// cfg.Providers), and modelsDevAbsentProviders lists providers models.dev
-// deliberately does not catalog.
+// cfg.Providers), modelsDevAbsentProviders lists providers models.dev
+// deliberately does not catalog, and modelsDevCatalogProviders resolves
+// the remaining providers to the id models.dev actually catalogs them
+// under, when it diverges from the docker-agent provider name.
 func catalogModelRefs(cfg *latest.Config) []modelsdev.ID {
 	var ids []modelsdev.ID
 	for _, model := range cfg.Models {
@@ -80,7 +89,11 @@ func catalogModelRefs(cfg *latest.Config) []modelsdev.ID {
 		if _, isCustomProvider := cfg.Providers[model.Provider]; isCustomProvider {
 			continue
 		}
-		ids = append(ids, modelsdev.NewID(model.Provider, model.Model))
+		catalogProvider := model.Provider
+		if id, ok := modelsDevCatalogProviders[model.Provider]; ok {
+			catalogProvider = id
+		}
+		ids = append(ids, modelsdev.NewID(catalogProvider, model.Model))
 	}
 	return ids
 }

--- a/pkg/model/provider/openai/system_message_merge_test.go
+++ b/pkg/model/provider/openai/system_message_merge_test.go
@@ -161,7 +161,7 @@ func TestShouldMergeConsecutiveMessages_Gating(t *testing.T) {
 		{"baseten", &latest.ModelConfig{Provider: "baseten", Model: "zai-org/GLM-5.2"}, true},
 		{"ovhcloud", &latest.ModelConfig{Provider: "ovhcloud", Model: "Qwen3.5-397B-A17B"}, true},
 		{"open-model host alias cerebras", &latest.ModelConfig{Provider: "cerebras", Model: "qwen-3-coder-480b"}, true},
-		{"open-model host fireworks", &latest.ModelConfig{Provider: "fireworks", Model: "accounts/fireworks/models/kimi-k2-instruct"}, true},
+		{"open-model host fireworks", &latest.ModelConfig{Provider: "fireworks", Model: "accounts/fireworks/models/kimi-k3"}, true},
 		{"open-model host together", &latest.ModelConfig{Provider: "together", Model: "Qwen/Qwen3-235B-A22B-Instruct-2507-tput"}, true},
 		{"open-model host huggingface", &latest.ModelConfig{Provider: "huggingface", Model: "meta-llama/Llama-3.3-70B-Instruct"}, true},
 		{"open-model host gateway vercel", &latest.ModelConfig{Provider: "vercel", Model: "openai/gpt-5"}, true},

--- a/pkg/model/provider/openai_alias_providers_test.go
+++ b/pkg/model/provider/openai_alias_providers_test.go
@@ -68,7 +68,7 @@ var openAIAliasProviders = []openAIAliasProvider{
 		provider:             "fireworks",
 		envVar:               "FIREWORKS_API_KEY",
 		testKey:              "fw-test-fireworks-key",
-		model:                "accounts/fireworks/models/kimi-k2-instruct",
+		model:                "accounts/fireworks/models/kimi-k3",
 		greeting:             "Hello from Fireworks",
 		mergesSystemMessages: true,
 	},


### PR DESCRIPTION
🤖 **Automated implementer agent** — *this comment was posted by the implementer bot from Docker Agentic Platform, not by a human developer*

Fixes #4132.

`accounts/fireworks/models/kimi-k2-instruct` does not exist in the `fireworks-ai` models.dev catalog (and never has). Replaces it with `accounts/fireworks/models/kimi-k3`, verified present in the current `pkg/modelsdev/snapshot.json`, across:

- `pkg/config/auto.go` (`DefaultModels["fireworks"]`)
- `examples/fireworks.yaml`
- `pkg/config/auto_test.go`, `pkg/model/provider/openai_alias_providers_test.go`, `pkg/model/provider/openai/system_message_merge_test.go`
- `docs/providers/fireworks/index.md` — 4 `model:` snippets, plus the "Available Models" table, which also listed two other nonexistent ids (`llama-v3p3-70b-instruct`, `qwen3-235b-a22b`); Llama has no successor in the `fireworks-ai` catalog at all, so it's dropped rather than remapped.

Also closes the CI blind spot the issue describes: `pkg/config/examples_test.go`'s `modelsDevAbsentProviders` unconditionally skipped models.dev validation for several providers whose docker-agent name diverges from their models.dev catalog id. Replaced with a `modelsDevCatalogProviders` map that resolves the real catalog id (`fireworks`→`fireworks-ai`, `together`→`togetherai`, `moonshot`→`moonshotai`, `chatgpt`→`openai`, `opencode-zen`→`opencode`) before validating — this is exactly the check that would have caught #4132 automatically. `vercel` now validates directly (models.dev catalogs it as-is). `dmr`, `ovhcloud`, `cloudflare-workers-ai`, `cloudflare-ai-gateway` remain skipped with corrected comments (e.g. `ovhcloud`'s example id is case-mismatched against models.dev's lower-cased ids, not "not yet catalogued").

**Known, deliberately out-of-scope follow-up:** `DefaultModels` itself isn't validated against models.dev for every provider (e.g. `github-copilot`'s default `gpt-5.6` isn't in that provider's catalog, which only has `gpt-5.6-luna/-sol/-terra`). Extending validation to `DefaultModels` would need separate model-choice review per provider, so left for a follow-up rather than bundled here.

**Testing:** `task build`, `task test` (green except the pre-existing, unrelated `pkg/rag/treesitter` CGO failures — no gcc in this sandbox), `task lint` (golangci-lint + `go run ./lint .` + `go mod tidy --diff`) all pass.