### PR TITLE
feat(share): sign or encrypt agent YAML in OCI artifacts with --key

### DIFF
--- a/cmd/root/pull.go
+++ b/cmd/root/pull.go
@@ -10,12 +10,14 @@ import (
 
 	"github.com/docker/docker-agent/pkg/cli"
 	"github.com/docker/docker-agent/pkg/content"
+	"github.com/docker/docker-agent/pkg/protect"
 	"github.com/docker/docker-agent/pkg/remote"
 	"github.com/docker/docker-agent/pkg/telemetry"
 )
 
 type pullFlags struct {
-	force bool
+	force   bool
+	keyFile string
 }
 
 func newPullCmd() *cobra.Command {
@@ -24,12 +26,19 @@ func newPullCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "pull <registry-ref>",
 		Short: "Pull an agent from an OCI registry",
-		Long:  "Pull an agent configuration file from an OCI registry",
-		Args:  cobra.ExactArgs(1),
-		RunE:  flags.runPullCommand,
+		Long: `Pull an agent configuration file from an OCI registry.
+
+With --key, the pulled agent YAML is verified against the protection recorded
+by 'share push --key': a signature is checked with the same secret or the
+matching public key; an encrypted copy (push --encrypt) is decrypted with the
+same secret or the matching private key and compared to the YAML. The pull
+fails if the artifact is unprotected or the check does not pass.`,
+		Args: cobra.ExactArgs(1),
+		RunE: flags.runPullCommand,
 	}
 
 	cmd.PersistentFlags().BoolVar(&flags.force, "force", false, "Force pull even if the configuration already exists locally")
+	cmd.Flags().StringVar(&flags.keyFile, "key", "", "Path to a key file (PEM/OpenSSH) or symmetric secret used to verify the agent")
 
 	return cmd
 }
@@ -44,6 +53,14 @@ func (f *pullFlags) runPullCommand(cmd *cobra.Command, args []string) (commandEr
 	out := cli.NewPrinter(cmd.OutOrStdout())
 	registryRef := args[0]
 	slog.DebugContext(ctx, "Starting pull", "registry_ref", registryRef)
+
+	var key *protect.Key
+	if f.keyFile != "" {
+		var err error
+		if key, err = protect.LoadKey(f.keyFile); err != nil {
+			return err
+		}
+	}
 
 	out.Println("Pulling agent", registryRef)
 
@@ -61,6 +78,17 @@ func (f *pullFlags) runPullCommand(cmd *cobra.Command, args []string) (commandEr
 		return fmt.Errorf("failed to get agent yaml: %w", err)
 	}
 
+	if key != nil {
+		metadata, err := store.GetArtifactMetadata(registryRef)
+		if err != nil {
+			return fmt.Errorf("failed to get artifact metadata: %w", err)
+		}
+		if err := key.VerifyAnnotations(metadata.Annotations, []byte(yamlFile)); err != nil {
+			return fmt.Errorf("verifying %s: %w", registryRef, err)
+		}
+		out.Printf("Verified %s\n", protectionSummary(metadata.Annotations))
+	}
+
 	agentName := strings.ReplaceAll(registryRef, "/", "_")
 	fileName := agentName + ".yaml"
 
@@ -71,4 +99,15 @@ func (f *pullFlags) runPullCommand(cmd *cobra.Command, args []string) (commandEr
 	out.Printf("Agent saved to %s\n", fileName)
 
 	return nil
+}
+
+func protectionSummary(annotations map[string]string) string {
+	var parts []string
+	if alg := annotations[protect.AnnotationSignatureAlgorithm]; alg != "" {
+		parts = append(parts, "signature ("+alg+")")
+	}
+	if alg := annotations[protect.AnnotationEncryptedAlgorithm]; alg != "" {
+		parts = append(parts, "encrypted copy ("+alg+")")
+	}
+	return strings.Join(parts, " and ")
 }

--- a/cmd/root/pull.go
+++ b/cmd/root/pull.go
@@ -84,10 +84,11 @@ func (f *pullFlags) runPullCommand(cmd *cobra.Command, args []string) (commandEr
 		if err != nil {
 			return fmt.Errorf("failed to get artifact metadata: %w", err)
 		}
-		if err := key.VerifyAnnotations(metadata.Annotations, []byte(yamlFile)); err != nil {
+		verified, err := key.VerifyAnnotations(metadata.Annotations, []byte(yamlFile))
+		if err != nil {
 			return fmt.Errorf("verifying %s: %w", registryRef, err)
 		}
-		out.Printf("Verified %s\n", protectionSummary(metadata.Annotations))
+		out.Printf("Verified %s\n", verified)
 	}
 
 	agentName := strings.ReplaceAll(registryRef, "/", "_")
@@ -100,15 +101,4 @@ func (f *pullFlags) runPullCommand(cmd *cobra.Command, args []string) (commandEr
 	out.Printf("Agent saved to %s\n", fileName)
 
 	return nil
-}
-
-func protectionSummary(annotations map[string]string) string {
-	var parts []string
-	if alg := annotations[protect.AnnotationSignatureAlgorithm]; alg != "" {
-		parts = append(parts, "signature ("+alg+")")
-	}
-	if alg := annotations[protect.AnnotationEncryptedAlgorithm]; alg != "" {
-		parts = append(parts, "encrypted copy ("+alg+")")
-	}
-	return strings.Join(parts, " and ")
 }

--- a/cmd/root/pull.go
+++ b/cmd/root/pull.go
@@ -31,8 +31,9 @@ func newPullCmd() *cobra.Command {
 With --key, the pulled agent YAML is verified against the protection recorded
 by 'share push --key': a signature is checked with the same secret or the
 matching public key; an encrypted copy (push --encrypt) is decrypted with the
-same secret or the matching private key and compared to the YAML. The pull
-fails if the artifact is unprotected or the check does not pass.`,
+same secret or the matching private key and compared to the YAML. With an
+asymmetric key the artifact must carry a signature. The pull fails if the
+artifact is unprotected or the check does not pass.`,
 		Args: cobra.ExactArgs(1),
 		RunE: flags.runPullCommand,
 	}

--- a/cmd/root/push.go
+++ b/cmd/root/push.go
@@ -33,7 +33,8 @@ With --key, the agent YAML is protected and the proof is stored as manifest
 annotations; the YAML itself is always pushed in clear. The key kind is
 detected from the file: PEM or OpenSSH keys (Ed25519, ECDSA, RSA) are
 asymmetric, anything else is a raw symmetric secret of at least 16 bytes
-(e.g. 'openssl rand -hex 32 > agent.key').
+(e.g. 'openssl rand -hex 32 > agent.key') that must not contain PEM or
+OpenSSH key markers.
 
   Default (sign):  a signature (private key) or MAC (secret) is recorded.
                    Holders of the public key or secret can check integrity

--- a/cmd/root/push.go
+++ b/cmd/root/push.go
@@ -31,24 +31,25 @@ func newPushCmd() *cobra.Command {
 
 With --key, the agent YAML is protected and the proof is stored as manifest
 annotations; the YAML itself is always pushed in clear. The key kind is
-detected from the file: PEM or OpenSSH keys are asymmetric, anything else is
-a raw symmetric secret.
+detected from the file: PEM or OpenSSH keys (Ed25519, ECDSA, RSA) are
+asymmetric, anything else is a raw symmetric secret of at least 16 bytes
+(e.g. 'openssl rand -hex 32 > agent.key').
 
   Default (sign):  a signature (private key) or MAC (secret) is recorded.
                    Holders of the public key or secret can check integrity
                    with 'share pull --key'.
-  --encrypt:       an encrypted copy of the whole YAML is recorded instead,
-                   encrypted with the secret or to the given public key.
-                   Holders of the secret or private key can check integrity
-                   and recover the YAML from the annotation alone.
-
-Signing needs Ed25519, ECDSA or RSA. Encrypting needs X25519, ECDSA or RSA.`,
+  --encrypt:       an encrypted copy of the whole YAML is recorded as well,
+                   so holders of the secret or private key can also recover
+                   the YAML from the annotation alone. With an asymmetric
+                   key this needs the private key and still records a
+                   signature, since a copy encrypted to a public key proves
+                   nothing about who published it. Ed25519 cannot encrypt.`,
 		Args: cobra.ExactArgs(2),
 		RunE: flags.runPushCommand,
 	}
 
 	cmd.Flags().StringVar(&flags.keyFile, "key", "", "Path to a key file (PEM/OpenSSH) or symmetric secret used to protect the agent")
-	cmd.Flags().BoolVar(&flags.encrypt, "encrypt", false, "Embed an encrypted copy of the agent instead of a signature (requires --key)")
+	cmd.Flags().BoolVar(&flags.encrypt, "encrypt", false, "Also embed an encrypted copy of the agent in the annotations (requires --key)")
 
 	return cmd
 }
@@ -68,11 +69,8 @@ func (f *pushFlags) protection() (oci.PackageOption, error) {
 	if f.encrypt {
 		mode = protect.ModeEncrypt
 	}
-	switch {
-	case mode == protect.ModeSign && !key.CanSign():
-		return nil, fmt.Errorf("%s (%s) cannot sign: use a private Ed25519/ECDSA/RSA key or a secret, or pass --encrypt", f.keyFile, key.Describe())
-	case mode == protect.ModeEncrypt && !key.CanEncrypt():
-		return nil, fmt.Errorf("%s (%s) cannot encrypt: use an X25519/ECDSA/RSA key or a secret", f.keyFile, key.Describe())
+	if err := key.Supports(mode); err != nil {
+		return nil, fmt.Errorf("%s: %w", f.keyFile, err)
 	}
 	return oci.WithProtection(key, mode), nil
 }

--- a/cmd/root/push.go
+++ b/cmd/root/push.go
@@ -1,6 +1,7 @@
 package root
 
 import (
+	"errors"
 	"fmt"
 	"log/slog"
 
@@ -10,21 +11,73 @@ import (
 	"github.com/docker/docker-agent/pkg/config"
 	"github.com/docker/docker-agent/pkg/content"
 	"github.com/docker/docker-agent/pkg/oci"
+	"github.com/docker/docker-agent/pkg/protect"
 	"github.com/docker/docker-agent/pkg/remote"
 	"github.com/docker/docker-agent/pkg/telemetry"
 )
 
-func newPushCmd() *cobra.Command {
-	return &cobra.Command{
-		Use:   "push <agent-file> <registry-ref>",
-		Short: "Push an agent to an OCI registry",
-		Long:  "Push an agent configuration file to an OCI registry",
-		Args:  cobra.ExactArgs(2),
-		RunE:  runPushCommand,
-	}
+type pushFlags struct {
+	keyFile string
+	encrypt bool
 }
 
-func runPushCommand(cmd *cobra.Command, args []string) (commandErr error) {
+func newPushCmd() *cobra.Command {
+	var flags pushFlags
+
+	cmd := &cobra.Command{
+		Use:   "push <agent-file> <registry-ref>",
+		Short: "Push an agent to an OCI registry",
+		Long: `Push an agent configuration file to an OCI registry.
+
+With --key, the agent YAML is protected and the proof is stored as manifest
+annotations; the YAML itself is always pushed in clear. The key kind is
+detected from the file: PEM or OpenSSH keys are asymmetric, anything else is
+a raw symmetric secret.
+
+  Default (sign):  a signature (private key) or MAC (secret) is recorded.
+                   Holders of the public key or secret can check integrity
+                   with 'share pull --key'.
+  --encrypt:       an encrypted copy of the whole YAML is recorded instead,
+                   encrypted with the secret or to the given public key.
+                   Holders of the secret or private key can check integrity
+                   and recover the YAML from the annotation alone.
+
+Signing needs Ed25519, ECDSA or RSA. Encrypting needs X25519, ECDSA or RSA.`,
+		Args: cobra.ExactArgs(2),
+		RunE: flags.runPushCommand,
+	}
+
+	cmd.Flags().StringVar(&flags.keyFile, "key", "", "Path to a key file (PEM/OpenSSH) or symmetric secret used to protect the agent")
+	cmd.Flags().BoolVar(&flags.encrypt, "encrypt", false, "Embed an encrypted copy of the agent instead of a signature (requires --key)")
+
+	return cmd
+}
+
+func (f *pushFlags) protection() (oci.PackageOption, error) {
+	if f.keyFile == "" {
+		if f.encrypt {
+			return nil, errors.New("--encrypt requires --key")
+		}
+		return nil, nil
+	}
+	key, err := protect.LoadKey(f.keyFile)
+	if err != nil {
+		return nil, err
+	}
+	mode := protect.ModeSign
+	if f.encrypt {
+		mode = protect.ModeEncrypt
+	}
+	switch {
+	case mode == protect.ModeSign && !key.CanSign():
+		return nil, fmt.Errorf("%s (%s) cannot sign: use a private Ed25519/ECDSA/RSA key or a secret, or pass --encrypt", f.keyFile, key.Describe())
+	case mode == protect.ModeEncrypt && !key.CanEncrypt():
+		return nil, fmt.Errorf("%s (%s) cannot encrypt: use an X25519/ECDSA/RSA key or a secret", f.keyFile, key.Describe())
+	}
+	return oci.WithProtection(key, mode), nil
+}
+
+func (f *pushFlags) runPushCommand(cmd *cobra.Command, args []string) (commandErr error) {
 	ctx := cmd.Context()
 	telemetry.TrackCommand(ctx, "share", append([]string{"push"}, args...))
 	defer func() { // do not inline this defer so that commandErr is not resolved early
@@ -34,6 +87,15 @@ func runPushCommand(cmd *cobra.Command, args []string) (commandErr error) {
 	agentFilename := args[0]
 	tag := args[1]
 	out := cli.NewPrinter(cmd.OutOrStdout())
+
+	var packageOpts []oci.PackageOption
+	protection, err := f.protection()
+	if err != nil {
+		return err
+	}
+	if protection != nil {
+		packageOpts = append(packageOpts, protection)
+	}
 
 	store, err := content.NewStore()
 	if err != nil {
@@ -45,12 +107,12 @@ func runPushCommand(cmd *cobra.Command, args []string) (commandErr error) {
 		return fmt.Errorf("resolving agent file: %w", err)
 	}
 
-	_, err = oci.PackageFileAsOCIToStore(ctx, agentSource, tag, store)
+	_, err = oci.PackageFileAsOCIToStore(ctx, agentSource, tag, store, packageOpts...)
 	if err != nil {
 		return fmt.Errorf("failed to build artifact: %w", err)
 	}
 
-	slog.DebugContext(ctx, "Starting push", "registry_ref", tag)
+	slog.DebugContext(ctx, "Starting push", "registry_ref", tag, "protected", protection != nil, "encrypt", f.encrypt)
 
 	out.Printf("Pushing agent %s to %s\n", agentFilename, tag)
 

--- a/cmd/root/push_test.go
+++ b/cmd/root/push_test.go
@@ -1,0 +1,72 @@
+package root
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/x509"
+	"encoding/pem"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/docker/docker-agent/pkg/protect"
+)
+
+func writeKey(t *testing.T, name string, data []byte) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), name)
+	require.NoError(t, os.WriteFile(path, data, 0o600))
+	return path
+}
+
+func TestPushFlags_Protection(t *testing.T) {
+	t.Parallel()
+
+	edPub, edPriv, err := ed25519.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+	privDER, err := x509.MarshalPKCS8PrivateKey(edPriv)
+	require.NoError(t, err)
+	pubDER, err := x509.MarshalPKIXPublicKey(edPub)
+	require.NoError(t, err)
+
+	secret := writeKey(t, "secret", []byte("a symmetric secret long enough\n"))
+	short := writeKey(t, "short", []byte("short"))
+	edPrivFile := writeKey(t, "ed25519", pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: privDER}))
+	edPubFile := writeKey(t, "ed25519.pub", pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: pubDER}))
+
+	tests := []struct {
+		name    string
+		flags   pushFlags
+		wantOpt bool
+		wantErr error
+		errMsg  string
+	}{
+		{name: "no key", flags: pushFlags{}},
+		{name: "encrypt without key", flags: pushFlags{encrypt: true}, errMsg: "--encrypt requires --key"},
+		{name: "missing key file", flags: pushFlags{keyFile: filepath.Join(t.TempDir(), "nope")}, errMsg: "reading key file"},
+		{name: "short secret", flags: pushFlags{keyFile: short}, wantErr: protect.ErrSecretTooShort},
+		{name: "secret sign", flags: pushFlags{keyFile: secret}, wantOpt: true},
+		{name: "secret encrypt", flags: pushFlags{keyFile: secret, encrypt: true}, wantOpt: true},
+		{name: "ed25519 sign", flags: pushFlags{keyFile: edPrivFile}, wantOpt: true},
+		{name: "ed25519 cannot encrypt", flags: pushFlags{keyFile: edPrivFile, encrypt: true}, wantErr: protect.ErrCannotEncrypt},
+		{name: "public key cannot sign", flags: pushFlags{keyFile: edPubFile}, wantErr: protect.ErrCannotSign},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			opt, err := tt.flags.protection()
+			switch {
+			case tt.wantErr != nil:
+				require.ErrorIs(t, err, tt.wantErr)
+			case tt.errMsg != "":
+				require.ErrorContains(t, err, tt.errMsg)
+			default:
+				require.NoError(t, err)
+			}
+			assert.Equal(t, tt.wantOpt, opt != nil)
+		})
+	}
+}

--- a/docs/concepts/distribution/index.md
+++ b/docs/concepts/distribution/index.md
@@ -63,7 +63,7 @@ The key kind is detected from the file contents:
 | PEM / OpenSSH public key (`.pub`)                          | asymmetric | ✗    | ✓      | ✗           |
 | Anything else: a raw **secret** of at least 16 bytes       | symmetric  | ✓    | ✓      | ✓           |
 
-Passphrase-protected keys are not supported. Malformed PEM or OpenSSH files are rejected rather than silently used as a secret. Symmetric secrets are compared offline against the public YAML by anyone guessing them, so use random material (`openssl rand -hex 32`), not a password.
+Passphrase-protected keys are not supported. Anything containing a PEM boundary (`-----BEGIN`) or an OpenSSH key type (`ssh-…`, `ecdsa-sha2-…`, `sk-…`) is treated as a key file and rejected if it does not parse — a broken public key is never silently used as a secret. Symmetric secrets can be guessed offline against the public YAML, so use random material (`openssl rand -hex 32`), not a password.
 
 ### Modes
 

--- a/docs/concepts/distribution/index.md
+++ b/docs/concepts/distribution/index.md
@@ -37,6 +37,49 @@ $ docker agent share pull docker.io/username/my-agent:latest
 $ docker agent share pull myorg/agent:tag
 ```
 
+## Signing and Encrypting Agents
+
+`share push --key <file>` protects the agent so that pullers holding the matching key can check it was published by you and has not been altered. The YAML is **always pushed in clear**; only the proof goes into the OCI manifest annotations. `share pull --key <file>` performs the check and refuses the artifact if it fails.
+
+```bash
+# Asymmetric: sign with a private key, verify with the public key
+$ docker agent share push ./agent.yaml myorg/agent:v1 --key ~/.ssh/id_ed25519
+$ docker agent share pull myorg/agent:v1 --key ~/.ssh/id_ed25519.pub
+
+# Symmetric: same secret on both sides
+$ openssl rand -hex 32 > agent.key
+$ docker agent share push ./agent.yaml myorg/agent:v1 --key agent.key
+$ docker agent share pull myorg/agent:v1 --key agent.key
+```
+
+### Key formats
+
+The key kind is detected from the file contents:
+
+| File contents                                              | Kind       | Sign | Verify | `--encrypt` |
+| ---------------------------------------------------------- | ---------- | ---- | ------ | ----------- |
+| PEM / OpenSSH **Ed25519** private key                      | asymmetric | ✓    | ✓      | ✗           |
+| PEM / OpenSSH **ECDSA** or **RSA** private key             | asymmetric | ✓    | ✓      | ✓           |
+| PEM / OpenSSH public key (`.pub`)                          | asymmetric | ✗    | ✓      | ✗           |
+| Anything else: a raw **secret** of at least 16 bytes       | symmetric  | ✓    | ✓      | ✓           |
+
+Passphrase-protected keys are not supported. Malformed PEM or OpenSSH files are rejected rather than silently used as a secret. Symmetric secrets are compared offline against the public YAML by anyone guessing them, so use random material (`openssl rand -hex 32`), not a password.
+
+### Modes
+
+- **Sign** (default): records a signature (private key) or an HMAC (secret) of the YAML. Anyone with the public key or secret can verify integrity and provenance.
+- **Encrypt** (`--encrypt`): additionally records an authenticated encrypted copy of the whole YAML. Holders of the secret or private key can recover the YAML from the annotation alone, without the layer. With an asymmetric key this requires the private key and a signature is still recorded — a copy encrypted to a public key could have been produced by anyone, so it proves nothing on its own.
+
+The pull side never needs to choose: the annotations describe what was recorded, and verification checks whatever is present. With an asymmetric key the artifact must carry a signature, which also prevents downgrading a signed artifact to an encrypted-only one.
+
+### Verifying when running
+
+Programs embedding Docker Agent can pass `config.WithVerificationKey(key)` to `config.Resolve` / `config.NewOCISource` so an OCI-sourced agent is verified on every read.
+
+### Limitations
+
+Signatures cover the YAML bytes only. Re-tagging a signed artifact, or serving an older signed version under the same tag, is not detected — pin digests (`myorg/agent@sha256:…`) when that matters.
+
 ## Running from a Registry
 
 Run agents directly from a registry without pulling first:

--- a/docs/concepts/distribution/index.md
+++ b/docs/concepts/distribution/index.md
@@ -63,7 +63,7 @@ The key kind is detected from the file contents:
 | PEM / OpenSSH public key (`.pub`)                          | asymmetric | ✗    | ✓      | ✗           |
 | Anything else: a raw **secret** of at least 16 bytes       | symmetric  | ✓    | ✓      | ✓           |
 
-Passphrase-protected keys are not supported. Anything containing a PEM boundary (`-----BEGIN`) or an OpenSSH key type (`ssh-…`, `ecdsa-sha2-…`, `sk-…`) is treated as a key file and rejected if it does not parse — a broken public key is never silently used as a secret. Symmetric secrets can be guessed offline against the public YAML, so use random material (`openssl rand -hex 32`), not a password.
+Passphrase-protected keys are not supported. Anything containing a PEM boundary (`-----BEGIN`) or an OpenSSH key-type marker (`ssh-`, `ecdsa-sha2-`, `sk-ssh-`, `sk-ecdsa-`) anywhere is treated as a key file and rejected if it does not parse — a broken public key is never silently used as a secret. Symmetric secrets can be guessed offline against the public YAML, so use random material (`openssl rand -hex 32`), not a password.
 
 ### Modes
 

--- a/docs/features/cli/index.md
+++ b/docs/features/cli/index.md
@@ -450,11 +450,19 @@ $ docker agent share pull docker.io/username/my-agent:latest
 
 # Force pull, overwriting the local copy
 $ docker agent share pull docker.io/username/my-agent:latest --force
+
+# Sign on push, verify on pull
+$ docker agent share push ./agent.yaml docker.io/username/my-agent:latest --key ~/.ssh/id_ed25519
+$ docker agent share pull docker.io/username/my-agent:latest --key ~/.ssh/id_ed25519.pub
 ```
 
