### PR TITLE
fix(share): push HCL configs as resolved, self-contained YAML

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -53,7 +53,7 @@ func Load(ctx context.Context, source Source, opts ...LoadOption) (*latest.Confi
 	// Detect the format from the source name extension or, when no hint is
 	// available (OCI artifacts, etc.), from the content itself, then
 	// transparently convert to YAML for the rest of the pipeline.
-	if isHCLSource(source.Name(), data) {
+	if IsHCLSource(source.Name(), data) {
 		data, err = hclconv.ToYAML(data, source.Name())
 		if err != nil {
 			return nil, fmt.Errorf("parsing HCL config file: %w", err)
@@ -400,10 +400,10 @@ func validateForceHandoffs(cfg *latest.Config, allNames map[string]bool) error {
 	return nil
 }
 
-// isHCLSource reports whether the configuration data should be parsed as HCL
+// IsHCLSource reports whether the configuration data should be parsed as HCL
 // rather than YAML. The decision is based first on the source name extension,
 // and then on a content-based heuristic when no extension hint is available.
-func isHCLSource(name string, data []byte) bool {
+func IsHCLSource(name string, data []byte) bool {
 	if strings.EqualFold(filepath.Ext(name), ".hcl") {
 		return true
 	}

--- a/pkg/oci/package.go
+++ b/pkg/oci/package.go
@@ -1,7 +1,6 @@
 package oci
 
 import (
-	"cmp"
 	"context"
 	"fmt"
 	"path/filepath"
@@ -16,7 +15,6 @@ import (
 	"github.com/google/go-containerregistry/pkg/v1/types"
 
 	"github.com/docker/docker-agent/pkg/config"
-	"github.com/docker/docker-agent/pkg/config/latest"
 	"github.com/docker/docker-agent/pkg/content"
 	"github.com/docker/docker-agent/pkg/protect"
 	"github.com/docker/docker-agent/pkg/version"
@@ -60,20 +58,24 @@ func PackageFileAsOCIToStore(ctx context.Context, agentSource config.Source, art
 	if err != nil {
 		return "", fmt.Errorf("reading file: %w", err)
 	}
-	if err := yaml.Unmarshal(data, &raw); err != nil {
-		return "", fmt.Errorf("looking for version in config file\n%s", yaml.FormatError(err, true, true))
+	isHCL := config.IsHCLSource(agentSource.Name(), data)
+	if !isHCL {
+		if err := yaml.Unmarshal(data, &raw); err != nil {
+			return "", fmt.Errorf("looking for version in config file\n%s", yaml.FormatError(err, true, true))
+		}
 	}
 
 	// Push a self-contained artifact. Normally we preserve the author's raw
 	// bytes (keeping comments and formatting), but we must serialize the
 	// resolved config instead when either:
-	//   - the config has no version (we inject the latest one), or
+	//   - the config has no version (config.Load injected the latest one),
+	//   - the config is HCL: its file() calls resolve against the local
+	//     directory, and the artifact is always stored as YAML, or
 	//   - any agent uses instruction_file: its contents have already been
 	//     inlined into Instruction by config.Load, and a pulled artifact has
 	//     no local directory to resolve the original path against, so the raw
 	//     reference would be unreadable.
-	if raw.Version == "" || configUsesInstructionFile(data) {
-		cfg.Version = cmp.Or(raw.Version, latest.Version)
+	if raw.Version == "" || isHCL || configUsesInstructionFile(data) {
 		data, err = yaml.MarshalWithOptions(cfg, yaml.Indent(2))
 		if err != nil {
 			return "", fmt.Errorf("marshaling config: %w", err)

--- a/pkg/oci/package_test.go
+++ b/pkg/oci/package_test.go
@@ -141,6 +141,63 @@ agents:
 	assert.Equal(t, "You are a self-contained agent.", cfg.Agents.First().Instruction)
 }
 
+func TestPackageFileAsOCIToStore_HCLInlinesLocalFiles(t *testing.T) {
+	t.Parallel()
+	// HCL configs resolve both instruction_file and file() against the local
+	// directory, so they are always pushed as the resolved YAML.
+	dir := t.TempDir()
+	agentFilename := filepath.Join(dir, "agent.hcl")
+	testContent := `agent "root" {
+  model            = "auto"
+  description      = "Root agent"
+  instruction_file = "prompts/root.md"
+  sub_agents       = ["helper"]
+}
+
+agent "helper" {
+  model       = "auto"
+  description = "Helper agent"
+  instruction = file("prompts/helper.md")
+}
+`
+	require.NoError(t, os.WriteFile(agentFilename, []byte(testContent), 0o644))
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "prompts"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "prompts", "root.md"), []byte("You are the root."), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "prompts", "helper.md"), []byte("You are the helper."), 0o644))
+
+	store, err := content.NewStore(content.WithBaseDir(t.TempDir()))
+	require.NoError(t, err)
+
+	agentSource, err := config.Resolve(agentFilename, nil)
+	require.NoError(t, err)
+
+	tag := "test-hcl-instruction-file:v1.0.0"
+	digest, err := PackageFileAsOCIToStore(t.Context(), agentSource, tag, store)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = store.DeleteArtifact(digest) })
+
+	img, err := store.GetArtifactImage(tag)
+	require.NoError(t, err)
+	layers, err := img.Layers()
+	require.NoError(t, err)
+	require.Len(t, layers, 1)
+	reader, err := layers[0].Uncompressed()
+	require.NoError(t, err)
+	defer reader.Close()
+	data, err := io.ReadAll(reader)
+	require.NoError(t, err)
+
+	assert.Contains(t, string(data), "You are the root.")
+	assert.Contains(t, string(data), "You are the helper.")
+	assert.NotContains(t, string(data), "instruction_file")
+	assert.NotContains(t, string(data), "file(")
+
+	// The pushed artifact is YAML that loads without the original directory.
+	cfg, err := config.Load(t.Context(), config.NewBytesSource("pulled.yaml", data))
+	require.NoError(t, err)
+	assert.Equal(t, "You are the root.", cfg.Agents.First().Instruction)
+}
+
 func TestPackageFileAsOCIToStoreInvalidTag(t *testing.T) {
 	t.Parallel()
 	agentFilename := filepath.Join(t.TempDir(), "test.txt")


### PR DESCRIPTION
`docker agent share push` was broken for any HCL agent: the code tried to sniff the config version by unmarshalling the raw file bytes as YAML, which fails for HCL and produced the error "looking for version in config file". As a result, HCL agents — including those that reference prompts via `instruction_file` or the `file()` template function — could not be pushed to OCI registries at all.

The fix detects HCL sources via the newly exported `config.IsHCLSource` and skips the YAML version sniff for them. For HCL configs the pushed bytes are always serialized from the already-loaded config struct, so `instruction_file` references and `file()` calls (including template variables) are inlined into the artifact. The pushed artifact is plain YAML that needs no local directory to be useful. A redundant `cfg.Version = cmp.Or(raw.Version, latest.Version)` assignment was also removed — `config.Load` already sets the version correctly, and for HCL it would have clobbered a declared value.

YAML `instruction_file` inlining was already supported; this closes the same gap for HCL sources. No breaking changes or follow-up work expected.