-| Flag       | Applies to | Description                                                |
-| ---------- | ---------- | ---------------------------------------------------------- |
-| `--force`  | `pull`     | Force pull even if the configuration already exists locally |
+| Flag        | Applies to | Description                                                                          |
+| ----------- | ---------- | ------------------------------------------------------------------------------------ |
+| `--force`   | `pull`     | Force pull even if the configuration already exists locally                          |
+| `--key`     | both       | Key file used to sign/encrypt the agent on push, or verify it on pull                |
+| `--encrypt` | `push`     | Also embed an encrypted copy of the agent in the manifest annotations (needs `--key`) |
+
+See [Signing and encrypting agents](../../concepts/distribution/index.md#signing-and-encrypting-agents) for key formats and the security model.
 
 See [Agent Distribution](../../concepts/distribution/index.md) for full registry workflow details.
 

--- a/go.mod
+++ b/go.mod
@@ -85,6 +85,7 @@ require (
 	go.opentelemetry.io/otel/trace v1.46.0
 	go.opentelemetry.io/proto/otlp v1.11.0
 	go.yaml.in/yaml/v4 v4.0.0-rc.6
+	golang.org/x/crypto v0.55.0
 	golang.org/x/image v0.45.0
 	golang.org/x/net v0.58.0
 	golang.org/x/oauth2 v0.36.0
@@ -218,7 +219,6 @@ require (
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.46.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.40.0 // indirect
 	go.yaml.in/yaml/v3 v3.0.5 // indirect
-	golang.org/x/crypto v0.55.0 // indirect
 	golang.org/x/mod v0.39.0 // indirect
 	golang.org/x/text v0.41.0 // indirect
 	golang.org/x/time v0.15.0 // indirect

--- a/pkg/config/resolve.go
+++ b/pkg/config/resolve.go
@@ -59,13 +59,13 @@ func ResolveAlias(agentFilename string) *userconfig.Alias {
 // If envProvider is non-nil, it will be used to look up GITHUB_TOKEN for authentication
 // when fetching from GitHub URLs.
 // For OCI references, always checks remote for updates but falls back to local cache if offline.
-func ResolveSources(agentsPath string, envProvider environment.Provider) (Sources, error) {
+func ResolveSources(agentsPath string, envProvider environment.Provider, opts ...SourceOption) (Sources, error) {
 	resolvedPath, err := resolve(agentsPath)
 	if err != nil {
 		// resolve() only fails for non-OCI, non-URL, non-builtin references
 		// that can't be made absolute. Try OCI as last resort.
 		if IsOCIReference(agentsPath) {
-			return singleSource(reference.OciRefToFilename(agentsPath), NewOCISource(agentsPath)), nil
+			return singleSource(reference.OciRefToFilename(agentsPath), NewOCISource(agentsPath, opts...)), nil
 		}
 		return nil, err
 	}
@@ -76,7 +76,7 @@ func ResolveSources(agentsPath string, envProvider environment.Provider) (Source
 	}
 
 	// For all other reference types, delegate to resolveOne.
-	key, source := resolveOne(resolvedPath, envProvider)
+	key, source := resolveOne(resolvedPath, envProvider, opts...)
 	return singleSource(key, source), nil
 }
 
@@ -84,16 +84,16 @@ func ResolveSources(agentsPath string, envProvider environment.Provider) (Source
 // If envProvider is non-nil, it will be used to look up GITHUB_TOKEN for authentication
 // when fetching from GitHub URLs.
 // For OCI references, always checks remote for updates but falls back to local cache if offline.
-func Resolve(agentFilename string, envProvider environment.Provider) (Source, error) {
+func Resolve(agentFilename string, envProvider environment.Provider, opts ...SourceOption) (Source, error) {
 	resolvedPath, err := resolve(agentFilename)
 	if err != nil {
 		if IsOCIReference(agentFilename) {
-			return NewOCISource(agentFilename), nil
+			return NewOCISource(agentFilename, opts...), nil
 		}
 		return nil, err
 	}
 
-	_, source := resolveOne(resolvedPath, envProvider)
+	_, source := resolveOne(resolvedPath, envProvider, opts...)
 	return source, nil
 }
 
@@ -101,7 +101,7 @@ func Resolve(agentFilename string, envProvider environment.Provider) (Source, er
 // in Sources maps. The path must already be resolved via resolve().
 // This is the single place that decides which source type a reference maps to.
 // To add a new source type, add a case here.
-func resolveOne(resolvedPath string, envProvider environment.Provider) (string, Source) {
+func resolveOne(resolvedPath string, envProvider environment.Provider, opts ...SourceOption) (string, Source) {
 	switch {
 	case builtinAgents[resolvedPath] != nil:
 		return resolvedPath, NewBytesSource(resolvedPath, builtinAgents[resolvedPath])
@@ -111,7 +111,7 @@ func resolveOne(resolvedPath string, envProvider environment.Provider) (string, 
 	case isLocalFile(resolvedPath):
 		return fileNameWithoutExt(resolvedPath), NewFileSource(resolvedPath)
 	default:
-		return reference.OciRefToFilename(resolvedPath), NewOCISource(resolvedPath)
+		return reference.OciRefToFilename(resolvedPath), NewOCISource(resolvedPath, opts...)
 	}
 }
 

--- a/pkg/config/sources.go
+++ b/pkg/config/sources.go
@@ -299,7 +299,7 @@ func (a ociSource) loadArtifact(store *content.Store, storeKey string) ([]byte, 
 	if err != nil {
 		return nil, err
 	}
-	if err := a.verifyKey.VerifyAnnotations(meta.Annotations, data); err != nil {
+	if _, err := a.verifyKey.VerifyAnnotations(meta.Annotations, data); err != nil {
 		return nil, fmt.Errorf("verifying %s: %w", a.reference, err)
 	}
 	return data, nil

--- a/pkg/config/sources.go
+++ b/pkg/config/sources.go
@@ -22,6 +22,7 @@ import (
 	"github.com/docker/docker-agent/pkg/httpclient"
 	"github.com/docker/docker-agent/pkg/memoize"
 	"github.com/docker/docker-agent/pkg/paths"
+	"github.com/docker/docker-agent/pkg/protect"
 	"github.com/docker/docker-agent/pkg/remote"
 )
 
@@ -98,14 +99,39 @@ func (a bytesSource) Read(context.Context) ([]byte, error) {
 	return a.data, nil
 }
 
+// SourceOption customizes how a Source is built. Options that do not apply
+// to a given source type are ignored.
+type SourceOption func(*sourceOptions)
+
+type sourceOptions struct {
+	verifyKey *protect.Key
+}
+
+// WithVerificationKey makes OCI sources verify the artifact protection
+// (signature or encrypted copy recorded by `share push --key`) against key on
+// every read. Unprotected or tampered artifacts fail to load.
+func WithVerificationKey(key *protect.Key) SourceOption {
+	return func(o *sourceOptions) { o.verifyKey = key }
+}
+
+func applySourceOptions(opts []SourceOption) sourceOptions {
+	var o sourceOptions
+	for _, opt := range opts {
+		opt(&o)
+	}
+	return o
+}
+
 // ociSource is used to load an agent configuration from an OCI artifact.
 type ociSource struct {
 	reference string
+	verifyKey *protect.Key
 }
 
-func NewOCISource(reference string) Source {
+func NewOCISource(reference string, opts ...SourceOption) Source {
 	return ociSource{
 		reference: reference,
+		verifyKey: applySourceOptions(opts).verifyKey,
 	}
 }
 
@@ -167,6 +193,11 @@ func (a ociSource) Read(ctx context.Context) ([]byte, error) {
 	if err != nil {
 		return nil, fmt.Errorf("normalizing OCI reference %s: %w", a.reference, err)
 	}
+	// A verified read must never be served to a reader holding a different
+	// key (or none), so the key identity is part of the cache key.
+	if a.verifyKey != nil {
+		cacheKey += "#" + a.verifyKey.Fingerprint()
+	}
 
 	data, err := ociReadMemoizer.Memoize(cacheKey, func() ([]byte, error) {
 		data, degraded, err := a.read(ctx)
@@ -209,7 +240,7 @@ func (a ociSource) read(ctx context.Context) (data []byte, degraded bool, err er
 	// For digest references, the content is immutable. If we already have
 	// the artifact locally, serve it directly without any network call.
 	if remote.IsDigestReference(a.reference) {
-		if data, loadErr := loadArtifact(store, storeKey); loadErr == nil {
+		if data, loadErr := a.loadArtifact(store, storeKey); loadErr == nil {
 			slog.DebugContext(ctx, "Serving digest-pinned OCI artifact from cache", "ref", a.reference)
 			return data, false, nil
 		}
@@ -229,7 +260,7 @@ func (a ociSource) read(ctx context.Context) (data []byte, degraded bool, err er
 	}
 
 	// Try loading from store.
-	data, err = loadArtifact(store, storeKey)
+	data, err = a.loadArtifact(store, storeKey)
 	if err == nil {
 		return data, degraded, nil
 	}
@@ -244,20 +275,33 @@ func (a ociSource) read(ctx context.Context) (data []byte, degraded bool, err er
 		return nil, false, fmt.Errorf("failed to force re-pull OCI image %s: %w", a.reference, pullErr)
 	}
 
-	data, err = loadArtifact(store, storeKey)
+	data, err = a.loadArtifact(store, storeKey)
 	if err != nil {
 		return nil, false, fmt.Errorf("failed to load agent from OCI source %s: %w", a.reference, err)
 	}
 	return data, false, nil
 }
 
-// loadArtifact reads the agent YAML from the content store.
-func loadArtifact(store *content.Store, storeKey string) ([]byte, error) {
+// loadArtifact reads the agent YAML from the content store and, when a
+// verification key is set, checks it against the signature annotations.
+func (a ociSource) loadArtifact(store *content.Store, storeKey string) ([]byte, error) {
 	af, err := store.GetArtifact(storeKey)
 	if err != nil {
 		return nil, err
 	}
-	return []byte(af), nil
+	data := []byte(af)
+	if a.verifyKey == nil {
+		return data, nil
+	}
+
+	meta, err := store.GetArtifactMetadata(storeKey)
+	if err != nil {
+		return nil, err
+	}
+	if err := a.verifyKey.VerifyAnnotations(meta.Annotations, data); err != nil {
+		return nil, fmt.Errorf("verifying %s: %w", a.reference, err)
+	}
+	return data, nil
 }
 
 // hasLocalArtifact reports whether the content store has metadata for the given key.

--- a/pkg/config/sources.go
+++ b/pkg/config/sources.go
@@ -194,9 +194,10 @@ func (a ociSource) Read(ctx context.Context) ([]byte, error) {
 		return nil, fmt.Errorf("normalizing OCI reference %s: %w", a.reference, err)
 	}
 	// A verified read must never be served to a reader holding a different
-	// key (or none), so the key identity is part of the cache key.
+	// key (or none, or only the public half), so the key identity is part of
+	// the cache key.
 	if a.verifyKey != nil {
-		cacheKey += "#" + a.verifyKey.Fingerprint()
+		cacheKey += "#" + a.verifyKey.Identity()
 	}
 
 	data, err := ociReadMemoizer.Memoize(cacheKey, func() ([]byte, error) {

--- a/pkg/config/sources_test.go
+++ b/pkg/config/sources_test.go
@@ -2,6 +2,12 @@ package config
 
 import (
 	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/pem"
 	"errors"
 	"net/http"
 	"net/http/httptest"
@@ -259,12 +265,20 @@ func TestOCISource_Read_DoesNotCacheDegradedFallback(t *testing.T) {
 func storeProtectedTestArtifact(t *testing.T, ref string, data []byte, key *protect.Key, mode protect.Mode) {
 	t.Helper()
 
+	annotations := map[string]string{}
+	require.NoError(t, key.Protect(annotations, data, mode))
+	storeTestArtifactWithAnnotations(t, ref, data, annotations)
+}
+
+// storeTestArtifactWithAnnotations is like storeTestArtifact with extra
+// manifest annotations.
+func storeTestArtifactWithAnnotations(t *testing.T, ref string, data []byte, annotations map[string]string) {
+	t.Helper()
+
 	store, err := content.NewStore()
 	require.NoError(t, err)
 
-	annotations := map[string]string{"io.docker.agent.version": "test"}
-	require.NoError(t, key.Protect(annotations, data, mode))
-
+	annotations["io.docker.agent.version"] = "test"
 	layer := static.NewLayer(data, "application/yaml")
 	img, err := mutate.AppendLayers(empty.Image, layer)
 	require.NoError(t, err)
@@ -283,9 +297,9 @@ func TestOCISource_Read_VerifiesProtection(t *testing.T) {
 	resetOCIMemoizer(t)
 	stubOCIPull(t, func(context.Context, string, bool) (string, error) { return "", nil })
 
-	key, err := protect.ParseKey([]byte("shared-secret"))
+	key, err := protect.ParseKey([]byte("a shared secret long enough"))
 	require.NoError(t, err)
-	wrongKey, err := protect.ParseKey([]byte("wrong-secret"))
+	wrongKey, err := protect.ParseKey([]byte("a wrong secret long enough"))
 	require.NoError(t, err)
 
 	testData := []byte("version: v1\nname: signed-agent")
@@ -327,6 +341,54 @@ func TestOCISource_Read_VerifiesProtection(t *testing.T) {
 	require.NoError(t, err)
 	_, err = source.Read(t.Context())
 	require.ErrorIs(t, err, protect.ErrInvalidSignature)
+}
+
+// Not parallel: stubs the package-level pullOCIArtifact and re-homes the
+// default content store via t.Setenv.
+func TestOCISource_Read_CacheDistinguishesPrivateAndPublicKey(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	resetOCIMemoizer(t)
+	stubOCIPull(t, func(context.Context, string, bool) (string, error) { return "", nil })
+
+	ecPriv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	privDER, err := x509.MarshalPKCS8PrivateKey(ecPriv)
+	require.NoError(t, err)
+	pubDER, err := x509.MarshalPKIXPublicKey(&ecPriv.PublicKey)
+	require.NoError(t, err)
+	priv, err := protect.ParseKey(pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: privDER}))
+	require.NoError(t, err)
+	pub, err := protect.ParseKey(pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: pubDER}))
+	require.NoError(t, err)
+
+	// An artifact whose only protection is an encrypted copy (no signature),
+	// as an attacker holding the public key could produce.
+	testData := []byte("version: v1\nname: unsigned-encrypted")
+	ref := "test-halves/agent:latest"
+	blob, err := pub.Encrypt(testData)
+	require.NoError(t, err)
+	storeTestArtifactWithAnnotations(t, ref, testData, map[string]string{
+		protect.AnnotationEncrypted:          base64.StdEncoding.EncodeToString(blob),
+		protect.AnnotationEncryptedAlgorithm: pub.EncryptAlgorithm(),
+	})
+
+	// Neither half accepts it, and a read with one half must not prime the
+	// cache for the other.
+	_, err = NewOCISource(ref, WithVerificationKey(priv)).Read(t.Context())
+	require.ErrorIs(t, err, protect.ErrNotSigned)
+	_, err = NewOCISource(ref, WithVerificationKey(pub)).Read(t.Context())
+	require.ErrorIs(t, err, protect.ErrNotSigned)
+
+	// A properly published (sign+encrypt) artifact verifies with both halves.
+	signedRef := "test-halves/signed:latest"
+	storeProtectedTestArtifact(t, signedRef, testData, priv, protect.ModeEncrypt)
+	for _, key := range []*protect.Key{priv, pub, priv} {
+		data, err := NewOCISource(signedRef, WithVerificationKey(key)).Read(t.Context())
+		require.NoError(t, err)
+		assert.Equal(t, testData, data)
+	}
 }
 
 func TestURLSource_Read(t *testing.T) {

--- a/pkg/config/sources_test.go
+++ b/pkg/config/sources_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/docker/docker-agent/pkg/content"
 	"github.com/docker/docker-agent/pkg/environment"
 	"github.com/docker/docker-agent/pkg/memoize"
+	"github.com/docker/docker-agent/pkg/protect"
 	"github.com/docker/docker-agent/pkg/remote"
 )
 
@@ -251,6 +252,81 @@ func TestOCISource_Read_DoesNotCacheDegradedFallback(t *testing.T) {
 		assert.Equal(t, testData, data)
 	}
 	assert.Equal(t, int32(3), pulls.Load(), "a validated read must be cached again")
+}
+
+// storeProtectedTestArtifact is like storeTestArtifact but adds protection
+// annotations produced by key in the given mode.
+func storeProtectedTestArtifact(t *testing.T, ref string, data []byte, key *protect.Key, mode protect.Mode) {
+	t.Helper()
+
+	store, err := content.NewStore()
+	require.NoError(t, err)
+
+	annotations := map[string]string{"io.docker.agent.version": "test"}
+	require.NoError(t, key.Protect(annotations, data, mode))
+
+	layer := static.NewLayer(data, "application/yaml")
+	img, err := mutate.AppendLayers(empty.Image, layer)
+	require.NoError(t, err)
+	img = mutate.Annotations(img, annotations).(v1.Image)
+
+	_, err = store.StoreArtifact(img, ref)
+	require.NoError(t, err)
+}
+
+// Not parallel: stubs the package-level pullOCIArtifact and re-homes the
+// default content store via t.Setenv.
+func TestOCISource_Read_VerifiesProtection(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	resetOCIMemoizer(t)
+	stubOCIPull(t, func(context.Context, string, bool) (string, error) { return "", nil })
+
+	key, err := protect.ParseKey([]byte("shared-secret"))
+	require.NoError(t, err)
+	wrongKey, err := protect.ParseKey([]byte("wrong-secret"))
+	require.NoError(t, err)
+
+	testData := []byte("version: v1\nname: signed-agent")
+	signedRef := "test-signed/agent:latest"
+	storeProtectedTestArtifact(t, signedRef, testData, key, protect.ModeSign)
+	encryptedRef := "test-encrypted/agent:latest"
+	storeProtectedTestArtifact(t, encryptedRef, testData, key, protect.ModeEncrypt)
+	unsignedRef := "test-unsigned/agent:latest"
+	storeTestArtifact(t, unsignedRef, testData)
+
+	// Matching key: verified read succeeds.
+	data, err := NewOCISource(signedRef, WithVerificationKey(key)).Read(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, testData, data)
+
+	// Wrong key: rejected, even though a verified read was just cached under
+	// the other key.
+	_, err = NewOCISource(signedRef, WithVerificationKey(wrongKey)).Read(t.Context())
+	require.ErrorIs(t, err, protect.ErrInvalidSignature)
+
+	// No key: signature is ignored.
+	data, err = NewOCISource(signedRef).Read(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, testData, data)
+
+	// Encrypted mode: verified by decrypting and comparing to the layer.
+	data, err = NewOCISource(encryptedRef, WithVerificationKey(key)).Read(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, testData, data)
+	_, err = NewOCISource(encryptedRef, WithVerificationKey(wrongKey)).Read(t.Context())
+	require.ErrorIs(t, err, protect.ErrDecryption)
+
+	// Key given but artifact unprotected: rejected.
+	_, err = NewOCISource(unsignedRef, WithVerificationKey(key)).Read(t.Context())
+	require.ErrorIs(t, err, protect.ErrNotProtected)
+
+	// Resolve threads the option through to the OCI source.
+	source, err := Resolve(signedRef, nil, WithVerificationKey(wrongKey))
+	require.NoError(t, err)
+	_, err = source.Read(t.Context())
+	require.ErrorIs(t, err, protect.ErrInvalidSignature)
 }
 
 func TestURLSource_Read(t *testing.T) {

--- a/pkg/config/sources_test.go
+++ b/pkg/config/sources_test.go
@@ -363,32 +363,25 @@ func TestOCISource_Read_CacheDistinguishesPrivateAndPublicKey(t *testing.T) {
 	pub, err := protect.ParseKey(pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: pubDER}))
 	require.NoError(t, err)
 
-	// An artifact whose only protection is an encrypted copy (no signature),
-	// as an attacker holding the public key could produce.
-	testData := []byte("version: v1\nname: unsigned-encrypted")
-	ref := "test-halves/agent:latest"
-	blob, err := pub.Encrypt(testData)
+	// A correctly signed artifact whose encrypted copy was swapped for an
+	// encryption of different content. The public key can only check the
+	// signature and accepts it; the private key decrypts and must reject it.
+	testData := []byte("version: v1\nname: swapped-copy")
+	annotations := map[string]string{}
+	require.NoError(t, priv.Protect(annotations, testData, protect.ModeEncrypt))
+	forged, err := pub.Encrypt([]byte("something else"))
 	require.NoError(t, err)
-	storeTestArtifactWithAnnotations(t, ref, testData, map[string]string{
-		protect.AnnotationEncrypted:          base64.StdEncoding.EncodeToString(blob),
-		protect.AnnotationEncryptedAlgorithm: pub.EncryptAlgorithm(),
-	})
+	annotations[protect.AnnotationEncrypted] = base64.StdEncoding.EncodeToString(forged)
+	ref := "test-halves/agent:latest"
+	storeTestArtifactWithAnnotations(t, ref, testData, annotations)
 
-	// Neither half accepts it, and a read with one half must not prime the
-	// cache for the other.
+	data, err := NewOCISource(ref, WithVerificationKey(pub)).Read(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, testData, data)
+
+	// The public-key success above must not be served to the private key.
 	_, err = NewOCISource(ref, WithVerificationKey(priv)).Read(t.Context())
-	require.ErrorIs(t, err, protect.ErrNotSigned)
-	_, err = NewOCISource(ref, WithVerificationKey(pub)).Read(t.Context())
-	require.ErrorIs(t, err, protect.ErrNotSigned)
-
-	// A properly published (sign+encrypt) artifact verifies with both halves.
-	signedRef := "test-halves/signed:latest"
-	storeProtectedTestArtifact(t, signedRef, testData, priv, protect.ModeEncrypt)
-	for _, key := range []*protect.Key{priv, pub, priv} {
-		data, err := NewOCISource(signedRef, WithVerificationKey(key)).Read(t.Context())
-		require.NoError(t, err)
-		assert.Equal(t, testData, data)
-	}
+	require.ErrorIs(t, err, protect.ErrTampered)
 }
 
 func TestURLSource_Read(t *testing.T) {

--- a/pkg/oci/package.go
+++ b/pkg/oci/package.go
@@ -18,11 +18,31 @@ import (
 	"github.com/docker/docker-agent/pkg/config"
 	"github.com/docker/docker-agent/pkg/config/latest"
 	"github.com/docker/docker-agent/pkg/content"
+	"github.com/docker/docker-agent/pkg/protect"
 	"github.com/docker/docker-agent/pkg/version"
 )
 
+type packageOptions struct {
+	key  *protect.Key
+	mode protect.Mode
+}
+
+type PackageOption func(*packageOptions)
+
+// WithProtection signs (ModeSign) or embeds an encrypted copy of (ModeEncrypt)
+// the packaged YAML in the manifest annotations, so holders of the matching
+// key can verify the artifact.
+func WithProtection(key *protect.Key, mode protect.Mode) PackageOption {
+	return func(o *packageOptions) { o.key, o.mode = key, mode }
+}
+
 // PackageFileAsOCIToStore creates an OCI artifact from a file and stores it in the content store
-func PackageFileAsOCIToStore(ctx context.Context, agentSource config.Source, artifactRef string, store *content.Store) (string, error) {
+func PackageFileAsOCIToStore(ctx context.Context, agentSource config.Source, artifactRef string, store *content.Store, opts ...PackageOption) (string, error) {
+	var o packageOptions
+	for _, opt := range opts {
+		opt(&o)
+	}
+
 	if !strings.Contains(artifactRef, ":") {
 		artifactRef += ":latest"
 	}
@@ -78,6 +98,11 @@ func PackageFileAsOCIToStore(ctx context.Context, agentSource config.Source, art
 	}
 	if len(cfg.Metadata.Tags) > 0 {
 		annotations["io.docker.agent.tags"] = strings.Join(cfg.Metadata.Tags, ",")
+	}
+	if o.key != nil {
+		if err := o.key.Protect(annotations, data, o.mode); err != nil {
+			return "", fmt.Errorf("protecting config: %w", err)
+		}
 	}
 
 	layer := static.NewLayer(data, "application/yaml")

--- a/pkg/oci/package_test.go
+++ b/pkg/oci/package_test.go
@@ -1,6 +1,7 @@
 package oci
 
 import (
+	"bytes"
 	"io"
 	"os"
 	"path/filepath"
@@ -11,6 +12,7 @@ import (
 
 	"github.com/docker/docker-agent/pkg/config"
 	"github.com/docker/docker-agent/pkg/content"
+	"github.com/docker/docker-agent/pkg/protect"
 )
 
 func TestPackageFileAsOCIToStore(t *testing.T) {
@@ -206,4 +208,74 @@ agents:
 	assert.Contains(t, string(data), "api_type:")
 	assert.Contains(t, string(data), "base_url:")
 	assert.Contains(t, string(data), "token_key:")
+}
+
+func TestPackageFileAsOCIToStore_WithProtection(t *testing.T) {
+	t.Parallel()
+
+	key, err := protect.ParseKey([]byte("shared-secret"))
+	require.NoError(t, err)
+	other, err := protect.ParseKey([]byte("other-secret"))
+	require.NoError(t, err)
+
+	for _, mode := range []protect.Mode{protect.ModeSign, protect.ModeEncrypt} {
+		t.Run(string(mode), func(t *testing.T) {
+			t.Parallel()
+			agentFilename := filepath.Join(t.TempDir(), "protected.yaml")
+			testContent := `version: "2"
+agents:
+  root:
+    model: auto
+    description: A protected assistant
+`
+			require.NoError(t, os.WriteFile(agentFilename, []byte(testContent), 0o644))
+			store, err := content.NewStore(content.WithBaseDir(t.TempDir()))
+			require.NoError(t, err)
+
+			agentSource, err := config.Resolve(agentFilename, nil)
+			require.NoError(t, err)
+
+			tag := "test-protected:" + string(mode)
+			digest, err := PackageFileAsOCIToStore(t.Context(), agentSource, tag, store, WithProtection(key, mode))
+			require.NoError(t, err)
+			t.Cleanup(func() { _ = store.DeleteArtifact(digest) })
+
+			metadata, err := store.GetArtifactMetadata(tag)
+			require.NoError(t, err)
+			assert.True(t, protect.IsProtected(metadata.Annotations))
+
+			// The protection covers the exact bytes stored in the layer.
+			yamlData, err := store.GetArtifact(tag)
+			require.NoError(t, err)
+			require.NoError(t, key.VerifyAnnotations(metadata.Annotations, []byte(yamlData)))
+			require.Error(t, other.VerifyAnnotations(metadata.Annotations, []byte(yamlData)))
+
+			if mode == protect.ModeEncrypt {
+				// The clear YAML is recoverable, byte-for-byte, from the annotations alone.
+				recovered, err := key.Recover(metadata.Annotations)
+				require.NoError(t, err)
+				assert.True(t, bytes.Equal([]byte(yamlData), recovered))
+			}
+		})
+	}
+}
+
+func TestPackageFileAsOCIToStore_WithoutProtectionHasNoAnnotations(t *testing.T) {
+	t.Parallel()
+	agentFilename := filepath.Join(t.TempDir(), "unsigned.yaml")
+	require.NoError(t, os.WriteFile(agentFilename, []byte("version: \"2\"\nagents:\n  root:\n    model: auto\n"), 0o644))
+	store, err := content.NewStore(content.WithBaseDir(t.TempDir()))
+	require.NoError(t, err)
+
+	agentSource, err := config.Resolve(agentFilename, nil)
+	require.NoError(t, err)
+
+	tag := "test-unsigned:v1"
+	digest, err := PackageFileAsOCIToStore(t.Context(), agentSource, tag, store)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = store.DeleteArtifact(digest) })
+
+	metadata, err := store.GetArtifactMetadata(tag)
+	require.NoError(t, err)
+	assert.False(t, protect.IsProtected(metadata.Annotations))
 }

--- a/pkg/oci/package_test.go
+++ b/pkg/oci/package_test.go
@@ -247,8 +247,10 @@ agents:
 			// The protection covers the exact bytes stored in the layer.
 			yamlData, err := store.GetArtifact(tag)
 			require.NoError(t, err)
-			require.NoError(t, key.VerifyAnnotations(metadata.Annotations, []byte(yamlData)))
-			require.Error(t, other.VerifyAnnotations(metadata.Annotations, []byte(yamlData)))
+			_, err = key.VerifyAnnotations(metadata.Annotations, []byte(yamlData))
+			require.NoError(t, err)
+			_, err = other.VerifyAnnotations(metadata.Annotations, []byte(yamlData))
+			require.Error(t, err)
 
 			if mode == protect.ModeEncrypt {
 				// The clear YAML is recoverable, byte-for-byte, from the annotations alone.

--- a/pkg/oci/package_test.go
+++ b/pkg/oci/package_test.go
@@ -213,9 +213,9 @@ agents:
 func TestPackageFileAsOCIToStore_WithProtection(t *testing.T) {
 	t.Parallel()
 
-	key, err := protect.ParseKey([]byte("shared-secret"))
+	key, err := protect.ParseKey([]byte("a shared secret long enough"))
 	require.NoError(t, err)
-	other, err := protect.ParseKey([]byte("other-secret"))
+	other, err := protect.ParseKey([]byte("an other secret long enough"))
 	require.NoError(t, err)
 
 	for _, mode := range []protect.Mode{protect.ModeSign, protect.ModeEncrypt} {

--- a/pkg/protect/annotations.go
+++ b/pkg/protect/annotations.go
@@ -1,0 +1,133 @@
+package protect
+
+import (
+	"crypto/subtle"
+	"encoding/base64"
+	"errors"
+	"fmt"
+)
+
+const (
+	// AnnotationSignature holds the base64 signature (or MAC) of the YAML layer.
+	AnnotationSignature = "io.docker.agent.signature"
+	// AnnotationSignatureAlgorithm names the algorithm behind AnnotationSignature.
+	AnnotationSignatureAlgorithm = "io.docker.agent.signature.algorithm"
+	// AnnotationEncrypted holds a base64 authenticated-encrypted copy of the
+	// whole YAML layer.
+	AnnotationEncrypted = "io.docker.agent.encrypted"
+	// AnnotationEncryptedAlgorithm names the algorithm behind AnnotationEncrypted.
+	AnnotationEncryptedAlgorithm = "io.docker.agent.encrypted.algorithm"
+)
+
+var (
+	ErrNotProtected  = errors.New("artifact is neither signed nor encrypted")
+	ErrNotEncrypted  = errors.New("artifact has no encrypted copy")
+	ErrTampered      = errors.New("encrypted copy does not match the artifact content")
+	ErrAlgorithmMism = errors.New("algorithm mismatch")
+)
+
+// Mode selects what the publisher records in the annotations.
+type Mode string
+
+const (
+	// ModeSign records a signature (asymmetric key) or MAC (secret).
+	// Holders of the matching public key or secret can verify integrity.
+	ModeSign Mode = "sign"
+	// ModeEncrypt records an encrypted copy of the whole YAML. Holders of the
+	// secret or private key can both verify integrity and recover the YAML
+	// from the annotation alone.
+	ModeEncrypt Mode = "encrypt"
+)
+
+// Protect records the protection for data in annotations according to mode.
+func (k *Key) Protect(annotations map[string]string, data []byte, mode Mode) error {
+	switch mode {
+	case ModeSign:
+		if !k.CanSign() {
+			return fmt.Errorf("%w (%s)", ErrCannotSign, k.Describe())
+		}
+		sig, err := k.Sign(data)
+		if err != nil {
+			return err
+		}
+		annotations[AnnotationSignature] = base64.StdEncoding.EncodeToString(sig)
+		annotations[AnnotationSignatureAlgorithm] = k.SignAlgorithm()
+		return nil
+	case ModeEncrypt:
+		if !k.CanEncrypt() {
+			return fmt.Errorf("%w (%s)", ErrCannotEncrypt, k.Describe())
+		}
+		blob, err := k.Encrypt(data)
+		if err != nil {
+			return err
+		}
+		annotations[AnnotationEncrypted] = base64.StdEncoding.EncodeToString(blob)
+		annotations[AnnotationEncryptedAlgorithm] = k.EncryptAlgorithm()
+		return nil
+	default:
+		return fmt.Errorf("unknown protection mode %q", mode)
+	}
+}
+
+// IsProtected reports whether annotations carry a signature or encrypted copy.
+func IsProtected(annotations map[string]string) bool {
+	return annotations[AnnotationSignature] != "" || annotations[AnnotationEncrypted] != ""
+}
+
+// VerifyAnnotations checks data against whatever protection annotations carry:
+// the signature is verified, and the encrypted copy is decrypted and compared
+// to data. ErrNotProtected is returned when neither is present.
+func (k *Key) VerifyAnnotations(annotations map[string]string, data []byte) error {
+	if !IsProtected(annotations) {
+		return ErrNotProtected
+	}
+	if annotations[AnnotationSignature] != "" {
+		if err := k.verifySignature(annotations, data); err != nil {
+			return err
+		}
+	}
+	if annotations[AnnotationEncrypted] != "" {
+		plain, err := k.Recover(annotations)
+		if err != nil {
+			return err
+		}
+		if subtle.ConstantTimeCompare(plain, data) != 1 {
+			return ErrTampered
+		}
+	}
+	return nil
+}
+
+func (k *Key) verifySignature(annotations map[string]string, data []byte) error {
+	if !k.CanVerify() {
+		return fmt.Errorf("%w: %s cannot verify signatures", ErrInvalidSignature, k.Describe())
+	}
+	if alg := annotations[AnnotationSignatureAlgorithm]; alg != k.SignAlgorithm() {
+		return fmt.Errorf("%w: artifact signed with %q but key supports %q", ErrAlgorithmMism, alg, k.SignAlgorithm())
+	}
+	sig, err := base64.StdEncoding.DecodeString(annotations[AnnotationSignature])
+	if err != nil {
+		return fmt.Errorf("%w: malformed signature annotation: %w", ErrInvalidSignature, err)
+	}
+	return k.Verify(data, sig)
+}
+
+// Recover decrypts the encrypted copy carried in annotations, returning the
+// clear YAML. It works from the annotations alone, without the layer.
+func (k *Key) Recover(annotations map[string]string) ([]byte, error) {
+	encoded := annotations[AnnotationEncrypted]
+	if encoded == "" {
+		return nil, ErrNotEncrypted
+	}
+	if !k.CanDecrypt() {
+		return nil, fmt.Errorf("%w (%s)", ErrCannotDecrypt, k.Describe())
+	}
+	if alg := annotations[AnnotationEncryptedAlgorithm]; alg != k.EncryptAlgorithm() {
+		return nil, fmt.Errorf("%w: artifact encrypted with %q but key supports %q", ErrAlgorithmMism, alg, k.EncryptAlgorithm())
+	}
+	blob, err := base64.StdEncoding.DecodeString(encoded)
+	if err != nil {
+		return nil, fmt.Errorf("%w: malformed encrypted annotation: %w", ErrDecryption, err)
+	}
+	return k.Decrypt(blob)
+}

--- a/pkg/protect/annotations.go
+++ b/pkg/protect/annotations.go
@@ -20,10 +20,12 @@ const (
 )
 
 var (
-	ErrNotProtected  = errors.New("artifact is neither signed nor encrypted")
-	ErrNotEncrypted  = errors.New("artifact has no encrypted copy")
-	ErrTampered      = errors.New("encrypted copy does not match the artifact content")
-	ErrAlgorithmMism = errors.New("algorithm mismatch")
+	ErrNotProtected     = errors.New("artifact is neither signed nor encrypted")
+	ErrNotEncrypted     = errors.New("artifact has no encrypted copy")
+	ErrNotSigned        = errors.New("artifact is not signed: an encrypted copy alone does not prove who published it when the key is asymmetric")
+	ErrTampered         = errors.New("encrypted copy does not match the artifact content")
+	ErrAlgorithmMism    = errors.New("algorithm mismatch")
+	ErrEncryptNeedsPriv = errors.New("encrypt mode with an asymmetric key requires the private key, so the artifact can also be signed")
 )
 
 // Mode selects what the publisher records in the annotations.
@@ -35,38 +37,61 @@ const (
 	ModeSign Mode = "sign"
 	// ModeEncrypt records an encrypted copy of the whole YAML. Holders of the
 	// secret or private key can both verify integrity and recover the YAML
-	// from the annotation alone.
+	// from the annotation alone. With an asymmetric key a signature is
+	// recorded as well (see the package security model).
 	ModeEncrypt Mode = "encrypt"
 )
 
-// Protect records the protection for data in annotations according to mode.
-func (k *Key) Protect(annotations map[string]string, data []byte, mode Mode) error {
+// Supports reports whether the key can publish in mode, with a descriptive
+// error when it cannot.
+func (k *Key) Supports(mode Mode) error {
 	switch mode {
 	case ModeSign:
 		if !k.CanSign() {
 			return fmt.Errorf("%w (%s)", ErrCannotSign, k.Describe())
 		}
-		sig, err := k.Sign(data)
-		if err != nil {
-			return err
-		}
-		annotations[AnnotationSignature] = base64.StdEncoding.EncodeToString(sig)
-		annotations[AnnotationSignatureAlgorithm] = k.SignAlgorithm()
-		return nil
 	case ModeEncrypt:
 		if !k.CanEncrypt() {
 			return fmt.Errorf("%w (%s)", ErrCannotEncrypt, k.Describe())
 		}
+		if !k.Symmetric() && !k.CanSign() {
+			return fmt.Errorf("%w (%s)", ErrEncryptNeedsPriv, k.Describe())
+		}
+	default:
+		return fmt.Errorf("unknown protection mode %q", mode)
+	}
+	return nil
+}
+
+// Protect records the protection for data in annotations according to mode.
+func (k *Key) Protect(annotations map[string]string, data []byte, mode Mode) error {
+	if err := k.Supports(mode); err != nil {
+		return err
+	}
+	if mode == ModeSign || !k.Symmetric() {
+		if err := k.sign(annotations, data); err != nil {
+			return err
+		}
+	}
+	if mode == ModeEncrypt {
 		blob, err := k.Encrypt(data)
 		if err != nil {
 			return err
 		}
 		annotations[AnnotationEncrypted] = base64.StdEncoding.EncodeToString(blob)
 		annotations[AnnotationEncryptedAlgorithm] = k.EncryptAlgorithm()
-		return nil
-	default:
-		return fmt.Errorf("unknown protection mode %q", mode)
 	}
+	return nil
+}
+
+func (k *Key) sign(annotations map[string]string, data []byte) error {
+	sig, err := k.Sign(data)
+	if err != nil {
+		return err
+	}
+	annotations[AnnotationSignature] = base64.StdEncoding.EncodeToString(sig)
+	annotations[AnnotationSignatureAlgorithm] = k.SignAlgorithm()
+	return nil
 }
 
 // IsProtected reports whether annotations carry a signature or encrypted copy.
@@ -74,19 +99,35 @@ func IsProtected(annotations map[string]string) bool {
 	return annotations[AnnotationSignature] != "" || annotations[AnnotationEncrypted] != ""
 }
 
-// VerifyAnnotations checks data against whatever protection annotations carry:
-// the signature is verified, and the encrypted copy is decrypted and compared
-// to data. ErrNotProtected is returned when neither is present.
+// VerifyAnnotations checks that data is what a holder of this key published,
+// using the protection annotations carry.
+//
+// A signature, when present, is always verified. An encrypted copy is
+// decrypted and compared to data when the key can decrypt; when it cannot,
+// the signature must have been verified instead. With an asymmetric key a
+// signature is mandatory, since anyone holding the public key could have
+// produced the encrypted copy. ErrNotProtected is returned when the artifact
+// carries no protection at all.
 func (k *Key) VerifyAnnotations(annotations map[string]string, data []byte) error {
-	if !IsProtected(annotations) {
+	signed := annotations[AnnotationSignature] != ""
+	encrypted := annotations[AnnotationEncrypted] != ""
+	if !signed && !encrypted {
 		return ErrNotProtected
 	}
-	if annotations[AnnotationSignature] != "" {
+	if !signed && !k.Symmetric() {
+		return ErrNotSigned
+	}
+
+	if signed {
 		if err := k.verifySignature(annotations, data); err != nil {
 			return err
 		}
 	}
-	if annotations[AnnotationEncrypted] != "" {
+	if encrypted {
+		if !k.CanDecrypt() {
+			// Signature verified above; the copy is for holders of the private key.
+			return nil
+		}
 		plain, err := k.Recover(annotations)
 		if err != nil {
 			return err
@@ -100,7 +141,7 @@ func (k *Key) VerifyAnnotations(annotations map[string]string, data []byte) erro
 
 func (k *Key) verifySignature(annotations map[string]string, data []byte) error {
 	if !k.CanVerify() {
-		return fmt.Errorf("%w: %s cannot verify signatures", ErrInvalidSignature, k.Describe())
+		return fmt.Errorf("%w (%s)", ErrCannotVerify, k.Describe())
 	}
 	if alg := annotations[AnnotationSignatureAlgorithm]; alg != k.SignAlgorithm() {
 		return fmt.Errorf("%w: artifact signed with %q but key supports %q", ErrAlgorithmMism, alg, k.SignAlgorithm())
@@ -113,7 +154,8 @@ func (k *Key) verifySignature(annotations map[string]string, data []byte) error 
 }
 
 // Recover decrypts the encrypted copy carried in annotations, returning the
-// clear YAML. It works from the annotations alone, without the layer.
+// clear YAML. It works from the annotations alone, without the layer. Note
+// that it does not check the signature; use VerifyAnnotations for that.
 func (k *Key) Recover(annotations map[string]string) ([]byte, error) {
 	encoded := annotations[AnnotationEncrypted]
 	if encoded == "" {

--- a/pkg/protect/annotations.go
+++ b/pkg/protect/annotations.go
@@ -181,7 +181,11 @@ func (k *Key) verifySignature(annotations map[string]string, data []byte) error 
 }
 
 func (k *Key) checkEncryptedAlgorithm(annotations map[string]string) error {
-	if alg := annotations[AnnotationEncryptedAlgorithm]; alg != k.EncryptAlgorithm() {
+	alg := annotations[AnnotationEncryptedAlgorithm]
+	if !k.CanEncrypt() {
+		return fmt.Errorf("%w: artifact carries an encrypted copy (%q) but %s cannot have produced one", ErrAlgorithmMism, alg, k.Describe())
+	}
+	if alg != k.EncryptAlgorithm() {
 		return fmt.Errorf("%w: artifact encrypted with %q but key supports %q", ErrAlgorithmMism, alg, k.EncryptAlgorithm())
 	}
 	return nil

--- a/pkg/protect/annotations.go
+++ b/pkg/protect/annotations.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
+	"strings"
 )
 
 const (
@@ -99,44 +100,70 @@ func IsProtected(annotations map[string]string) bool {
 	return annotations[AnnotationSignature] != "" || annotations[AnnotationEncrypted] != ""
 }
 
+// Verification reports which protections VerifyAnnotations actually checked.
+type Verification struct {
+	// SignatureAlgorithm is set when a signature was verified.
+	SignatureAlgorithm string
+	// EncryptedAlgorithm is set when the encrypted copy was decrypted and
+	// matched the content. It stays empty for a public key, which can only
+	// check the copy's algorithm label.
+	EncryptedAlgorithm string
+}
+
+func (v Verification) String() string {
+	var parts []string
+	if v.SignatureAlgorithm != "" {
+		parts = append(parts, "signature ("+v.SignatureAlgorithm+")")
+	}
+	if v.EncryptedAlgorithm != "" {
+		parts = append(parts, "encrypted copy ("+v.EncryptedAlgorithm+")")
+	}
+	return strings.Join(parts, " and ")
+}
+
 // VerifyAnnotations checks that data is what a holder of this key published,
-// using the protection annotations carry.
+// using the protection annotations carry, and reports what was checked.
 //
 // A signature, when present, is always verified. An encrypted copy is
-// decrypted and compared to data when the key can decrypt; when it cannot,
-// the signature must have been verified instead. With an asymmetric key a
-// signature is mandatory, since anyone holding the public key could have
-// produced the encrypted copy. ErrNotProtected is returned when the artifact
-// carries no protection at all.
-func (k *Key) VerifyAnnotations(annotations map[string]string, data []byte) error {
+// decrypted and compared to data when the key can decrypt; a public key only
+// checks its algorithm label and relies on the signature. With an asymmetric
+// key a signature is mandatory, since anyone holding the public key could
+// have produced the encrypted copy. ErrNotProtected is returned when the
+// artifact carries no protection at all.
+func (k *Key) VerifyAnnotations(annotations map[string]string, data []byte) (Verification, error) {
+	var v Verification
 	signed := annotations[AnnotationSignature] != ""
 	encrypted := annotations[AnnotationEncrypted] != ""
 	if !signed && !encrypted {
-		return ErrNotProtected
+		return v, ErrNotProtected
 	}
 	if !signed && !k.Symmetric() {
-		return ErrNotSigned
+		return v, ErrNotSigned
 	}
 
 	if signed {
 		if err := k.verifySignature(annotations, data); err != nil {
-			return err
+			return v, err
 		}
+		v.SignatureAlgorithm = k.SignAlgorithm()
 	}
 	if encrypted {
+		if err := k.checkEncryptedAlgorithm(annotations); err != nil {
+			return Verification{}, err
+		}
 		if !k.CanDecrypt() {
-			// Signature verified above; the copy is for holders of the private key.
-			return nil
+			return v, nil
 		}
 		plain, err := k.Recover(annotations)
 		if err != nil {
-			return err
+			return Verification{}, err
 		}
 		if subtle.ConstantTimeCompare(plain, data) != 1 {
-			return ErrTampered
+			return Verification{}, ErrTampered
 		}
+		v.EncryptedAlgorithm = k.EncryptAlgorithm()
 	}
-	return nil
+	return v, nil
 }
 
 func (k *Key) verifySignature(annotations map[string]string, data []byte) error {
@@ -153,6 +180,13 @@ func (k *Key) verifySignature(annotations map[string]string, data []byte) error 
 	return k.Verify(data, sig)
 }
 
+func (k *Key) checkEncryptedAlgorithm(annotations map[string]string) error {
+	if alg := annotations[AnnotationEncryptedAlgorithm]; alg != k.EncryptAlgorithm() {
+		return fmt.Errorf("%w: artifact encrypted with %q but key supports %q", ErrAlgorithmMism, alg, k.EncryptAlgorithm())
+	}
+	return nil
+}
+
 // Recover decrypts the encrypted copy carried in annotations, returning the
 // clear YAML. It works from the annotations alone, without the layer. Note
 // that it does not check the signature; use VerifyAnnotations for that.
@@ -164,8 +198,8 @@ func (k *Key) Recover(annotations map[string]string) ([]byte, error) {
 	if !k.CanDecrypt() {
 		return nil, fmt.Errorf("%w (%s)", ErrCannotDecrypt, k.Describe())
 	}
-	if alg := annotations[AnnotationEncryptedAlgorithm]; alg != k.EncryptAlgorithm() {
-		return nil, fmt.Errorf("%w: artifact encrypted with %q but key supports %q", ErrAlgorithmMism, alg, k.EncryptAlgorithm())
+	if err := k.checkEncryptedAlgorithm(annotations); err != nil {
+		return nil, err
 	}
 	blob, err := base64.StdEncoding.DecodeString(encoded)
 	if err != nil {

--- a/pkg/protect/encrypt.go
+++ b/pkg/protect/encrypt.go
@@ -1,0 +1,246 @@
+package protect
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/ecdh"
+	"crypto/ecdsa"
+	"crypto/hkdf"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"errors"
+	"fmt"
+	"strings"
+)
+
+const (
+	AlgAESGCM  = "aes-256-gcm"
+	AlgRSAOAEP = "rsa-oaep-sha256-aes-256-gcm"
+	// ECIES algorithms are "ecies-<curve>-aes-256-gcm", see eciesAlgorithm.
+	eciesPrefix = "ecies-"
+	eciesSuffix = "-aes-256-gcm"
+)
+
+var (
+	ErrCannotEncrypt = errors.New("key cannot encrypt")
+	ErrCannotDecrypt = errors.New("key cannot decrypt: a private key or secret is required")
+	ErrDecryption    = errors.New("decryption failed")
+)
+
+// EncryptAlgorithm returns the encryption algorithm this key supports, or ""
+// if the key type cannot encrypt (e.g. Ed25519).
+func (k *Key) EncryptAlgorithm() string {
+	if k.Symmetric() {
+		return AlgAESGCM
+	}
+	switch p := k.pub.(type) {
+	case *rsa.PublicKey:
+		return AlgRSAOAEP
+	case *ecdh.PublicKey:
+		return eciesAlgorithm(p.Curve())
+	case *ecdsa.PublicKey:
+		if e, err := p.ECDH(); err == nil {
+			return eciesAlgorithm(e.Curve())
+		}
+	}
+	return ""
+}
+
+func eciesAlgorithm(curve ecdh.Curve) string {
+	name := strings.ToLower(strings.ReplaceAll(fmt.Sprint(curve), "-", ""))
+	return eciesPrefix + name + eciesSuffix
+}
+
+// CanEncrypt reports whether the key can encrypt (any key of an
+// encryption-capable type; a public key is enough).
+func (k *Key) CanEncrypt() bool { return k.EncryptAlgorithm() != "" }
+
+// CanDecrypt reports whether the key can decrypt (private material required).
+func (k *Key) CanDecrypt() bool { return k.CanEncrypt() && k.Private() }
+
+// Encrypt returns an authenticated ciphertext of data that only holders of
+// the secret (symmetric) or of the private key (asymmetric) can open.
+//
+// Blob layouts:
+//   - aes-256-gcm:      nonce || ciphertext
+//   - ecies-*:          ephemeralPub || nonce || ciphertext
+//   - rsa-oaep-*:       wrappedKey || nonce || ciphertext
+func (k *Key) Encrypt(data []byte) ([]byte, error) {
+	if !k.CanEncrypt() {
+		return nil, ErrCannotEncrypt
+	}
+	if k.Symmetric() {
+		return aeadSeal(deriveKey(k.secret, []byte("docker-agent/"+AlgAESGCM)), data)
+	}
+	if p, ok := k.pub.(*rsa.PublicKey); ok {
+		return rsaEncrypt(p, data)
+	}
+	recipient, err := k.ecdhPublic()
+	if err != nil {
+		return nil, err
+	}
+	return eciesEncrypt(recipient, data)
+}
+
+// Decrypt opens a blob produced by Encrypt with the matching key.
+func (k *Key) Decrypt(blob []byte) ([]byte, error) {
+	if !k.CanDecrypt() {
+		return nil, ErrCannotDecrypt
+	}
+	if k.Symmetric() {
+		return aeadOpen(deriveKey(k.secret, []byte("docker-agent/"+AlgAESGCM)), blob)
+	}
+	if p, ok := k.priv.(*rsa.PrivateKey); ok {
+		return rsaDecrypt(p, blob)
+	}
+	priv, err := k.ecdhPrivate()
+	if err != nil {
+		return nil, err
+	}
+	return eciesDecrypt(priv, blob)
+}
+
+func (k *Key) ecdhPublic() (*ecdh.PublicKey, error) {
+	switch p := k.pub.(type) {
+	case *ecdh.PublicKey:
+		return p, nil
+	case *ecdsa.PublicKey:
+		return p.ECDH()
+	default:
+		return nil, ErrCannotEncrypt
+	}
+}
+
+func (k *Key) ecdhPrivate() (*ecdh.PrivateKey, error) {
+	switch p := k.priv.(type) {
+	case *ecdh.PrivateKey:
+		return p, nil
+	case *ecdsa.PrivateKey:
+		return p.ECDH()
+	default:
+		return nil, ErrCannotDecrypt
+	}
+}
+
+const (
+	aesKeySize   = 32
+	gcmNonceSize = 12
+)
+
+// deriveKey stretches arbitrary secret material into an AES-256 key. Using a
+// KDF with a purpose-specific info string keeps the AES key independent from
+// the HMAC use of the same secret.
+func deriveKey(secret, info []byte) []byte {
+	key, err := hkdf.Key(sha256.New, secret, nil, string(info), aesKeySize)
+	if err != nil {
+		// Only fails for an absurd key length; aesKeySize is a constant.
+		panic(err)
+	}
+	return key
+}
+
+func newGCM(key []byte) (cipher.AEAD, error) {
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, err
+	}
+	return cipher.NewGCM(block)
+}
+
+func aeadSeal(key, data []byte) ([]byte, error) {
+	gcm, err := newGCM(key)
+	if err != nil {
+		return nil, err
+	}
+	nonce := make([]byte, gcmNonceSize)
+	if _, err := rand.Read(nonce); err != nil {
+		return nil, err
+	}
+	return gcm.Seal(nonce, nonce, data, nil), nil
+}
+
+func aeadOpen(key, blob []byte) ([]byte, error) {
+	gcm, err := newGCM(key)
+	if err != nil {
+		return nil, err
+	}
+	if len(blob) < gcmNonceSize {
+		return nil, ErrDecryption
+	}
+	plain, err := gcm.Open(nil, blob[:gcmNonceSize], blob[gcmNonceSize:], nil)
+	if err != nil {
+		return nil, ErrDecryption
+	}
+	return plain, nil
+}
+
+// eciesEncrypt performs ephemeral-static ECDH and encrypts under the derived
+// key. Binding both public keys into the KDF info prevents key-substitution.
+func eciesEncrypt(recipient *ecdh.PublicKey, data []byte) ([]byte, error) {
+	ephemeral, err := recipient.Curve().GenerateKey(rand.Reader)
+	if err != nil {
+		return nil, err
+	}
+	shared, err := ephemeral.ECDH(recipient)
+	if err != nil {
+		return nil, err
+	}
+	ephPub := ephemeral.PublicKey().Bytes()
+	sealed, err := aeadSeal(deriveKey(shared, eciesInfo(ephPub, recipient.Bytes())), data)
+	if err != nil {
+		return nil, err
+	}
+	return append(ephPub, sealed...), nil
+}
+
+func eciesDecrypt(priv *ecdh.PrivateKey, blob []byte) ([]byte, error) {
+	pubLen := len(priv.PublicKey().Bytes())
+	if len(blob) < pubLen {
+		return nil, ErrDecryption
+	}
+	ephemeral, err := priv.Curve().NewPublicKey(blob[:pubLen])
+	if err != nil {
+		return nil, ErrDecryption
+	}
+	shared, err := priv.ECDH(ephemeral)
+	if err != nil {
+		return nil, ErrDecryption
+	}
+	return aeadOpen(deriveKey(shared, eciesInfo(blob[:pubLen], priv.PublicKey().Bytes())), blob[pubLen:])
+}
+
+func eciesInfo(ephPub, recipientPub []byte) []byte {
+	info := []byte("docker-agent/ecies")
+	info = append(info, ephPub...)
+	return append(info, recipientPub...)
+}
+
+// rsaEncrypt wraps a fresh AES key with RSA-OAEP and encrypts data under it.
+func rsaEncrypt(pub *rsa.PublicKey, data []byte) ([]byte, error) {
+	key := make([]byte, aesKeySize)
+	if _, err := rand.Read(key); err != nil {
+		return nil, err
+	}
+	wrapped, err := rsa.EncryptOAEP(sha256.New(), rand.Reader, pub, key, []byte(AlgRSAOAEP))
+	if err != nil {
+		return nil, err
+	}
+	sealed, err := aeadSeal(key, data)
+	if err != nil {
+		return nil, err
+	}
+	return append(wrapped, sealed...), nil
+}
+
+func rsaDecrypt(priv *rsa.PrivateKey, blob []byte) ([]byte, error) {
+	size := priv.Size()
+	if len(blob) < size {
+		return nil, ErrDecryption
+	}
+	key, err := rsa.DecryptOAEP(sha256.New(), nil, priv, blob[:size], []byte(AlgRSAOAEP))
+	if err != nil {
+		return nil, ErrDecryption
+	}
+	return aeadOpen(key, blob[size:])
+}

--- a/pkg/protect/encrypt.go
+++ b/pkg/protect/encrypt.go
@@ -29,7 +29,7 @@ var (
 )
 
 // EncryptAlgorithm returns the encryption algorithm this key supports, or ""
-// if the key type cannot encrypt (e.g. Ed25519).
+// if the key type cannot encrypt (Ed25519).
 func (k *Key) EncryptAlgorithm() string {
 	if k.Symmetric() {
 		return AlgAESGCM
@@ -37,8 +37,6 @@ func (k *Key) EncryptAlgorithm() string {
 	switch p := k.pub.(type) {
 	case *rsa.PublicKey:
 		return AlgRSAOAEP
-	case *ecdh.PublicKey:
-		return eciesAlgorithm(p.Curve())
 	case *ecdsa.PublicKey:
 		if e, err := p.ECDH(); err == nil {
 			return eciesAlgorithm(e.Curve())
@@ -60,7 +58,8 @@ func (k *Key) CanEncrypt() bool { return k.EncryptAlgorithm() != "" }
 func (k *Key) CanDecrypt() bool { return k.CanEncrypt() && k.Private() }
 
 // Encrypt returns an authenticated ciphertext of data that only holders of
-// the secret (symmetric) or of the private key (asymmetric) can open.
+// the secret (symmetric) or of the private key (asymmetric) can open. The
+// algorithm label is bound as AEAD additional data.
 //
 // Blob layouts:
 //   - aes-256-gcm:      nonce || ciphertext
@@ -70,17 +69,23 @@ func (k *Key) Encrypt(data []byte) ([]byte, error) {
 	if !k.CanEncrypt() {
 		return nil, ErrCannotEncrypt
 	}
-	if k.Symmetric() {
-		return aeadSeal(deriveKey(k.secret, []byte("docker-agent/"+AlgAESGCM)), data)
+	aad := domainInput("encrypt", k.EncryptAlgorithm(), nil)
+	switch {
+	case k.Symmetric():
+		key, err := deriveKey(k.secret, "docker-agent/"+AlgAESGCM)
+		if err != nil {
+			return nil, err
+		}
+		return aeadSeal(key, data, aad)
+	case k.EncryptAlgorithm() == AlgRSAOAEP:
+		return rsaEncrypt(k.pub.(*rsa.PublicKey), data, aad)
+	default:
+		recipient, err := k.pub.(*ecdsa.PublicKey).ECDH()
+		if err != nil {
+			return nil, err
+		}
+		return eciesEncrypt(recipient, data, aad)
 	}
-	if p, ok := k.pub.(*rsa.PublicKey); ok {
-		return rsaEncrypt(p, data)
-	}
-	recipient, err := k.ecdhPublic()
-	if err != nil {
-		return nil, err
-	}
-	return eciesEncrypt(recipient, data)
 }
 
 // Decrypt opens a blob produced by Encrypt with the matching key.
@@ -88,87 +93,64 @@ func (k *Key) Decrypt(blob []byte) ([]byte, error) {
 	if !k.CanDecrypt() {
 		return nil, ErrCannotDecrypt
 	}
-	if k.Symmetric() {
-		return aeadOpen(deriveKey(k.secret, []byte("docker-agent/"+AlgAESGCM)), blob)
-	}
-	if p, ok := k.priv.(*rsa.PrivateKey); ok {
-		return rsaDecrypt(p, blob)
-	}
-	priv, err := k.ecdhPrivate()
-	if err != nil {
-		return nil, err
-	}
-	return eciesDecrypt(priv, blob)
-}
-
-func (k *Key) ecdhPublic() (*ecdh.PublicKey, error) {
-	switch p := k.pub.(type) {
-	case *ecdh.PublicKey:
-		return p, nil
-	case *ecdsa.PublicKey:
-		return p.ECDH()
-	default:
-		return nil, ErrCannotEncrypt
-	}
-}
-
-func (k *Key) ecdhPrivate() (*ecdh.PrivateKey, error) {
+	aad := domainInput("encrypt", k.EncryptAlgorithm(), nil)
 	switch p := k.priv.(type) {
-	case *ecdh.PrivateKey:
-		return p, nil
+	case nil:
+		key, err := deriveKey(k.secret, "docker-agent/"+AlgAESGCM)
+		if err != nil {
+			return nil, err
+		}
+		return aeadOpen(key, blob, aad)
+	case *rsa.PrivateKey:
+		return rsaDecrypt(p, blob, aad)
 	case *ecdsa.PrivateKey:
-		return p.ECDH()
+		priv, err := p.ECDH()
+		if err != nil {
+			return nil, err
+		}
+		return eciesDecrypt(priv, blob, aad)
 	default:
 		return nil, ErrCannotDecrypt
 	}
 }
 
-const (
-	aesKeySize   = 32
-	gcmNonceSize = 12
-)
+const aesKeySize = 32
 
-// deriveKey stretches arbitrary secret material into an AES-256 key. Using a
-// KDF with a purpose-specific info string keeps the AES key independent from
-// the HMAC use of the same secret.
-func deriveKey(secret, info []byte) []byte {
-	key, err := hkdf.Key(sha256.New, secret, nil, string(info), aesKeySize)
+// deriveKey stretches secret material into an AES-256 key. The
+// purpose-specific info keeps the AES key independent from other uses of the
+// same material (e.g. HMAC on a shared secret).
+func deriveKey(secret []byte, info string) ([]byte, error) {
+	key, err := hkdf.Key(sha256.New, secret, nil, info, aesKeySize)
 	if err != nil {
-		// Only fails for an absurd key length; aesKeySize is a constant.
-		panic(err)
+		return nil, fmt.Errorf("deriving key: %w", err)
 	}
-	return key
+	return key, nil
 }
 
+// newGCM returns AES-GCM with an internally generated random nonce that is
+// prepended to the ciphertext (and expected in front of it when opening).
 func newGCM(key []byte) (cipher.AEAD, error) {
 	block, err := aes.NewCipher(key)
 	if err != nil {
 		return nil, err
 	}
-	return cipher.NewGCM(block)
+	return cipher.NewGCMWithRandomNonce(block)
 }
 
-func aeadSeal(key, data []byte) ([]byte, error) {
+func aeadSeal(key, data, aad []byte) ([]byte, error) {
 	gcm, err := newGCM(key)
 	if err != nil {
 		return nil, err
 	}
-	nonce := make([]byte, gcmNonceSize)
-	if _, err := rand.Read(nonce); err != nil {
-		return nil, err
-	}
-	return gcm.Seal(nonce, nonce, data, nil), nil
+	return gcm.Seal(nil, nil, data, aad), nil
 }
 
-func aeadOpen(key, blob []byte) ([]byte, error) {
+func aeadOpen(key, blob, aad []byte) ([]byte, error) {
 	gcm, err := newGCM(key)
 	if err != nil {
 		return nil, err
 	}
-	if len(blob) < gcmNonceSize {
-		return nil, ErrDecryption
-	}
-	plain, err := gcm.Open(nil, blob[:gcmNonceSize], blob[gcmNonceSize:], nil)
+	plain, err := gcm.Open(nil, nil, blob, aad)
 	if err != nil {
 		return nil, ErrDecryption
 	}
@@ -177,7 +159,7 @@ func aeadOpen(key, blob []byte) ([]byte, error) {
 
 // eciesEncrypt performs ephemeral-static ECDH and encrypts under the derived
 // key. Binding both public keys into the KDF info prevents key-substitution.
-func eciesEncrypt(recipient *ecdh.PublicKey, data []byte) ([]byte, error) {
+func eciesEncrypt(recipient *ecdh.PublicKey, data, aad []byte) ([]byte, error) {
 	ephemeral, err := recipient.Curve().GenerateKey(rand.Reader)
 	if err != nil {
 		return nil, err
@@ -187,14 +169,18 @@ func eciesEncrypt(recipient *ecdh.PublicKey, data []byte) ([]byte, error) {
 		return nil, err
 	}
 	ephPub := ephemeral.PublicKey().Bytes()
-	sealed, err := aeadSeal(deriveKey(shared, eciesInfo(ephPub, recipient.Bytes())), data)
+	key, err := deriveKey(shared, eciesInfo(ephPub, recipient.Bytes()))
+	if err != nil {
+		return nil, err
+	}
+	sealed, err := aeadSeal(key, data, aad)
 	if err != nil {
 		return nil, err
 	}
 	return append(ephPub, sealed...), nil
 }
 
-func eciesDecrypt(priv *ecdh.PrivateKey, blob []byte) ([]byte, error) {
+func eciesDecrypt(priv *ecdh.PrivateKey, blob, aad []byte) ([]byte, error) {
 	pubLen := len(priv.PublicKey().Bytes())
 	if len(blob) < pubLen {
 		return nil, ErrDecryption
@@ -207,17 +193,19 @@ func eciesDecrypt(priv *ecdh.PrivateKey, blob []byte) ([]byte, error) {
 	if err != nil {
 		return nil, ErrDecryption
 	}
-	return aeadOpen(deriveKey(shared, eciesInfo(blob[:pubLen], priv.PublicKey().Bytes())), blob[pubLen:])
+	key, err := deriveKey(shared, eciesInfo(blob[:pubLen], priv.PublicKey().Bytes()))
+	if err != nil {
+		return nil, err
+	}
+	return aeadOpen(key, blob[pubLen:], aad)
 }
 
-func eciesInfo(ephPub, recipientPub []byte) []byte {
-	info := []byte("docker-agent/ecies")
-	info = append(info, ephPub...)
-	return append(info, recipientPub...)
+func eciesInfo(ephPub, recipientPub []byte) string {
+	return "docker-agent/ecies" + string(ephPub) + string(recipientPub)
 }
 
 // rsaEncrypt wraps a fresh AES key with RSA-OAEP and encrypts data under it.
-func rsaEncrypt(pub *rsa.PublicKey, data []byte) ([]byte, error) {
+func rsaEncrypt(pub *rsa.PublicKey, data, aad []byte) ([]byte, error) {
 	key := make([]byte, aesKeySize)
 	if _, err := rand.Read(key); err != nil {
 		return nil, err
@@ -226,14 +214,14 @@ func rsaEncrypt(pub *rsa.PublicKey, data []byte) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	sealed, err := aeadSeal(key, data)
+	sealed, err := aeadSeal(key, data, aad)
 	if err != nil {
 		return nil, err
 	}
 	return append(wrapped, sealed...), nil
 }
 
-func rsaDecrypt(priv *rsa.PrivateKey, blob []byte) ([]byte, error) {
+func rsaDecrypt(priv *rsa.PrivateKey, blob, aad []byte) ([]byte, error) {
 	size := priv.Size()
 	if len(blob) < size {
 		return nil, ErrDecryption
@@ -242,5 +230,5 @@ func rsaDecrypt(priv *rsa.PrivateKey, blob []byte) ([]byte, error) {
 	if err != nil {
 		return nil, ErrDecryption
 	}
-	return aeadOpen(key, blob[size:])
+	return aeadOpen(key, blob[size:], aad)
 }

--- a/pkg/protect/key.go
+++ b/pkg/protect/key.go
@@ -94,7 +94,7 @@ func ParseKey(data []byte) (*Key, error) {
 		return nil, fmt.Errorf("malformed PEM key (a raw secret must not contain %q)", pemMarker)
 	}
 	if hasOpenSSHKeyType(data) {
-		return nil, fmt.Errorf("malformed OpenSSH public key: %w (a raw secret must not contain an OpenSSH key type)", sshErr)
+		return nil, fmt.Errorf("malformed OpenSSH public key: %w (a raw secret must not contain an OpenSSH key type such as \"ssh-\")", sshErr)
 	}
 
 	secret := bytes.Clone(bytes.TrimSpace(data))
@@ -118,17 +118,16 @@ func parseAuthorizedKey(data []byte) (crypto.PublicKey, error) {
 	return cpk.CryptoPublicKey(), nil
 }
 
-var opensshKeyTypes = []string{"ssh-", "ecdsa-sha2-", "sk-ssh-", "sk-ecdsa-"}
+var opensshKeyTypes = [][]byte{[]byte("ssh-"), []byte("ecdsa-sha2-"), []byte("sk-ssh-"), []byte("sk-ecdsa-")}
 
-// hasOpenSSHKeyType reports whether any whitespace-separated field starts
-// with an OpenSSH key-type prefix, wherever it appears (authorized_keys
-// options may precede it).
+// hasOpenSSHKeyType reports whether data contains an OpenSSH key-type marker
+// anywhere. A plain substring match, like the PEM check: anything subtler
+// (field boundaries, trailing material) leaves a BOM- or garbage-prefixed
+// public key free to pass as a secret.
 func hasOpenSSHKeyType(data []byte) bool {
-	for field := range strings.FieldsSeq(string(data)) {
-		for _, t := range opensshKeyTypes {
-			if strings.HasPrefix(field, t) {
-				return true
-			}
+	for _, t := range opensshKeyTypes {
+		if bytes.Contains(data, t) {
+			return true
 		}
 	}
 	return false

--- a/pkg/protect/key.go
+++ b/pkg/protect/key.go
@@ -74,11 +74,13 @@ func LoadKey(path string) (*Key, error) {
 	return key, nil
 }
 
-// ParseKey detects the key kind from its encoding. Input that looks like a
-// PEM block or an OpenSSH authorized_keys line is parsed as an asymmetric key
-// and any parse error is reported rather than falling back to a secret.
-// Anything else is a raw symmetric secret (surrounding whitespace is trimmed
-// so a trailing newline does not change the key).
+// ParseKey detects the key kind from its encoding. PEM blocks and OpenSSH
+// authorized_keys lines (with or without options) are parsed as asymmetric
+// keys; input that merely looks like one of those is rejected rather than
+// falling back to a secret, so a broken public key file can never become an
+// HMAC key made of public material. Anything else is a raw symmetric secret
+// (surrounding whitespace is trimmed so a trailing newline does not change
+// the key).
 func ParseKey(data []byte) (*Key, error) {
 	if bytes.Contains(data, []byte("-----BEGIN")) {
 		block, _ := pem.Decode(data)
@@ -87,16 +89,14 @@ func ParseKey(data []byte) (*Key, error) {
 		}
 		return parsePEM(block, data)
 	}
-	if looksLikeOpenSSHPublicKey(data) {
-		pub, _, _, _, err := ssh.ParseAuthorizedKey(data)
-		if err != nil {
-			return nil, fmt.Errorf("parsing OpenSSH public key: %w", err)
-		}
+	if pub, _, _, _, err := ssh.ParseAuthorizedKey(data); err == nil {
 		cpk, ok := pub.(ssh.CryptoPublicKey)
 		if !ok {
 			return nil, fmt.Errorf("unsupported ssh public key type %s", pub.Type())
 		}
 		return fromPublic(cpk.CryptoPublicKey())
+	} else if looksLikeOpenSSHPublicKey(data) {
+		return nil, fmt.Errorf("parsing OpenSSH public key: %w", err)
 	}
 
 	secret := bytes.Clone(bytes.TrimSpace(data))
@@ -106,12 +106,13 @@ func ParseKey(data []byte) (*Key, error) {
 	return &Key{secret: secret}, nil
 }
 
-var opensshKeyTypePrefixes = []string{"ssh-", "ecdsa-sha2-", "sk-ssh-", "sk-ecdsa-"}
+var opensshKeyTypes = [][]byte{[]byte("ssh-"), []byte("ecdsa-sha2-"), []byte("sk-ssh-"), []byte("sk-ecdsa-")}
 
+// looksLikeOpenSSHPublicKey reports whether data contains an OpenSSH key-type
+// token anywhere, since authorized_keys options may precede it.
 func looksLikeOpenSSHPublicKey(data []byte) bool {
-	first := string(bytes.TrimSpace(data))
-	for _, p := range opensshKeyTypePrefixes {
-		if strings.HasPrefix(first, p) {
+	for _, t := range opensshKeyTypes {
+		if bytes.Contains(data, t) {
 			return true
 		}
 	}
@@ -149,9 +150,16 @@ func parsePEM(block *pem.Block, data []byte) (*Key, error) {
 	}
 }
 
+// MinRSABits is the smallest accepted RSA modulus; smaller keys are
+// considered broken.
+const MinRSABits = 2048
+
 func fromPrivate(priv any) (*Key, error) {
 	switch p := priv.(type) {
 	case *rsa.PrivateKey:
+		if err := checkRSA(&p.PublicKey); err != nil {
+			return nil, err
+		}
 		return &Key{priv: p, pub: &p.PublicKey}, nil
 	case *ecdsa.PrivateKey:
 		return &Key{priv: p, pub: &p.PublicKey}, nil
@@ -165,12 +173,24 @@ func fromPrivate(priv any) (*Key, error) {
 }
 
 func fromPublic(pub crypto.PublicKey) (*Key, error) {
-	switch pub.(type) {
-	case *rsa.PublicKey, *ecdsa.PublicKey, ed25519.PublicKey:
+	switch p := pub.(type) {
+	case *rsa.PublicKey:
+		if err := checkRSA(p); err != nil {
+			return nil, err
+		}
+		return &Key{pub: pub}, nil
+	case *ecdsa.PublicKey, ed25519.PublicKey:
 		return &Key{pub: pub}, nil
 	default:
 		return nil, unsupportedKeyType(pub)
 	}
+}
+
+func checkRSA(pub *rsa.PublicKey) error {
+	if bits := pub.N.BitLen(); bits < MinRSABits {
+		return fmt.Errorf("RSA-%d key is too small: at least %d bits required", bits, MinRSABits)
+	}
+	return nil
 }
 
 func unsupportedKeyType(key any) error {

--- a/pkg/protect/key.go
+++ b/pkg/protect/key.go
@@ -39,7 +39,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"regexp"
 	"strings"
 
 	"golang.org/x/crypto/ssh"
@@ -77,26 +76,25 @@ func LoadKey(path string) (*Key, error) {
 
 // ParseKey detects the key kind from its encoding. PEM blocks and OpenSSH
 // authorized_keys lines (with or without options) are parsed as asymmetric
-// keys; input that merely looks like one of those is rejected rather than
-// falling back to a secret, so a broken public key file can never become an
-// HMAC key made of public material. Anything else is a raw symmetric secret
-// (surrounding whitespace is trimmed so a trailing newline does not change
-// the key).
+// keys. Anything else is a raw symmetric secret (surrounding whitespace is
+// trimmed so a trailing newline does not change the key) — unless it
+// contains a PEM boundary or an OpenSSH key-type token, in which case it is
+// treated as a broken key file and rejected. Failing closed here matters: a
+// truncated or BOM-prefixed public key must never silently become an HMAC
+// key made of public material. Random secrets never contain those markers.
 func ParseKey(data []byte) (*Key, error) {
 	if block, _ := pem.Decode(data); block != nil {
 		return parsePEM(block, data)
 	}
-	if pub, _, _, _, err := ssh.ParseAuthorizedKey(data); err == nil {
-		cpk, ok := pub.(ssh.CryptoPublicKey)
-		if !ok {
-			return nil, fmt.Errorf("unsupported ssh public key type %s", pub.Type())
-		}
-		return fromPublic(cpk.CryptoPublicKey())
-	} else if looksLikeOpenSSHPublicKey(data) {
-		return nil, fmt.Errorf("parsing OpenSSH public key: %w", err)
+	pub, sshErr := parseAuthorizedKey(data)
+	if sshErr == nil {
+		return fromPublic(pub)
 	}
-	if pemHeaderRe.Match(data) {
-		return nil, errors.New("malformed PEM key")
+	if bytes.Contains(data, []byte(pemMarker)) {
+		return nil, fmt.Errorf("malformed PEM key (a raw secret must not contain %q)", pemMarker)
+	}
+	if hasOpenSSHKeyType(data) {
+		return nil, fmt.Errorf("malformed OpenSSH public key: %w (a raw secret must not contain an OpenSSH key type)", sshErr)
 	}
 
 	secret := bytes.Clone(bytes.TrimSpace(data))
@@ -106,19 +104,27 @@ func ParseKey(data []byte) (*Key, error) {
 	return &Key{secret: secret}, nil
 }
 
-// pemHeaderRe matches a PEM pre-encapsulation boundary at the start of a line.
-var pemHeaderRe = regexp.MustCompile(`(?m)^\s*-{5}BEGIN `)
+const pemMarker = "-----BEGIN"
+
+func parseAuthorizedKey(data []byte) (crypto.PublicKey, error) {
+	pub, _, _, _, err := ssh.ParseAuthorizedKey(data) //nolint:dogsled // comment, options and rest are irrelevant
+	if err != nil {
+		return nil, err
+	}
+	cpk, ok := pub.(ssh.CryptoPublicKey)
+	if !ok {
+		return nil, fmt.Errorf("unsupported ssh public key type %s", pub.Type())
+	}
+	return cpk.CryptoPublicKey(), nil
+}
 
 var opensshKeyTypes = []string{"ssh-", "ecdsa-sha2-", "sk-ssh-", "sk-ecdsa-"}
 
-// looksLikeOpenSSHPublicKey reports whether a whitespace-separated field
-// starts with an OpenSSH key-type prefix and is followed by another field
-// (the key material). Fields rather than substrings, so authorized_keys
-// options before the type are caught while a secret that merely contains
-// "ssh-" is not.
-func looksLikeOpenSSHPublicKey(data []byte) bool {
-	fields := strings.Fields(string(data))
-	for _, field := range fields[:max(len(fields)-1, 0)] {
+// hasOpenSSHKeyType reports whether any whitespace-separated field starts
+// with an OpenSSH key-type prefix, wherever it appears (authorized_keys
+// options may precede it).
+func hasOpenSSHKeyType(data []byte) bool {
+	for field := range strings.FieldsSeq(string(data)) {
 		for _, t := range opensshKeyTypes {
 			if strings.HasPrefix(field, t) {
 				return true

--- a/pkg/protect/key.go
+++ b/pkg/protect/key.go
@@ -6,15 +6,29 @@
 // (RFC 7468) or OpenSSH keys are asymmetric; anything else is a raw secret.
 //
 // The YAML always stays in clear in the artifact layer. Depending on the
-// Mode chosen by the publisher, the manifest annotations carry either a
-// signature (MAC or digital signature) or an authenticated encrypted copy of
-// the whole YAML that key holders can decrypt.
+// Mode chosen by the publisher, the manifest annotations carry a signature
+// (MAC or digital signature) and optionally an authenticated encrypted copy
+// of the whole YAML that key holders can decrypt.
+//
+// # Security model
+//
+// Verification answers "was this produced by a holder of the key?". For a
+// symmetric secret, both the MAC and the AEAD ciphertext require the secret,
+// so either annotation alone is proof. For an asymmetric key, only a
+// signature proves possession of the private key: anyone holding the public
+// key can encrypt. Encrypt mode with an asymmetric key therefore requires the
+// private key and records both a signature and an encrypted copy, and
+// verification with an asymmetric key always requires a signature. This also
+// rules out downgrading a signed artifact to an encrypted-only one.
+//
+// Signatures cover the layer bytes only. Re-tagging a signed artifact or
+// serving an older signed version under a tag is not detected; pin digests
+// when that matters.
 package protect
 
 import (
 	"bytes"
 	"crypto"
-	"crypto/ecdh"
 	"crypto/ecdsa"
 	"crypto/ed25519"
 	"crypto/rsa"
@@ -30,11 +44,18 @@ import (
 	"golang.org/x/crypto/ssh"
 )
 
+// MinSecretLen is the minimum accepted length of a symmetric secret. The
+// clear YAML plus its MAC/ciphertext is an offline oracle for guessing the
+// secret, and HKDF adds no entropy, so short secrets are refused outright.
+const MinSecretLen = 16
+
+var ErrSecretTooShort = fmt.Errorf("symmetric secret must be at least %d bytes (generate one with `openssl rand -hex 32`)", MinSecretLen)
+
 // Key is a symmetric secret or an asymmetric key (private, or public-only).
 type Key struct {
 	secret []byte
 	// priv is nil for public-only keys. One of: *rsa.PrivateKey,
-	// *ecdsa.PrivateKey, ed25519.PrivateKey, *ecdh.PrivateKey.
+	// *ecdsa.PrivateKey, ed25519.PrivateKey.
 	priv crypto.PrivateKey
 	// pub is always set for asymmetric keys.
 	pub crypto.PublicKey
@@ -53,15 +74,24 @@ func LoadKey(path string) (*Key, error) {
 	return key, nil
 }
 
-// ParseKey detects the key kind from its encoding. PEM blocks and OpenSSH
-// authorized_keys lines are parsed as asymmetric keys; any other content is a
-// raw symmetric secret (surrounding whitespace is trimmed so a trailing
-// newline does not change the key).
+// ParseKey detects the key kind from its encoding. Input that looks like a
+// PEM block or an OpenSSH authorized_keys line is parsed as an asymmetric key
+// and any parse error is reported rather than falling back to a secret.
+// Anything else is a raw symmetric secret (surrounding whitespace is trimmed
+// so a trailing newline does not change the key).
 func ParseKey(data []byte) (*Key, error) {
-	if block, _ := pem.Decode(data); block != nil {
+	if bytes.Contains(data, []byte("-----BEGIN")) {
+		block, _ := pem.Decode(data)
+		if block == nil {
+			return nil, errors.New("malformed PEM key")
+		}
 		return parsePEM(block, data)
 	}
-	if pub, _, _, _, err := ssh.ParseAuthorizedKey(data); err == nil {
+	if looksLikeOpenSSHPublicKey(data) {
+		pub, _, _, _, err := ssh.ParseAuthorizedKey(data)
+		if err != nil {
+			return nil, fmt.Errorf("parsing OpenSSH public key: %w", err)
+		}
 		cpk, ok := pub.(ssh.CryptoPublicKey)
 		if !ok {
 			return nil, fmt.Errorf("unsupported ssh public key type %s", pub.Type())
@@ -69,11 +99,23 @@ func ParseKey(data []byte) (*Key, error) {
 		return fromPublic(cpk.CryptoPublicKey())
 	}
 
-	secret := bytes.TrimSpace(data)
-	if len(secret) == 0 {
-		return nil, errors.New("key is empty")
+	secret := bytes.Clone(bytes.TrimSpace(data))
+	if len(secret) < MinSecretLen {
+		return nil, ErrSecretTooShort
 	}
 	return &Key{secret: secret}, nil
+}
+
+var opensshKeyTypePrefixes = []string{"ssh-", "ecdsa-sha2-", "sk-ssh-", "sk-ecdsa-"}
+
+func looksLikeOpenSSHPublicKey(data []byte) bool {
+	first := string(bytes.TrimSpace(data))
+	for _, p := range opensshKeyTypePrefixes {
+		if strings.HasPrefix(first, p) {
+			return true
+		}
+	}
+	return false
 }
 
 func parsePEM(block *pem.Block, data []byte) (*Key, error) {
@@ -81,7 +123,7 @@ func parsePEM(block *pem.Block, data []byte) (*Key, error) {
 	case strings.Contains(block.Type, "ENCRYPTED"):
 		return nil, errors.New("passphrase-protected keys are not supported")
 	case strings.HasSuffix(block.Type, "PRIVATE KEY"):
-		// Handles PKCS#1, SEC1, PKCS#8 (incl. X25519) and OpenSSH private keys.
+		// Handles PKCS#1, SEC1, PKCS#8 and OpenSSH private keys.
 		priv, err := ssh.ParseRawPrivateKey(data)
 		if err != nil {
 			if _, missing := errors.AsType[*ssh.PassphraseMissingError](err); missing {
@@ -117,20 +159,22 @@ func fromPrivate(priv any) (*Key, error) {
 		return &Key{priv: p, pub: p.Public()}, nil
 	case *ed25519.PrivateKey:
 		return fromPrivate(*p)
-	case *ecdh.PrivateKey:
-		return &Key{priv: p, pub: p.PublicKey()}, nil
 	default:
-		return nil, fmt.Errorf("unsupported private key type %T", priv)
+		return nil, unsupportedKeyType(priv)
 	}
 }
 
 func fromPublic(pub crypto.PublicKey) (*Key, error) {
 	switch pub.(type) {
-	case *rsa.PublicKey, *ecdsa.PublicKey, ed25519.PublicKey, *ecdh.PublicKey:
+	case *rsa.PublicKey, *ecdsa.PublicKey, ed25519.PublicKey:
 		return &Key{pub: pub}, nil
 	default:
-		return nil, fmt.Errorf("unsupported public key type %T", pub)
+		return nil, unsupportedKeyType(pub)
 	}
+}
+
+func unsupportedKeyType(key any) error {
+	return fmt.Errorf("unsupported key type %T: use an Ed25519, ECDSA or RSA key", key)
 }
 
 // Symmetric reports whether the key is a raw secret.
@@ -153,6 +197,16 @@ func (k *Key) Fingerprint() string {
 	return hex.EncodeToString(sum[:])
 }
 
+// Identity extends Fingerprint with the key's role, so that the private and
+// public halves of a pair — which have different verification capabilities —
+// are told apart. Suitable as a cache key for verification results.
+func (k *Key) Identity() string {
+	if k.Private() {
+		return k.Fingerprint() + "/private"
+	}
+	return k.Fingerprint() + "/public"
+}
+
 // Describe returns a short human-readable description of the key.
 func (k *Key) Describe() string {
 	if k.Symmetric() {
@@ -169,8 +223,6 @@ func (k *Key) Describe() string {
 		return fmt.Sprintf("ECDSA %s %s key", p.Curve.Params().Name, half)
 	case ed25519.PublicKey:
 		return "Ed25519 " + half + " key"
-	case *ecdh.PublicKey:
-		return fmt.Sprintf("%s %s key", p.Curve(), half)
 	default:
 		return "unknown key"
 	}

--- a/pkg/protect/key.go
+++ b/pkg/protect/key.go
@@ -1,0 +1,177 @@
+// Package protect signs or encrypts agent YAML shipped in OCI artifacts and
+// verifies it on the way back.
+//
+// A key is either a symmetric secret or an asymmetric key (private, or
+// public-only). The kind is detected from the file contents: PEM-encoded
+// (RFC 7468) or OpenSSH keys are asymmetric; anything else is a raw secret.
+//
+// The YAML always stays in clear in the artifact layer. Depending on the
+// Mode chosen by the publisher, the manifest annotations carry either a
+// signature (MAC or digital signature) or an authenticated encrypted copy of
+// the whole YAML that key holders can decrypt.
+package protect
+
+import (
+	"bytes"
+	"crypto"
+	"crypto/ecdh"
+	"crypto/ecdsa"
+	"crypto/ed25519"
+	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/hex"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+
+	"golang.org/x/crypto/ssh"
+)
+
+// Key is a symmetric secret or an asymmetric key (private, or public-only).
+type Key struct {
+	secret []byte
+	// priv is nil for public-only keys. One of: *rsa.PrivateKey,
+	// *ecdsa.PrivateKey, ed25519.PrivateKey, *ecdh.PrivateKey.
+	priv crypto.PrivateKey
+	// pub is always set for asymmetric keys.
+	pub crypto.PublicKey
+}
+
+// LoadKey reads and parses a key file. See ParseKey.
+func LoadKey(path string) (*Key, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("reading key file: %w", err)
+	}
+	key, err := ParseKey(data)
+	if err != nil {
+		return nil, fmt.Errorf("parsing key file %s: %w", path, err)
+	}
+	return key, nil
+}
+
+// ParseKey detects the key kind from its encoding. PEM blocks and OpenSSH
+// authorized_keys lines are parsed as asymmetric keys; any other content is a
+// raw symmetric secret (surrounding whitespace is trimmed so a trailing
+// newline does not change the key).
+func ParseKey(data []byte) (*Key, error) {
+	if block, _ := pem.Decode(data); block != nil {
+		return parsePEM(block, data)
+	}
+	if pub, _, _, _, err := ssh.ParseAuthorizedKey(data); err == nil {
+		cpk, ok := pub.(ssh.CryptoPublicKey)
+		if !ok {
+			return nil, fmt.Errorf("unsupported ssh public key type %s", pub.Type())
+		}
+		return fromPublic(cpk.CryptoPublicKey())
+	}
+
+	secret := bytes.TrimSpace(data)
+	if len(secret) == 0 {
+		return nil, errors.New("key is empty")
+	}
+	return &Key{secret: secret}, nil
+}
+
+func parsePEM(block *pem.Block, data []byte) (*Key, error) {
+	switch {
+	case strings.Contains(block.Type, "ENCRYPTED"):
+		return nil, errors.New("passphrase-protected keys are not supported")
+	case strings.HasSuffix(block.Type, "PRIVATE KEY"):
+		// Handles PKCS#1, SEC1, PKCS#8 (incl. X25519) and OpenSSH private keys.
+		priv, err := ssh.ParseRawPrivateKey(data)
+		if err != nil {
+			if _, missing := errors.AsType[*ssh.PassphraseMissingError](err); missing {
+				return nil, errors.New("passphrase-protected keys are not supported")
+			}
+			return nil, fmt.Errorf("parsing private key: %w", err)
+		}
+		return fromPrivate(priv)
+	case block.Type == "PUBLIC KEY":
+		pub, err := x509.ParsePKIXPublicKey(block.Bytes)
+		if err != nil {
+			return nil, fmt.Errorf("parsing public key: %w", err)
+		}
+		return fromPublic(pub)
+	case block.Type == "RSA PUBLIC KEY":
+		pub, err := x509.ParsePKCS1PublicKey(block.Bytes)
+		if err != nil {
+			return nil, fmt.Errorf("parsing RSA public key: %w", err)
+		}
+		return fromPublic(pub)
+	default:
+		return nil, fmt.Errorf("unsupported PEM block type %q", block.Type)
+	}
+}
+
+func fromPrivate(priv any) (*Key, error) {
+	switch p := priv.(type) {
+	case *rsa.PrivateKey:
+		return &Key{priv: p, pub: &p.PublicKey}, nil
+	case *ecdsa.PrivateKey:
+		return &Key{priv: p, pub: &p.PublicKey}, nil
+	case ed25519.PrivateKey:
+		return &Key{priv: p, pub: p.Public()}, nil
+	case *ed25519.PrivateKey:
+		return fromPrivate(*p)
+	case *ecdh.PrivateKey:
+		return &Key{priv: p, pub: p.PublicKey()}, nil
+	default:
+		return nil, fmt.Errorf("unsupported private key type %T", priv)
+	}
+}
+
+func fromPublic(pub crypto.PublicKey) (*Key, error) {
+	switch pub.(type) {
+	case *rsa.PublicKey, *ecdsa.PublicKey, ed25519.PublicKey, *ecdh.PublicKey:
+		return &Key{pub: pub}, nil
+	default:
+		return nil, fmt.Errorf("unsupported public key type %T", pub)
+	}
+}
+
+// Symmetric reports whether the key is a raw secret.
+func (k *Key) Symmetric() bool { return k.secret != nil }
+
+// Private reports whether the key holds private material (a secret or a
+// private key), as opposed to a public-only key.
+func (k *Key) Private() bool { return k.Symmetric() || k.priv != nil }
+
+// Fingerprint returns a stable hex identifier for the key material: SHA-256 of
+// the secret, or of the PKIX-encoded public key. Private and public halves of
+// the same pair share a fingerprint.
+func (k *Key) Fingerprint() string {
+	material := k.secret
+	if !k.Symmetric() {
+		// Only fails for unsupported types, which fromPublic rejects.
+		material, _ = x509.MarshalPKIXPublicKey(k.pub)
+	}
+	sum := sha256.Sum256(material)
+	return hex.EncodeToString(sum[:])
+}
+
+// Describe returns a short human-readable description of the key.
+func (k *Key) Describe() string {
+	if k.Symmetric() {
+		return "symmetric secret"
+	}
+	half := "public"
+	if k.priv != nil {
+		half = "private"
+	}
+	switch p := k.pub.(type) {
+	case *rsa.PublicKey:
+		return fmt.Sprintf("RSA-%d %s key", p.N.BitLen(), half)
+	case *ecdsa.PublicKey:
+		return fmt.Sprintf("ECDSA %s %s key", p.Curve.Params().Name, half)
+	case ed25519.PublicKey:
+		return "Ed25519 " + half + " key"
+	case *ecdh.PublicKey:
+		return fmt.Sprintf("%s %s key", p.Curve(), half)
+	default:
+		return "unknown key"
+	}
+}

--- a/pkg/protect/key.go
+++ b/pkg/protect/key.go
@@ -39,6 +39,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"regexp"
 	"strings"
 
 	"golang.org/x/crypto/ssh"
@@ -82,11 +83,7 @@ func LoadKey(path string) (*Key, error) {
 // (surrounding whitespace is trimmed so a trailing newline does not change
 // the key).
 func ParseKey(data []byte) (*Key, error) {
-	if bytes.Contains(data, []byte("-----BEGIN")) {
-		block, _ := pem.Decode(data)
-		if block == nil {
-			return nil, errors.New("malformed PEM key")
-		}
+	if block, _ := pem.Decode(data); block != nil {
 		return parsePEM(block, data)
 	}
 	if pub, _, _, _, err := ssh.ParseAuthorizedKey(data); err == nil {
@@ -98,6 +95,9 @@ func ParseKey(data []byte) (*Key, error) {
 	} else if looksLikeOpenSSHPublicKey(data) {
 		return nil, fmt.Errorf("parsing OpenSSH public key: %w", err)
 	}
+	if pemHeaderRe.Match(data) {
+		return nil, errors.New("malformed PEM key")
+	}
 
 	secret := bytes.Clone(bytes.TrimSpace(data))
 	if len(secret) < MinSecretLen {
@@ -106,14 +106,23 @@ func ParseKey(data []byte) (*Key, error) {
 	return &Key{secret: secret}, nil
 }
 
-var opensshKeyTypes = [][]byte{[]byte("ssh-"), []byte("ecdsa-sha2-"), []byte("sk-ssh-"), []byte("sk-ecdsa-")}
+// pemHeaderRe matches a PEM pre-encapsulation boundary at the start of a line.
+var pemHeaderRe = regexp.MustCompile(`(?m)^\s*-{5}BEGIN `)
 
-// looksLikeOpenSSHPublicKey reports whether data contains an OpenSSH key-type
-// token anywhere, since authorized_keys options may precede it.
+var opensshKeyTypes = []string{"ssh-", "ecdsa-sha2-", "sk-ssh-", "sk-ecdsa-"}
+
+// looksLikeOpenSSHPublicKey reports whether a whitespace-separated field
+// starts with an OpenSSH key-type prefix and is followed by another field
+// (the key material). Fields rather than substrings, so authorized_keys
+// options before the type are caught while a secret that merely contains
+// "ssh-" is not.
 func looksLikeOpenSSHPublicKey(data []byte) bool {
-	for _, t := range opensshKeyTypes {
-		if bytes.Contains(data, t) {
-			return true
+	fields := strings.Fields(string(data))
+	for _, field := range fields[:max(len(fields)-1, 0)] {
+		for _, t := range opensshKeyTypes {
+			if strings.HasPrefix(field, t) {
+				return true
+			}
 		}
 	}
 	return false

--- a/pkg/protect/protect_test.go
+++ b/pkg/protect/protect_test.go
@@ -9,6 +9,7 @@ import (
 	"crypto/x509"
 	"encoding/base64"
 	"encoding/pem"
+	"maps"
 	"os"
 	"path/filepath"
 	"strings"
@@ -41,6 +42,12 @@ func pkix(t *testing.T, pub any) []byte {
 	der, err := x509.MarshalPKIXPublicKey(pub)
 	require.NoError(t, err)
 	return pemEncode(t, "PUBLIC KEY", der)
+}
+
+// verifyErr discards the Verification report for tests that only care about the error.
+func verifyErr(k *Key, annotations map[string]string, data []byte) error {
+	_, err := k.VerifyAnnotations(annotations, data)
+	return err
 }
 
 func mustParse(t *testing.T, data []byte) *Key {
@@ -123,6 +130,59 @@ func TestParseKey_RejectsShortSecret(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestParseKey_OpenSSHWithOptions(t *testing.T) {
+	t.Parallel()
+
+	edPub, _, err := ed25519.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+	sshPub, err := ssh.NewPublicKey(edPub)
+	require.NoError(t, err)
+	line := `from="10.0.0.0/8",no-agent-forwarding ` + string(ssh.MarshalAuthorizedKey(sshPub))
+
+	key := mustParse(t, []byte(line))
+	assert.False(t, key.Symmetric(), "an authorized_keys line with options is a public key, not a secret")
+	assert.Equal(t, AlgEd25519, key.SignAlgorithm())
+
+	_, err = ParseKey([]byte(`from="10.0.0.0/8" ssh-ed25519 AAAAbroken comment`))
+	require.ErrorContains(t, err, "OpenSSH")
+}
+
+func TestParseKey_RejectsSmallRSA(t *testing.T) {
+	t.Parallel()
+
+	// Fixtures rather than rsa.GenerateKey: FIPS-only mode refuses to
+	// generate keys this small, which is exactly what we assert on.
+	const priv1024 = `-----BEGIN PRIVATE KEY-----
+MIICdwIBADANBgkqhkiG9w0BAQEFAASCAmEwggJdAgEAAoGBAMGC3Svsn0pS9Plq
+0H7O9s7HNbEBTpmdfJrLD2MVCsVH6HmAja7cVKqxgFZfPR03Mh30YvJ0oSGae/ak
+ZIsBYz3uyBDzan6UKuFwlj9xKM6rKiS0QSNIkaTE8Bbb4boGd0LkPyR7gaCSkxCm
+PjZjycXKjS7Ltulp2JAHg2gQX9HlAgMBAAECgYADgT5GRGPiMbx0JAYgtdjsh9km
+GpL031BZcWIW9lOanSHNyZFHYIA8Ezjy14jA1bYXqsx7/bbJaAXkwrd7eQv2FCKJ
+U+jBA1N/DYOMtrPNZHwWkdVyuZh7x4IIe1YJTeVzoGBIJH9blzmwuBw1GhL61ttJ
+P6o/z6AA6Tab/pZWJQJBAOdN+6654PZ3DvfRurAYlizXkd9sD7Df9GBSKdamfPrm
+sfrHA/6Fx5d5uFYGHjgsFyLZXhKrXA3C4AN8fTcinSsCQQDWK+ks8tfUX2nepkaW
+P9z80Sj0UPdUk2oWJ09JRXPW/nHkh1PdfvStLn4ZPTmJ2JQpuWZofi+SCsnZbYgH
+iWUvAkEAqXH9cFCHNsadVnpz8tDwIsWA/VViYUaO9Yj7UV4BrKQXugjVKj3Cq3rl
+yU8OEERsZoEqYy7ZbtNV2/f0mtFmpQJANvav8cQk1bDi56v+g4LCQPOgsgqxXrgy
+SpsuAtzbHLrSGdcNE9QIEQXUgL+wq4q0g3y8Jmbz6GPyZ2VvupdtKwJBAJ9TgAIz
+Fgzgv26ejpkp297lNYAXLrgJIPWaBXgpBEFm/doqZhJep/w0Rt4eKG/OwjF2F3XA
+ejTm/Yk3MH+ru0Y=
+-----END PRIVATE KEY-----
+`
+	const pub1024 = `-----BEGIN PUBLIC KEY-----
+MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDBgt0r7J9KUvT5atB+zvbOxzWx
+AU6ZnXyayw9jFQrFR+h5gI2u3FSqsYBWXz0dNzId9GLydKEhmnv2pGSLAWM97sgQ
+82p+lCrhcJY/cSjOqyoktEEjSJGkxPAW2+G6BndC5D8ke4GgkpMQpj42Y8nFyo0u
+y7bpadiQB4NoEF/R5QIDAQAB
+-----END PUBLIC KEY-----
+`
+
+	_, err := ParseKey([]byte(priv1024))
+	require.ErrorContains(t, err, "too small")
+	_, err = ParseKey([]byte(pub1024))
+	require.ErrorContains(t, err, "too small")
+}
+
 func TestParseKey_MalformedAsymmetricIsNotASecret(t *testing.T) {
 	t.Parallel()
 
@@ -132,6 +192,7 @@ func TestParseKey_MalformedAsymmetricIsNotASecret(t *testing.T) {
 		"pem no end":       "-----BEGIN PRIVATE KEY-----\nAAAA",
 		"bad ssh base64":   "ssh-ed25519 definitely-not-base64 comment",
 		"bad ecdsa ssh":    "ecdsa-sha2-nistp256 AAAA garbage",
+		"bad ssh options":  `command="x" ssh-rsa AAAA garbage`,
 		"unsupported pem":  string(pemEncode(t, "CERTIFICATE", []byte("junk"))),
 		"unsupported type": string(pemEncode(t, "DSA PARAMETERS", make([]byte, 40))),
 	} {
@@ -202,9 +263,9 @@ func TestAsymmetric_SignMode(t *testing.T) {
 			assert.Equal(t, kp.signAlg, annotations[AnnotationSignatureAlgorithm])
 			assert.NotContains(t, annotations, AnnotationEncrypted)
 
-			require.NoError(t, pub.VerifyAnnotations(annotations, []byte(payload)))
-			require.NoError(t, priv.VerifyAnnotations(annotations, []byte(payload)))
-			require.ErrorIs(t, pub.VerifyAnnotations(annotations, []byte(payload+"#\n")), ErrInvalidSignature)
+			require.NoError(t, verifyErr(pub, annotations, []byte(payload)))
+			require.NoError(t, verifyErr(priv, annotations, []byte(payload)))
+			require.ErrorIs(t, verifyErr(pub, annotations, []byte(payload+"#\n")), ErrInvalidSignature)
 
 			_, err := priv.Recover(annotations)
 			require.ErrorIs(t, err, ErrNotEncrypted)
@@ -235,10 +296,20 @@ func TestAsymmetric_EncryptMode(t *testing.T) {
 			assert.Equal(t, kp.signAlg, annotations[AnnotationSignatureAlgorithm], "encrypt mode must also sign")
 
 			// Private key: signature + decrypt-and-compare. Public key: signature only.
-			require.NoError(t, priv.VerifyAnnotations(annotations, []byte(payload)))
-			require.NoError(t, pub.VerifyAnnotations(annotations, []byte(payload)))
-			require.ErrorIs(t, priv.VerifyAnnotations(annotations, []byte("tampered")), ErrInvalidSignature)
-			require.ErrorIs(t, pub.VerifyAnnotations(annotations, []byte("tampered")), ErrInvalidSignature)
+			v, err := priv.VerifyAnnotations(annotations, []byte(payload))
+			require.NoError(t, err)
+			assert.Equal(t, Verification{SignatureAlgorithm: kp.signAlg, EncryptedAlgorithm: kp.encAlg}, v)
+			v, err = pub.VerifyAnnotations(annotations, []byte(payload))
+			require.NoError(t, err)
+			assert.Equal(t, Verification{SignatureAlgorithm: kp.signAlg}, v)
+			assert.Equal(t, "signature ("+kp.signAlg+")", v.String())
+
+			// Even a public key must notice an encrypted copy that this key could not have produced.
+			relabeled := maps.Clone(annotations)
+			relabeled[AnnotationEncryptedAlgorithm] = "something-else"
+			require.ErrorIs(t, verifyErr(pub, relabeled, []byte(payload)), ErrAlgorithmMism)
+			require.ErrorIs(t, verifyErr(priv, annotations, []byte("tampered")), ErrInvalidSignature)
+			require.ErrorIs(t, verifyErr(pub, annotations, []byte("tampered")), ErrInvalidSignature)
 
 			plain, err := priv.Recover(annotations)
 			require.NoError(t, err)
@@ -281,8 +352,8 @@ func TestAsymmetric_EncryptedCopyAloneIsNotProof(t *testing.T) {
 			annotations[AnnotationEncrypted] = base64.StdEncoding.EncodeToString(forged)
 			annotations[AnnotationEncryptedAlgorithm] = pub.EncryptAlgorithm()
 
-			require.ErrorIs(t, priv.VerifyAnnotations(annotations, malicious), ErrNotSigned)
-			require.ErrorIs(t, pub.VerifyAnnotations(annotations, malicious), ErrNotSigned)
+			require.ErrorIs(t, verifyErr(priv, annotations, malicious), ErrNotSigned)
+			require.ErrorIs(t, verifyErr(pub, annotations, malicious), ErrNotSigned)
 
 			// Recover still works (it is not a verification), but is explicit about that.
 			plain, err := priv.Recover(annotations)
@@ -309,8 +380,8 @@ func TestAsymmetric_SwappedEncryptedCopyIsDetected(t *testing.T) {
 	annotations[AnnotationEncrypted] = base64.StdEncoding.EncodeToString(forged)
 
 	// Layer swapped too: signature fails. Layer intact: copy mismatch.
-	require.ErrorIs(t, priv.VerifyAnnotations(annotations, malicious), ErrInvalidSignature)
-	require.ErrorIs(t, priv.VerifyAnnotations(annotations, []byte(payload)), ErrTampered)
+	require.ErrorIs(t, verifyErr(priv, annotations, malicious), ErrInvalidSignature)
+	require.ErrorIs(t, verifyErr(priv, annotations, []byte(payload)), ErrTampered)
 }
 
 // regenerate returns a fresh private key of the same type as kp.
@@ -335,17 +406,17 @@ func TestSymmetric_BothModes(t *testing.T) {
 	signed := map[string]string{}
 	require.NoError(t, key.Protect(signed, []byte(payload), ModeSign))
 	assert.NotContains(t, signed, AnnotationEncrypted)
-	require.NoError(t, key.VerifyAnnotations(signed, []byte(payload)))
-	require.ErrorIs(t, key.VerifyAnnotations(signed, []byte("changed")), ErrInvalidSignature)
-	require.ErrorIs(t, other.VerifyAnnotations(signed, []byte(payload)), ErrInvalidSignature)
+	require.NoError(t, verifyErr(key, signed, []byte(payload)))
+	require.ErrorIs(t, verifyErr(key, signed, []byte("changed")), ErrInvalidSignature)
+	require.ErrorIs(t, verifyErr(other, signed, []byte(payload)), ErrInvalidSignature)
 
 	// With a secret, the AEAD copy alone is proof: producing it needs the secret.
 	encrypted := map[string]string{}
 	require.NoError(t, key.Protect(encrypted, []byte(payload), ModeEncrypt))
 	assert.NotContains(t, encrypted, AnnotationSignature)
-	require.NoError(t, key.VerifyAnnotations(encrypted, []byte(payload)))
-	require.ErrorIs(t, key.VerifyAnnotations(encrypted, []byte("changed")), ErrTampered)
-	require.ErrorIs(t, other.VerifyAnnotations(encrypted, []byte(payload)), ErrDecryption)
+	require.NoError(t, verifyErr(key, encrypted, []byte(payload)))
+	require.ErrorIs(t, verifyErr(key, encrypted, []byte("changed")), ErrTampered)
+	require.ErrorIs(t, verifyErr(other, encrypted, []byte(payload)), ErrDecryption)
 
 	plain, err := key.Recover(encrypted)
 	require.NoError(t, err)
@@ -385,28 +456,28 @@ func TestVerifyAnnotations_Errors(t *testing.T) {
 
 	key := mustParse(t, []byte(secret))
 
-	require.ErrorIs(t, key.VerifyAnnotations(map[string]string{}, []byte(payload)), ErrNotProtected)
+	require.ErrorIs(t, verifyErr(key, map[string]string{}, []byte(payload)), ErrNotProtected)
 
-	err := key.VerifyAnnotations(map[string]string{
+	err := verifyErr(key, map[string]string{
 		AnnotationSignature:          "AAAA",
 		AnnotationSignatureAlgorithm: AlgEd25519,
 	}, []byte(payload))
 	require.ErrorIs(t, err, ErrAlgorithmMism)
 
-	err = key.VerifyAnnotations(map[string]string{
+	err = verifyErr(key, map[string]string{
 		AnnotationSignature:          "not base64!",
 		AnnotationSignatureAlgorithm: AlgHMACSHA256,
 	}, []byte(payload))
 	require.ErrorIs(t, err, ErrInvalidSignature)
 
-	err = key.VerifyAnnotations(map[string]string{
+	err = verifyErr(key, map[string]string{
 		AnnotationEncrypted:          "AAAA",
 		AnnotationEncryptedAlgorithm: AlgRSAOAEP,
 	}, []byte(payload))
 	require.ErrorIs(t, err, ErrAlgorithmMism)
 
 	for _, blob := range []string{"", "AAAA", "not base64!", base64.StdEncoding.EncodeToString(make([]byte, 11))} {
-		err = key.VerifyAnnotations(map[string]string{
+		err = verifyErr(key, map[string]string{
 			AnnotationEncrypted:          blob,
 			AnnotationEncryptedAlgorithm: AlgAESGCM,
 		}, []byte(payload))

--- a/pkg/protect/protect_test.go
+++ b/pkg/protect/protect_test.go
@@ -1,0 +1,320 @@
+package protect
+
+import (
+	"crypto/ecdh"
+	"crypto/ecdsa"
+	"crypto/ed25519"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/crypto/ssh"
+)
+
+const payload = "version: \"2\"\nagents:\n  root:\n    model: auto\n"
+
+func pemEncode(t *testing.T, typ string, der []byte) []byte {
+	t.Helper()
+	return pem.EncodeToMemory(&pem.Block{Type: typ, Bytes: der})
+}
+
+func pkcs8(t *testing.T, priv any) []byte {
+	t.Helper()
+	der, err := x509.MarshalPKCS8PrivateKey(priv)
+	require.NoError(t, err)
+	return pemEncode(t, "PRIVATE KEY", der)
+}
+
+func pkix(t *testing.T, pub any) []byte {
+	t.Helper()
+	der, err := x509.MarshalPKIXPublicKey(pub)
+	require.NoError(t, err)
+	return pemEncode(t, "PUBLIC KEY", der)
+}
+
+type keyPair struct {
+	priv, pub  []byte
+	canSign    bool
+	canEncrypt bool
+	signAlg    string
+	encAlg     string
+}
+
+// keyPairs returns every supported asymmetric key type and encoding.
+func keyPairs(t *testing.T) map[string]keyPair {
+	t.Helper()
+
+	edPub, edPriv, err := ed25519.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+	ecPriv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	rsaPriv, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	xPriv, err := ecdh.X25519().GenerateKey(rand.Reader)
+	require.NoError(t, err)
+
+	ecSEC1, err := x509.MarshalECPrivateKey(ecPriv)
+	require.NoError(t, err)
+	openssh, err := ssh.MarshalPrivateKey(edPriv, "")
+	require.NoError(t, err)
+	sshPub, err := ssh.NewPublicKey(edPub)
+	require.NoError(t, err)
+
+	ed := keyPair{canSign: true, signAlg: AlgEd25519}
+	ec := keyPair{canSign: true, canEncrypt: true, signAlg: AlgECDSASHA256, encAlg: "ecies-p256-aes-256-gcm"}
+	rs := keyPair{canSign: true, canEncrypt: true, signAlg: AlgRSAPSSSHA256, encAlg: AlgRSAOAEP}
+	x := keyPair{canEncrypt: true, encAlg: "ecies-x25519-aes-256-gcm"}
+
+	with := func(kp keyPair, priv, pub []byte) keyPair { kp.priv, kp.pub = priv, pub; return kp }
+
+	return map[string]keyPair{
+		"ed25519/pkcs8+pkix": with(ed, pkcs8(t, edPriv), pkix(t, edPub)),
+		"ed25519/openssh":    with(ed, pem.EncodeToMemory(openssh), ssh.MarshalAuthorizedKey(sshPub)),
+		"ecdsa/pkcs8+pkix":   with(ec, pkcs8(t, ecPriv), pkix(t, &ecPriv.PublicKey)),
+		"ecdsa/sec1":         with(ec, pemEncode(t, "EC PRIVATE KEY", ecSEC1), pkix(t, &ecPriv.PublicKey)),
+		"rsa/pkcs8+pkix":     with(rs, pkcs8(t, rsaPriv), pkix(t, &rsaPriv.PublicKey)),
+		"rsa/pkcs1":          with(rs, pemEncode(t, "RSA PRIVATE KEY", x509.MarshalPKCS1PrivateKey(rsaPriv)), pemEncode(t, "RSA PUBLIC KEY", x509.MarshalPKCS1PublicKey(&rsaPriv.PublicKey))),
+		"x25519/pkcs8+pkix":  with(x, pkcs8(t, xPriv), pkix(t, xPriv.PublicKey())),
+	}
+}
+
+func TestParseKey_DetectsSymmetric(t *testing.T) {
+	t.Parallel()
+
+	key, err := ParseKey([]byte("s3cret\n"))
+	require.NoError(t, err)
+	assert.True(t, key.Symmetric())
+	assert.True(t, key.CanSign())
+	assert.True(t, key.CanEncrypt())
+	assert.True(t, key.CanDecrypt())
+	assert.Equal(t, AlgHMACSHA256, key.SignAlgorithm())
+	assert.Equal(t, AlgAESGCM, key.EncryptAlgorithm())
+
+	// Trailing newline must not change the key.
+	same, err := ParseKey([]byte("s3cret"))
+	require.NoError(t, err)
+	assert.Equal(t, key.Fingerprint(), same.Fingerprint())
+}
+
+func TestParseKey_Errors(t *testing.T) {
+	t.Parallel()
+
+	_, err := ParseKey([]byte("  \n"))
+	require.Error(t, err)
+
+	_, err = ParseKey(pemEncode(t, "CERTIFICATE", []byte("junk")))
+	require.ErrorContains(t, err, "unsupported PEM block type")
+
+	_, edPriv, err := ed25519.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+	block, err := ssh.MarshalPrivateKeyWithPassphrase(edPriv, "", []byte("pw"))
+	require.NoError(t, err)
+	_, err = ParseKey(pem.EncodeToMemory(block))
+	require.ErrorContains(t, err, "passphrase-protected")
+}
+
+func TestAsymmetric_Capabilities(t *testing.T) {
+	t.Parallel()
+
+	for name, kp := range keyPairs(t) {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			priv, err := ParseKey(kp.priv)
+			require.NoError(t, err)
+			pub, err := ParseKey(kp.pub)
+			require.NoError(t, err)
+
+			assert.False(t, priv.Symmetric())
+			assert.True(t, priv.Private())
+			assert.False(t, pub.Private())
+			assert.Equal(t, priv.Fingerprint(), pub.Fingerprint())
+
+			assert.Equal(t, kp.canSign, priv.CanSign())
+			assert.False(t, pub.CanSign(), "public keys never sign")
+			assert.Equal(t, kp.canSign, pub.CanVerify())
+			assert.Equal(t, kp.signAlg, priv.SignAlgorithm())
+
+			assert.Equal(t, kp.canEncrypt, priv.CanEncrypt())
+			assert.Equal(t, kp.canEncrypt, pub.CanEncrypt(), "public keys can encrypt")
+			assert.Equal(t, kp.canEncrypt, priv.CanDecrypt())
+			assert.False(t, pub.CanDecrypt(), "public keys never decrypt")
+			assert.Equal(t, kp.encAlg, priv.EncryptAlgorithm())
+		})
+	}
+}
+
+func TestAsymmetric_SignMode(t *testing.T) {
+	t.Parallel()
+
+	for name, kp := range keyPairs(t) {
+		if !kp.canSign {
+			continue
+		}
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			priv, err := ParseKey(kp.priv)
+			require.NoError(t, err)
+			pub, err := ParseKey(kp.pub)
+			require.NoError(t, err)
+
+			annotations := map[string]string{}
+			require.ErrorIs(t, pub.Protect(annotations, []byte(payload), ModeSign), ErrCannotSign)
+			require.NoError(t, priv.Protect(annotations, []byte(payload), ModeSign))
+			assert.Equal(t, kp.signAlg, annotations[AnnotationSignatureAlgorithm])
+			assert.NotContains(t, annotations, AnnotationEncrypted)
+
+			require.NoError(t, pub.VerifyAnnotations(annotations, []byte(payload)))
+			require.NoError(t, priv.VerifyAnnotations(annotations, []byte(payload)))
+			require.ErrorIs(t, pub.VerifyAnnotations(annotations, []byte(payload+"#\n")), ErrInvalidSignature)
+
+			_, err = priv.Recover(annotations)
+			require.ErrorIs(t, err, ErrNotEncrypted)
+		})
+	}
+}
+
+func TestAsymmetric_EncryptMode(t *testing.T) {
+	t.Parallel()
+
+	for name, kp := range keyPairs(t) {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			priv, err := ParseKey(kp.priv)
+			require.NoError(t, err)
+			pub, err := ParseKey(kp.pub)
+			require.NoError(t, err)
+
+			annotations := map[string]string{}
+			if !kp.canEncrypt {
+				require.ErrorIs(t, priv.Protect(annotations, []byte(payload), ModeEncrypt), ErrCannotEncrypt)
+				return
+			}
+
+			// The publisher only needs the recipient's public key.
+			require.NoError(t, pub.Protect(annotations, []byte(payload), ModeEncrypt))
+			assert.Equal(t, kp.encAlg, annotations[AnnotationEncryptedAlgorithm])
+			assert.NotContains(t, annotations, AnnotationSignature)
+
+			// Only the private key can verify or recover.
+			require.NoError(t, priv.VerifyAnnotations(annotations, []byte(payload)))
+			require.ErrorIs(t, pub.VerifyAnnotations(annotations, []byte(payload)), ErrCannotDecrypt)
+			require.ErrorIs(t, priv.VerifyAnnotations(annotations, []byte("tampered")), ErrTampered)
+
+			plain, err := priv.Recover(annotations)
+			require.NoError(t, err)
+			assert.Equal(t, payload, string(plain))
+
+			// A different key of the same type cannot decrypt.
+			otherPriv, err := ParseKey(regenerate(t, kp))
+			require.NoError(t, err)
+			_, err = otherPriv.Recover(annotations)
+			require.ErrorIs(t, err, ErrDecryption)
+		})
+	}
+}
+
+// regenerate returns a fresh private key of the same type as kp.
+func regenerate(t *testing.T, kp keyPair) []byte {
+	t.Helper()
+	switch kp.encAlg {
+	case AlgRSAOAEP:
+		k, err := rsa.GenerateKey(rand.Reader, 2048)
+		require.NoError(t, err)
+		return pkcs8(t, k)
+	case "ecies-p256-aes-256-gcm":
+		k, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+		require.NoError(t, err)
+		return pkcs8(t, k)
+	default:
+		k, err := ecdh.X25519().GenerateKey(rand.Reader)
+		require.NoError(t, err)
+		return pkcs8(t, k)
+	}
+}
+
+func TestSymmetric_BothModes(t *testing.T) {
+	t.Parallel()
+
+	key, err := ParseKey([]byte("correct horse battery staple"))
+	require.NoError(t, err)
+	other, err := ParseKey([]byte("wrong key"))
+	require.NoError(t, err)
+
+	signed := map[string]string{}
+	require.NoError(t, key.Protect(signed, []byte(payload), ModeSign))
+	require.NoError(t, key.VerifyAnnotations(signed, []byte(payload)))
+	require.ErrorIs(t, key.VerifyAnnotations(signed, []byte("changed")), ErrInvalidSignature)
+	require.ErrorIs(t, other.VerifyAnnotations(signed, []byte(payload)), ErrInvalidSignature)
+
+	encrypted := map[string]string{}
+	require.NoError(t, key.Protect(encrypted, []byte(payload), ModeEncrypt))
+	require.NoError(t, key.VerifyAnnotations(encrypted, []byte(payload)))
+	require.ErrorIs(t, key.VerifyAnnotations(encrypted, []byte("changed")), ErrTampered)
+	_, err = other.Recover(encrypted)
+	require.ErrorIs(t, err, ErrDecryption)
+
+	plain, err := key.Recover(encrypted)
+	require.NoError(t, err)
+	assert.Equal(t, payload, string(plain))
+
+	// Each encryption uses a fresh nonce.
+	again := map[string]string{}
+	require.NoError(t, key.Protect(again, []byte(payload), ModeEncrypt))
+	assert.NotEqual(t, encrypted[AnnotationEncrypted], again[AnnotationEncrypted])
+}
+
+func TestVerifyAnnotations_Errors(t *testing.T) {
+	t.Parallel()
+
+	key, err := ParseKey([]byte("secret"))
+	require.NoError(t, err)
+
+	require.ErrorIs(t, key.VerifyAnnotations(map[string]string{}, []byte(payload)), ErrNotProtected)
+
+	err = key.VerifyAnnotations(map[string]string{
+		AnnotationSignature:          "AAAA",
+		AnnotationSignatureAlgorithm: AlgEd25519,
+	}, []byte(payload))
+	require.ErrorIs(t, err, ErrAlgorithmMism)
+
+	err = key.VerifyAnnotations(map[string]string{
+		AnnotationSignature:          "not base64!",
+		AnnotationSignatureAlgorithm: AlgHMACSHA256,
+	}, []byte(payload))
+	require.ErrorIs(t, err, ErrInvalidSignature)
+
+	err = key.VerifyAnnotations(map[string]string{
+		AnnotationEncrypted:          "AAAA",
+		AnnotationEncryptedAlgorithm: AlgRSAOAEP,
+	}, []byte(payload))
+	require.ErrorIs(t, err, ErrAlgorithmMism)
+
+	err = key.VerifyAnnotations(map[string]string{
+		AnnotationEncrypted:          "AAAA",
+		AnnotationEncryptedAlgorithm: AlgAESGCM,
+	}, []byte(payload))
+	require.ErrorIs(t, err, ErrDecryption)
+
+	require.ErrorContains(t, key.Protect(map[string]string{}, nil, Mode("bogus")), "unknown protection mode")
+}
+
+func TestLoadKey(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "key")
+	require.NoError(t, os.WriteFile(path, []byte("secret"), 0o600))
+
+	key, err := LoadKey(path)
+	require.NoError(t, err)
+	assert.True(t, key.Symmetric())
+
+	_, err = LoadKey(filepath.Join(t.TempDir(), "missing"))
+	require.Error(t, err)
+}

--- a/pkg/protect/protect_test.go
+++ b/pkg/protect/protect_test.go
@@ -145,6 +145,23 @@ func TestParseKey_OpenSSHWithOptions(t *testing.T) {
 
 	_, err = ParseKey([]byte(`from="10.0.0.0/8" ssh-ed25519 AAAAbroken comment`))
 	require.ErrorContains(t, err, "OpenSSH")
+
+	// An option containing the PEM marker must not shadow a valid key line.
+	key = mustParse(t, []byte(`command="echo -----BEGIN" `+string(ssh.MarshalAuthorizedKey(sshPub))))
+	assert.Equal(t, AlgEd25519, key.SignAlgorithm())
+}
+
+func TestParseKey_SecretsMayContainKeyLookingSubstrings(t *testing.T) {
+	t.Parallel()
+
+	for _, s := range []string{
+		"correct-horse-ssh-battery-staple",
+		"ecdsa-sha2-is-just-part-of-my-passphrase",
+		"prefix-----BEGIN-is-not-a-pem-header",
+	} {
+		key := mustParse(t, []byte(s))
+		assert.True(t, key.Symmetric(), s)
+	}
 }
 
 func TestParseKey_RejectsSmallRSA(t *testing.T) {
@@ -284,6 +301,13 @@ func TestAsymmetric_EncryptMode(t *testing.T) {
 			annotations := map[string]string{}
 			if !kp.canEncrypt {
 				require.ErrorIs(t, priv.Protect(annotations, []byte(payload), ModeEncrypt), ErrCannotEncrypt)
+
+				// This key type never produces an encrypted copy, so a signed
+				// artifact carrying one is inconsistent whatever its label.
+				require.NoError(t, priv.Protect(annotations, []byte(payload), ModeSign))
+				annotations[AnnotationEncrypted] = "AAAA"
+				require.ErrorIs(t, verifyErr(pub, annotations, []byte(payload)), ErrAlgorithmMism)
+				require.ErrorIs(t, verifyErr(priv, annotations, []byte(payload)), ErrAlgorithmMism)
 				return
 			}
 

--- a/pkg/protect/protect_test.go
+++ b/pkg/protect/protect_test.go
@@ -1,16 +1,17 @@
 package protect
 
 import (
-	"crypto/ecdh"
 	"crypto/ecdsa"
 	"crypto/ed25519"
 	"crypto/elliptic"
 	"crypto/rand"
 	"crypto/rsa"
 	"crypto/x509"
+	"encoding/base64"
 	"encoding/pem"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -18,7 +19,10 @@ import (
 	"golang.org/x/crypto/ssh"
 )
 
-const payload = "version: \"2\"\nagents:\n  root:\n    model: auto\n"
+const (
+	payload = "version: \"2\"\nagents:\n  root:\n    model: auto\n"
+	secret  = "correct horse battery staple"
+)
 
 func pemEncode(t *testing.T, typ string, der []byte) []byte {
 	t.Helper()
@@ -39,9 +43,15 @@ func pkix(t *testing.T, pub any) []byte {
 	return pemEncode(t, "PUBLIC KEY", der)
 }
 
+func mustParse(t *testing.T, data []byte) *Key {
+	t.Helper()
+	key, err := ParseKey(data)
+	require.NoError(t, err)
+	return key
+}
+
 type keyPair struct {
 	priv, pub  []byte
-	canSign    bool
 	canEncrypt bool
 	signAlg    string
 	encAlg     string
@@ -57,8 +67,6 @@ func keyPairs(t *testing.T) map[string]keyPair {
 	require.NoError(t, err)
 	rsaPriv, err := rsa.GenerateKey(rand.Reader, 2048)
 	require.NoError(t, err)
-	xPriv, err := ecdh.X25519().GenerateKey(rand.Reader)
-	require.NoError(t, err)
 
 	ecSEC1, err := x509.MarshalECPrivateKey(ecPriv)
 	require.NoError(t, err)
@@ -67,10 +75,9 @@ func keyPairs(t *testing.T) map[string]keyPair {
 	sshPub, err := ssh.NewPublicKey(edPub)
 	require.NoError(t, err)
 
-	ed := keyPair{canSign: true, signAlg: AlgEd25519}
-	ec := keyPair{canSign: true, canEncrypt: true, signAlg: AlgECDSASHA256, encAlg: "ecies-p256-aes-256-gcm"}
-	rs := keyPair{canSign: true, canEncrypt: true, signAlg: AlgRSAPSSSHA256, encAlg: AlgRSAOAEP}
-	x := keyPair{canEncrypt: true, encAlg: "ecies-x25519-aes-256-gcm"}
+	ed := keyPair{signAlg: AlgEd25519}
+	ec := keyPair{canEncrypt: true, signAlg: AlgECDSASHA256, encAlg: "ecies-p256-aes-256-gcm"}
+	rs := keyPair{canEncrypt: true, signAlg: AlgRSAPSSSHA256, encAlg: AlgRSAOAEP}
 
 	with := func(kp keyPair, priv, pub []byte) keyPair { kp.priv, kp.pub = priv, pub; return kp }
 
@@ -81,16 +88,15 @@ func keyPairs(t *testing.T) map[string]keyPair {
 		"ecdsa/sec1":         with(ec, pemEncode(t, "EC PRIVATE KEY", ecSEC1), pkix(t, &ecPriv.PublicKey)),
 		"rsa/pkcs8+pkix":     with(rs, pkcs8(t, rsaPriv), pkix(t, &rsaPriv.PublicKey)),
 		"rsa/pkcs1":          with(rs, pemEncode(t, "RSA PRIVATE KEY", x509.MarshalPKCS1PrivateKey(rsaPriv)), pemEncode(t, "RSA PUBLIC KEY", x509.MarshalPKCS1PublicKey(&rsaPriv.PublicKey))),
-		"x25519/pkcs8+pkix":  with(x, pkcs8(t, xPriv), pkix(t, xPriv.PublicKey())),
 	}
 }
 
-func TestParseKey_DetectsSymmetric(t *testing.T) {
+func TestParseKey_Symmetric(t *testing.T) {
 	t.Parallel()
 
-	key, err := ParseKey([]byte("s3cret\n"))
-	require.NoError(t, err)
+	key := mustParse(t, []byte(secret+"\n"))
 	assert.True(t, key.Symmetric())
+	assert.True(t, key.Private())
 	assert.True(t, key.CanSign())
 	assert.True(t, key.CanEncrypt())
 	assert.True(t, key.CanDecrypt())
@@ -98,19 +104,48 @@ func TestParseKey_DetectsSymmetric(t *testing.T) {
 	assert.Equal(t, AlgAESGCM, key.EncryptAlgorithm())
 
 	// Trailing newline must not change the key.
-	same, err := ParseKey([]byte("s3cret"))
-	require.NoError(t, err)
-	assert.Equal(t, key.Fingerprint(), same.Fingerprint())
+	assert.Equal(t, key.Fingerprint(), mustParse(t, []byte(secret)).Fingerprint())
+
+	// The key must not alias the caller's buffer.
+	buf := []byte(secret)
+	aliased := mustParse(t, buf)
+	buf[0] ^= 0xff
+	assert.Equal(t, key.Fingerprint(), aliased.Fingerprint())
 }
 
-func TestParseKey_Errors(t *testing.T) {
+func TestParseKey_RejectsShortSecret(t *testing.T) {
+	t.Parallel()
+	_, err := ParseKey([]byte("  \n"))
+	require.ErrorIs(t, err, ErrSecretTooShort)
+	_, err = ParseKey([]byte(strings.Repeat("x", MinSecretLen-1)))
+	require.ErrorIs(t, err, ErrSecretTooShort)
+	_, err = ParseKey([]byte(strings.Repeat("x", MinSecretLen)))
+	require.NoError(t, err)
+}
+
+func TestParseKey_MalformedAsymmetricIsNotASecret(t *testing.T) {
 	t.Parallel()
 
-	_, err := ParseKey([]byte("  \n"))
-	require.Error(t, err)
+	// Long enough to pass as a secret, but claims to be PEM/OpenSSH.
+	for name, data := range map[string]string{
+		"truncated pem":    "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE\n",
+		"pem no end":       "-----BEGIN PRIVATE KEY-----\nAAAA",
+		"bad ssh base64":   "ssh-ed25519 definitely-not-base64 comment",
+		"bad ecdsa ssh":    "ecdsa-sha2-nistp256 AAAA garbage",
+		"unsupported pem":  string(pemEncode(t, "CERTIFICATE", []byte("junk"))),
+		"unsupported type": string(pemEncode(t, "DSA PARAMETERS", make([]byte, 40))),
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			key, err := ParseKey([]byte(data))
+			require.Error(t, err)
+			assert.Nil(t, key)
+		})
+	}
+}
 
-	_, err = ParseKey(pemEncode(t, "CERTIFICATE", []byte("junk")))
-	require.ErrorContains(t, err, "unsupported PEM block type")
+func TestParseKey_RejectsEncryptedAndX25519(t *testing.T) {
+	t.Parallel()
 
 	_, edPriv, err := ed25519.GenerateKey(rand.Reader)
 	require.NoError(t, err)
@@ -118,6 +153,11 @@ func TestParseKey_Errors(t *testing.T) {
 	require.NoError(t, err)
 	_, err = ParseKey(pem.EncodeToMemory(block))
 	require.ErrorContains(t, err, "passphrase-protected")
+
+	// X25519 cannot sign, so it cannot prove authorship under this model.
+	x25519PKCS8 := "-----BEGIN PRIVATE KEY-----\nMC4CAQAwBQYDK2VuBCIEIIikJ7f7vZ0pE4oSd0kkbPKt+N2eOrdKQ7yhqMXjMkFa\n-----END PRIVATE KEY-----\n"
+	_, err = ParseKey([]byte(x25519PKCS8))
+	require.Error(t, err) // "unsupported key type", or refused earlier by crypto/ecdh in FIPS-only mode
 }
 
 func TestAsymmetric_Capabilities(t *testing.T) {
@@ -126,23 +166,21 @@ func TestAsymmetric_Capabilities(t *testing.T) {
 	for name, kp := range keyPairs(t) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
-			priv, err := ParseKey(kp.priv)
-			require.NoError(t, err)
-			pub, err := ParseKey(kp.pub)
-			require.NoError(t, err)
+			priv, pub := mustParse(t, kp.priv), mustParse(t, kp.pub)
 
 			assert.False(t, priv.Symmetric())
 			assert.True(t, priv.Private())
 			assert.False(t, pub.Private())
 			assert.Equal(t, priv.Fingerprint(), pub.Fingerprint())
+			assert.NotEqual(t, priv.Identity(), pub.Identity())
 
-			assert.Equal(t, kp.canSign, priv.CanSign())
+			assert.True(t, priv.CanSign())
 			assert.False(t, pub.CanSign(), "public keys never sign")
-			assert.Equal(t, kp.canSign, pub.CanVerify())
+			assert.True(t, pub.CanVerify())
 			assert.Equal(t, kp.signAlg, priv.SignAlgorithm())
 
 			assert.Equal(t, kp.canEncrypt, priv.CanEncrypt())
-			assert.Equal(t, kp.canEncrypt, pub.CanEncrypt(), "public keys can encrypt")
+			assert.Equal(t, kp.canEncrypt, pub.CanEncrypt())
 			assert.Equal(t, kp.canEncrypt, priv.CanDecrypt())
 			assert.False(t, pub.CanDecrypt(), "public keys never decrypt")
 			assert.Equal(t, kp.encAlg, priv.EncryptAlgorithm())
@@ -154,15 +192,9 @@ func TestAsymmetric_SignMode(t *testing.T) {
 	t.Parallel()
 
 	for name, kp := range keyPairs(t) {
-		if !kp.canSign {
-			continue
-		}
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
-			priv, err := ParseKey(kp.priv)
-			require.NoError(t, err)
-			pub, err := ParseKey(kp.pub)
-			require.NoError(t, err)
+			priv, pub := mustParse(t, kp.priv), mustParse(t, kp.pub)
 
 			annotations := map[string]string{}
 			require.ErrorIs(t, pub.Protect(annotations, []byte(payload), ModeSign), ErrCannotSign)
@@ -174,7 +206,7 @@ func TestAsymmetric_SignMode(t *testing.T) {
 			require.NoError(t, priv.VerifyAnnotations(annotations, []byte(payload)))
 			require.ErrorIs(t, pub.VerifyAnnotations(annotations, []byte(payload+"#\n")), ErrInvalidSignature)
 
-			_, err = priv.Recover(annotations)
+			_, err := priv.Recover(annotations)
 			require.ErrorIs(t, err, ErrNotEncrypted)
 		})
 	}
@@ -186,10 +218,7 @@ func TestAsymmetric_EncryptMode(t *testing.T) {
 	for name, kp := range keyPairs(t) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
-			priv, err := ParseKey(kp.priv)
-			require.NoError(t, err)
-			pub, err := ParseKey(kp.pub)
-			require.NoError(t, err)
+			priv, pub := mustParse(t, kp.priv), mustParse(t, kp.pub)
 
 			annotations := map[string]string{}
 			if !kp.canEncrypt {
@@ -197,68 +226,126 @@ func TestAsymmetric_EncryptMode(t *testing.T) {
 				return
 			}
 
-			// The publisher only needs the recipient's public key.
-			require.NoError(t, pub.Protect(annotations, []byte(payload), ModeEncrypt))
-			assert.Equal(t, kp.encAlg, annotations[AnnotationEncryptedAlgorithm])
-			assert.NotContains(t, annotations, AnnotationSignature)
+			// Encrypting with only the public key would leave the artifact unauthenticated.
+			require.ErrorIs(t, pub.Protect(annotations, []byte(payload), ModeEncrypt), ErrEncryptNeedsPriv)
+			assert.Empty(t, annotations)
 
-			// Only the private key can verify or recover.
+			require.NoError(t, priv.Protect(annotations, []byte(payload), ModeEncrypt))
+			assert.Equal(t, kp.encAlg, annotations[AnnotationEncryptedAlgorithm])
+			assert.Equal(t, kp.signAlg, annotations[AnnotationSignatureAlgorithm], "encrypt mode must also sign")
+
+			// Private key: signature + decrypt-and-compare. Public key: signature only.
 			require.NoError(t, priv.VerifyAnnotations(annotations, []byte(payload)))
-			require.ErrorIs(t, pub.VerifyAnnotations(annotations, []byte(payload)), ErrCannotDecrypt)
-			require.ErrorIs(t, priv.VerifyAnnotations(annotations, []byte("tampered")), ErrTampered)
+			require.NoError(t, pub.VerifyAnnotations(annotations, []byte(payload)))
+			require.ErrorIs(t, priv.VerifyAnnotations(annotations, []byte("tampered")), ErrInvalidSignature)
+			require.ErrorIs(t, pub.VerifyAnnotations(annotations, []byte("tampered")), ErrInvalidSignature)
 
 			plain, err := priv.Recover(annotations)
 			require.NoError(t, err)
 			assert.Equal(t, payload, string(plain))
+			_, err = pub.Recover(annotations)
+			require.ErrorIs(t, err, ErrCannotDecrypt)
 
 			// A different key of the same type cannot decrypt.
-			otherPriv, err := ParseKey(regenerate(t, kp))
-			require.NoError(t, err)
-			_, err = otherPriv.Recover(annotations)
+			_, err = mustParse(t, regenerate(t, kp)).Recover(annotations)
 			require.ErrorIs(t, err, ErrDecryption)
 		})
 	}
 }
 
+// Anyone holding a public key can encrypt to it. Such a blob must never be
+// accepted as proof that the private-key holder published the artifact,
+// whether presented on its own or as a replacement for a stripped signature.
+func TestAsymmetric_EncryptedCopyAloneIsNotProof(t *testing.T) {
+	t.Parallel()
+
+	for name, kp := range keyPairs(t) {
+		if !kp.canEncrypt {
+			continue
+		}
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			priv, pub := mustParse(t, kp.priv), mustParse(t, kp.pub)
+
+			// Legitimate signed artifact.
+			annotations := map[string]string{}
+			require.NoError(t, priv.Protect(annotations, []byte(payload), ModeSign))
+
+			// Attacker with the public key swaps the layer and downgrades the
+			// signature to an encrypted copy of the malicious content.
+			malicious := []byte("agents:\n  root:\n    instruction: exfiltrate\n")
+			forged, err := pub.Encrypt(malicious)
+			require.NoError(t, err)
+			delete(annotations, AnnotationSignature)
+			delete(annotations, AnnotationSignatureAlgorithm)
+			annotations[AnnotationEncrypted] = base64.StdEncoding.EncodeToString(forged)
+			annotations[AnnotationEncryptedAlgorithm] = pub.EncryptAlgorithm()
+
+			require.ErrorIs(t, priv.VerifyAnnotations(annotations, malicious), ErrNotSigned)
+			require.ErrorIs(t, pub.VerifyAnnotations(annotations, malicious), ErrNotSigned)
+
+			// Recover still works (it is not a verification), but is explicit about that.
+			plain, err := priv.Recover(annotations)
+			require.NoError(t, err)
+			assert.Equal(t, malicious, plain)
+		})
+	}
+}
+
+// Replacing the encrypted copy in a sign+encrypt artifact with an attacker's
+// encryption of different content must be caught by the signature.
+func TestAsymmetric_SwappedEncryptedCopyIsDetected(t *testing.T) {
+	t.Parallel()
+
+	kp := keyPairs(t)["ecdsa/pkcs8+pkix"]
+	priv, pub := mustParse(t, kp.priv), mustParse(t, kp.pub)
+
+	annotations := map[string]string{}
+	require.NoError(t, priv.Protect(annotations, []byte(payload), ModeEncrypt))
+
+	malicious := []byte("malicious")
+	forged, err := pub.Encrypt(malicious)
+	require.NoError(t, err)
+	annotations[AnnotationEncrypted] = base64.StdEncoding.EncodeToString(forged)
+
+	// Layer swapped too: signature fails. Layer intact: copy mismatch.
+	require.ErrorIs(t, priv.VerifyAnnotations(annotations, malicious), ErrInvalidSignature)
+	require.ErrorIs(t, priv.VerifyAnnotations(annotations, []byte(payload)), ErrTampered)
+}
+
 // regenerate returns a fresh private key of the same type as kp.
 func regenerate(t *testing.T, kp keyPair) []byte {
 	t.Helper()
-	switch kp.encAlg {
-	case AlgRSAOAEP:
+	if kp.encAlg == AlgRSAOAEP {
 		k, err := rsa.GenerateKey(rand.Reader, 2048)
 		require.NoError(t, err)
 		return pkcs8(t, k)
-	case "ecies-p256-aes-256-gcm":
-		k, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
-		require.NoError(t, err)
-		return pkcs8(t, k)
-	default:
-		k, err := ecdh.X25519().GenerateKey(rand.Reader)
-		require.NoError(t, err)
-		return pkcs8(t, k)
 	}
+	k, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	return pkcs8(t, k)
 }
 
 func TestSymmetric_BothModes(t *testing.T) {
 	t.Parallel()
 
-	key, err := ParseKey([]byte("correct horse battery staple"))
-	require.NoError(t, err)
-	other, err := ParseKey([]byte("wrong key"))
-	require.NoError(t, err)
+	key := mustParse(t, []byte(secret))
+	other := mustParse(t, []byte("a completely different secret"))
 
 	signed := map[string]string{}
 	require.NoError(t, key.Protect(signed, []byte(payload), ModeSign))
+	assert.NotContains(t, signed, AnnotationEncrypted)
 	require.NoError(t, key.VerifyAnnotations(signed, []byte(payload)))
 	require.ErrorIs(t, key.VerifyAnnotations(signed, []byte("changed")), ErrInvalidSignature)
 	require.ErrorIs(t, other.VerifyAnnotations(signed, []byte(payload)), ErrInvalidSignature)
 
+	// With a secret, the AEAD copy alone is proof: producing it needs the secret.
 	encrypted := map[string]string{}
 	require.NoError(t, key.Protect(encrypted, []byte(payload), ModeEncrypt))
+	assert.NotContains(t, encrypted, AnnotationSignature)
 	require.NoError(t, key.VerifyAnnotations(encrypted, []byte(payload)))
 	require.ErrorIs(t, key.VerifyAnnotations(encrypted, []byte("changed")), ErrTampered)
-	_, err = other.Recover(encrypted)
-	require.ErrorIs(t, err, ErrDecryption)
+	require.ErrorIs(t, other.VerifyAnnotations(encrypted, []byte(payload)), ErrDecryption)
 
 	plain, err := key.Recover(encrypted)
 	require.NoError(t, err)
@@ -270,15 +357,37 @@ func TestSymmetric_BothModes(t *testing.T) {
 	assert.NotEqual(t, encrypted[AnnotationEncrypted], again[AnnotationEncrypted])
 }
 
+// Signatures and ciphertexts are bound to this protocol and their algorithm
+// label; raw primitives over the same bytes must not verify.
+func TestDomainSeparation(t *testing.T) {
+	t.Parallel()
+
+	kp := keyPairs(t)["ed25519/pkcs8+pkix"]
+	priv, pub := mustParse(t, kp.priv), mustParse(t, kp.pub)
+	rawSig := ed25519.Sign(priv.priv.(ed25519.PrivateKey), []byte(payload))
+	require.ErrorIs(t, pub.Verify([]byte(payload), rawSig), ErrInvalidSignature)
+
+	key := mustParse(t, []byte(secret))
+	annotations := map[string]string{}
+	require.NoError(t, key.Protect(annotations, []byte(payload), ModeEncrypt))
+	// Relabeling the algorithm changes the AAD and must break decryption, not
+	// just the label check.
+	blob, err := base64.StdEncoding.DecodeString(annotations[AnnotationEncrypted])
+	require.NoError(t, err)
+	derived, err := deriveKey(key.secret, "docker-agent/"+AlgAESGCM)
+	require.NoError(t, err)
+	_, err = aeadOpen(derived, blob, domainInput("encrypt", "other-alg", nil))
+	require.ErrorIs(t, err, ErrDecryption)
+}
+
 func TestVerifyAnnotations_Errors(t *testing.T) {
 	t.Parallel()
 
-	key, err := ParseKey([]byte("secret"))
-	require.NoError(t, err)
+	key := mustParse(t, []byte(secret))
 
 	require.ErrorIs(t, key.VerifyAnnotations(map[string]string{}, []byte(payload)), ErrNotProtected)
 
-	err = key.VerifyAnnotations(map[string]string{
+	err := key.VerifyAnnotations(map[string]string{
 		AnnotationSignature:          "AAAA",
 		AnnotationSignatureAlgorithm: AlgEd25519,
 	}, []byte(payload))
@@ -296,11 +405,17 @@ func TestVerifyAnnotations_Errors(t *testing.T) {
 	}, []byte(payload))
 	require.ErrorIs(t, err, ErrAlgorithmMism)
 
-	err = key.VerifyAnnotations(map[string]string{
-		AnnotationEncrypted:          "AAAA",
-		AnnotationEncryptedAlgorithm: AlgAESGCM,
-	}, []byte(payload))
-	require.ErrorIs(t, err, ErrDecryption)
+	for _, blob := range []string{"", "AAAA", "not base64!", base64.StdEncoding.EncodeToString(make([]byte, 11))} {
+		err = key.VerifyAnnotations(map[string]string{
+			AnnotationEncrypted:          blob,
+			AnnotationEncryptedAlgorithm: AlgAESGCM,
+		}, []byte(payload))
+		if blob == "" {
+			require.ErrorIs(t, err, ErrNotProtected)
+		} else {
+			require.ErrorIs(t, err, ErrDecryption)
+		}
+	}
 
 	require.ErrorContains(t, key.Protect(map[string]string{}, nil, Mode("bogus")), "unknown protection mode")
 }
@@ -309,7 +424,7 @@ func TestLoadKey(t *testing.T) {
 	t.Parallel()
 
 	path := filepath.Join(t.TempDir(), "key")
-	require.NoError(t, os.WriteFile(path, []byte("secret"), 0o600))
+	require.NoError(t, os.WriteFile(path, []byte(secret), 0o600))
 
 	key, err := LoadKey(path)
 	require.NoError(t, err)

--- a/pkg/protect/protect_test.go
+++ b/pkg/protect/protect_test.go
@@ -160,16 +160,17 @@ func TestParseKey_SecretsMustNotLookLikeKeys(t *testing.T) {
 	for _, s := range []string{
 		"ecdsa-sha2-is-just-part-of-my-passphrase",
 		"my passphrase ssh-rsa is long enough",
+		"correct-horse-ssh-battery-staple",
 		"prefix-----BEGIN-is-not-a-pem-header",
 	} {
 		_, err := ParseKey([]byte(s))
 		require.ErrorContains(t, err, "a raw secret must not contain", s)
 	}
 
-	// While ordinary and random secrets are fine, even with "ssh-" mid-word.
+	// While ordinary and random secrets are fine.
 	for _, s := range []string{
 		"correct horse battery staple",
-		"correct-horse-ssh-battery-staple",
+		"a-secret-with-sshd-in-it-is-fine", // "sshd-" is not a key type
 		"3f9c2a1b4e8d7c6f5a0b9e8d7c6f5a4b3c2d1e0f",
 	} {
 		assert.True(t, mustParse(t, []byte(s)).Symmetric(), s)
@@ -224,6 +225,8 @@ func TestParseKey_MalformedAsymmetricIsNotASecret(t *testing.T) {
 		"bad ssh options":  `command="x" ssh-rsa AAAA garbage`,
 		"truncated ssh":    "ecdsa-sha2-nistp256",
 		"truncated ssh 2":  "command=x ecdsa-sha2-nistp256\n",
+		"bom ssh":          "\xef\xbb\xbfssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGb0l7v5+6E4CMbQ7v9k1Yl6vX0+dTn3vE0jvFq6gFqK",
+		"garbage ssh":      "garbagessh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGb0l7v5+6E4CMbQ7v9k1Yl6vX0+dTn3vE0jvFq6gFqK",
 		"bom pem":          "\xef\xbb\xbf-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE\n-----END PUBLIC KEY-----\n",
 		"garbage pem":      "garbage-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE\n-----END PUBLIC KEY-----\n",
 		"unsupported pem":  string(pemEncode(t, "CERTIFICATE", []byte("junk"))),

--- a/pkg/protect/protect_test.go
+++ b/pkg/protect/protect_test.go
@@ -151,16 +151,28 @@ func TestParseKey_OpenSSHWithOptions(t *testing.T) {
 	assert.Equal(t, AlgEd25519, key.SignAlgorithm())
 }
 
-func TestParseKey_SecretsMayContainKeyLookingSubstrings(t *testing.T) {
+// A secret is never allowed to look like a key file: such input is far more
+// likely a broken public key than a deliberate passphrase, and accepting it
+// would protect artifacts with public material.
+func TestParseKey_SecretsMustNotLookLikeKeys(t *testing.T) {
 	t.Parallel()
 
 	for _, s := range []string{
-		"correct-horse-ssh-battery-staple",
 		"ecdsa-sha2-is-just-part-of-my-passphrase",
+		"my passphrase ssh-rsa is long enough",
 		"prefix-----BEGIN-is-not-a-pem-header",
 	} {
-		key := mustParse(t, []byte(s))
-		assert.True(t, key.Symmetric(), s)
+		_, err := ParseKey([]byte(s))
+		require.ErrorContains(t, err, "a raw secret must not contain", s)
+	}
+
+	// While ordinary and random secrets are fine, even with "ssh-" mid-word.
+	for _, s := range []string{
+		"correct horse battery staple",
+		"correct-horse-ssh-battery-staple",
+		"3f9c2a1b4e8d7c6f5a0b9e8d7c6f5a4b3c2d1e0f",
+	} {
+		assert.True(t, mustParse(t, []byte(s)).Symmetric(), s)
 	}
 }
 
@@ -210,6 +222,10 @@ func TestParseKey_MalformedAsymmetricIsNotASecret(t *testing.T) {
 		"bad ssh base64":   "ssh-ed25519 definitely-not-base64 comment",
 		"bad ecdsa ssh":    "ecdsa-sha2-nistp256 AAAA garbage",
 		"bad ssh options":  `command="x" ssh-rsa AAAA garbage`,
+		"truncated ssh":    "ecdsa-sha2-nistp256",
+		"truncated ssh 2":  "command=x ecdsa-sha2-nistp256\n",
+		"bom pem":          "\xef\xbb\xbf-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE\n-----END PUBLIC KEY-----\n",
+		"garbage pem":      "garbage-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE\n-----END PUBLIC KEY-----\n",
 		"unsupported pem":  string(pemEncode(t, "CERTIFICATE", []byte("junk"))),
 		"unsupported type": string(pemEncode(t, "DSA PARAMETERS", make([]byte, 40))),
 	} {

--- a/pkg/protect/sign.go
+++ b/pkg/protect/sign.go
@@ -1,0 +1,106 @@
+package protect
+
+import (
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/ed25519"
+	"crypto/hmac"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"errors"
+	"fmt"
+)
+
+const (
+	AlgHMACSHA256   = "hmac-sha256"
+	AlgEd25519      = "ed25519"
+	AlgECDSASHA256  = "ecdsa-sha256"
+	AlgRSAPSSSHA256 = "rsa-pss-sha256"
+)
+
+var (
+	ErrInvalidSignature = errors.New("signature verification failed")
+	ErrCannotSign       = errors.New("key cannot sign: a private key or secret is required")
+)
+
+// SignAlgorithm returns the signature algorithm this key supports, or "" if
+// the key type cannot sign or verify (e.g. X25519).
+func (k *Key) SignAlgorithm() string {
+	if k.Symmetric() {
+		return AlgHMACSHA256
+	}
+	switch k.pub.(type) {
+	case ed25519.PublicKey:
+		return AlgEd25519
+	case *ecdsa.PublicKey:
+		return AlgECDSASHA256
+	case *rsa.PublicKey:
+		return AlgRSAPSSSHA256
+	default:
+		return ""
+	}
+}
+
+// CanSign reports whether the key can produce signatures.
+func (k *Key) CanSign() bool { return k.SignAlgorithm() != "" && k.Private() }
+
+// CanVerify reports whether the key can verify signatures.
+func (k *Key) CanVerify() bool { return k.SignAlgorithm() != "" }
+
+// Sign returns the raw signature (or MAC) of data.
+func (k *Key) Sign(data []byte) ([]byte, error) {
+	if !k.CanSign() {
+		return nil, ErrCannotSign
+	}
+	switch p := k.priv.(type) {
+	case nil:
+		mac := hmac.New(sha256.New, k.secret)
+		mac.Write(data)
+		return mac.Sum(nil), nil
+	case ed25519.PrivateKey:
+		return ed25519.Sign(p, data), nil
+	case *ecdsa.PrivateKey:
+		h := sha256.Sum256(data)
+		return ecdsa.SignASN1(rand.Reader, p, h[:])
+	case *rsa.PrivateKey:
+		h := sha256.Sum256(data)
+		return rsa.SignPSS(rand.Reader, p, crypto.SHA256, h[:], rsaPSSOptions())
+	default:
+		return nil, ErrCannotSign
+	}
+}
+
+// Verify checks that sig is a valid signature of data for this key.
+func (k *Key) Verify(data, sig []byte) error {
+	var ok bool
+	switch p := k.pub.(type) {
+	case nil:
+		if !k.Symmetric() {
+			return fmt.Errorf("%w: key cannot verify", ErrInvalidSignature)
+		}
+		expected, err := k.Sign(data)
+		if err != nil {
+			return err
+		}
+		ok = hmac.Equal(expected, sig)
+	case ed25519.PublicKey:
+		ok = ed25519.Verify(p, data, sig)
+	case *ecdsa.PublicKey:
+		h := sha256.Sum256(data)
+		ok = ecdsa.VerifyASN1(p, h[:], sig)
+	case *rsa.PublicKey:
+		h := sha256.Sum256(data)
+		ok = rsa.VerifyPSS(p, crypto.SHA256, h[:], sig, rsaPSSOptions()) == nil
+	default:
+		return fmt.Errorf("%w: key type cannot verify signatures", ErrInvalidSignature)
+	}
+	if !ok {
+		return ErrInvalidSignature
+	}
+	return nil
+}
+
+func rsaPSSOptions() *rsa.PSSOptions {
+	return &rsa.PSSOptions{SaltLength: rsa.PSSSaltLengthEqualsHash, Hash: crypto.SHA256}
+}

--- a/pkg/protect/sign.go
+++ b/pkg/protect/sign.go
@@ -9,7 +9,6 @@ import (
 	"crypto/rsa"
 	"crypto/sha256"
 	"errors"
-	"fmt"
 )
 
 const (
@@ -22,10 +21,10 @@ const (
 var (
 	ErrInvalidSignature = errors.New("signature verification failed")
 	ErrCannotSign       = errors.New("key cannot sign: a private key or secret is required")
+	ErrCannotVerify     = errors.New("key cannot verify signatures")
 )
 
-// SignAlgorithm returns the signature algorithm this key supports, or "" if
-// the key type cannot sign or verify (e.g. X25519).
+// SignAlgorithm returns the signature algorithm this key supports.
 func (k *Key) SignAlgorithm() string {
 	if k.Symmetric() {
 		return AlgHMACSHA256
@@ -48,23 +47,26 @@ func (k *Key) CanSign() bool { return k.SignAlgorithm() != "" && k.Private() }
 // CanVerify reports whether the key can verify signatures.
 func (k *Key) CanVerify() bool { return k.SignAlgorithm() != "" }
 
-// Sign returns the raw signature (or MAC) of data.
+// Sign returns the raw signature (or MAC) of data. The signed message is
+// domain-separated (see domainInput) so a signature cannot be reused in
+// another protocol or under another algorithm label.
 func (k *Key) Sign(data []byte) ([]byte, error) {
 	if !k.CanSign() {
 		return nil, ErrCannotSign
 	}
+	msg := domainInput("sign", k.SignAlgorithm(), data)
 	switch p := k.priv.(type) {
 	case nil:
 		mac := hmac.New(sha256.New, k.secret)
-		mac.Write(data)
+		mac.Write(msg)
 		return mac.Sum(nil), nil
 	case ed25519.PrivateKey:
-		return ed25519.Sign(p, data), nil
+		return ed25519.Sign(p, msg), nil
 	case *ecdsa.PrivateKey:
-		h := sha256.Sum256(data)
+		h := sha256.Sum256(msg)
 		return ecdsa.SignASN1(rand.Reader, p, h[:])
 	case *rsa.PrivateKey:
-		h := sha256.Sum256(data)
+		h := sha256.Sum256(msg)
 		return rsa.SignPSS(rand.Reader, p, crypto.SHA256, h[:], rsaPSSOptions())
 	default:
 		return nil, ErrCannotSign
@@ -73,32 +75,38 @@ func (k *Key) Sign(data []byte) ([]byte, error) {
 
 // Verify checks that sig is a valid signature of data for this key.
 func (k *Key) Verify(data, sig []byte) error {
+	if !k.CanVerify() {
+		return ErrCannotVerify
+	}
+	msg := domainInput("sign", k.SignAlgorithm(), data)
 	var ok bool
 	switch p := k.pub.(type) {
 	case nil:
-		if !k.Symmetric() {
-			return fmt.Errorf("%w: key cannot verify", ErrInvalidSignature)
-		}
 		expected, err := k.Sign(data)
 		if err != nil {
 			return err
 		}
 		ok = hmac.Equal(expected, sig)
 	case ed25519.PublicKey:
-		ok = ed25519.Verify(p, data, sig)
+		ok = ed25519.Verify(p, msg, sig)
 	case *ecdsa.PublicKey:
-		h := sha256.Sum256(data)
+		h := sha256.Sum256(msg)
 		ok = ecdsa.VerifyASN1(p, h[:], sig)
 	case *rsa.PublicKey:
-		h := sha256.Sum256(data)
+		h := sha256.Sum256(msg)
 		ok = rsa.VerifyPSS(p, crypto.SHA256, h[:], sig, rsaPSSOptions()) == nil
-	default:
-		return fmt.Errorf("%w: key type cannot verify signatures", ErrInvalidSignature)
 	}
 	if !ok {
 		return ErrInvalidSignature
 	}
 	return nil
+}
+
+// domainInput prefixes data with a protocol/purpose/algorithm header. NUL
+// separators keep the header unambiguous since none of the fields contain NUL.
+func domainInput(purpose, alg string, data []byte) []byte {
+	header := "docker-agent/agent-yaml/v1\x00" + purpose + "\x00" + alg + "\x00"
+	return append([]byte(header), data...)
 }
 
 func rsaPSSOptions() *rsa.PSSOptions {


### PR DESCRIPTION
Agents shared via OCI registries have no integrity protection today — any actor that can push to a registry can serve a modified YAML to every consumer. This change adds optional signing and encryption so that publishers can prove provenance and consumers can verify it before the agent runs.

`docker agent share push` gains a `--key <file>` flag. On push the YAML is always stored in clear in the OCI layer; a proof (signature or AEAD-encrypted copy) is recorded in manifest annotations (`io.docker.agent.signature`, `io.docker.agent.encrypted`, plus algorithm variants). `docker agent share pull --key <file>` reads back those annotations and verifies them, reporting exactly what was checked. `config.Resolve` and `config.NewOCISource` accept a `config.WithVerificationKey` option so embedders that load agents from OCI automatically verify on every read.

Key detection is fully automatic: PEM (PKCS#1/SEC1/PKCS#8/SPKI) and OpenSSH formats (private keys and `authorized_keys` lines, with or without options) map to Ed25519, ECDSA-SHA256, or RSA-PSS/OAEP; anything else that is at least 16 bytes is treated as a raw symmetric secret (e.g. `openssl rand -hex 32` for HMAC-SHA256 / AES-256-GCM). Input that looks like a key file but fails to parse is rejected rather than silently falling back to secret mode. With asymmetric keys a signature is always required — encrypting to a public key alone proves nothing about the publisher and would open a downgrade path. Signatures and AEAD blobs are domain-separated. Verification results are memoized per key identity. The implementation is compatible with `GODEBUG=fips140=only`.

The `--encrypt` flag additionally stores an AEAD-encrypted copy of the full YAML in the annotation (AES-256-GCM via HKDF from a secret; ephemeral-ECDH+HKDF+AES-GCM for ECDSA; RSA-OAEP-wrapped AES-GCM for RSA), allowing key holders to recover the YAML from the annotation alone via `Key.Recover`. Signatures cover the YAML bytes as stored: re-tagging a signed layer under a new reference is not detected; pin digests when that matters.