### PR TITLE
fix(runtime): deliver StreamStopped with a bounded blocking send

### DIFF
--- a/pkg/a2a/adapter.go
+++ b/pkg/a2a/adapter.go
@@ -135,6 +135,21 @@ func runDockerAgent(ctx agent.InvocationContext, t *team.Team, agentName string,
 		// Track accumulated content for chunked responses
 		var contentBuilder strings.Builder
 
+		// finalEvent builds the turn-complete ADK event from whatever content
+		// was accumulated so far. Shared by the StreamStoppedEvent case and the
+		// post-loop fallback below, so both paths build an identical event.
+		finalEvent := func() *adksession.Event {
+			return &adksession.Event{
+				Author: agentName,
+				LLMResponse: model.LLMResponse{
+					Content:      genai.NewContentFromParts([]*genai.Part{{Text: contentBuilder.String()}}, genai.RoleModel),
+					Partial:      false,
+					TurnComplete: true,
+					FinishReason: genai.FinishReasonStop,
+				},
+			}
+		}
+
 		// Convert docker agent events to ADK events and yield them
 
 		for event := range eventsChan {
@@ -171,19 +186,18 @@ func runDockerAgent(ctx agent.InvocationContext, t *team.Team, agentName string,
 			case *runtime.StreamStoppedEvent:
 				// Send final complete event with all accumulated content
 				if contentBuilder.Len() > 0 {
-					finalEvent := &adksession.Event{
-						Author: agentName,
-						LLMResponse: model.LLMResponse{
-							Content:      genai.NewContentFromParts([]*genai.Part{{Text: contentBuilder.String()}}, genai.RoleModel),
-							Partial:      false,
-							TurnComplete: true,
-							FinishReason: genai.FinishReasonStop,
-						},
-					}
-					yield(finalEvent, nil)
+					yield(finalEvent(), nil)
 					return
 				}
 			}
+		}
+
+		// The channel closed without a StreamStoppedEvent: the runtime bounds
+		// how long it waits to deliver that event (#4136), but a consumer that
+		// abandoned the channel or an unexpected close should still complete
+		// the ADK turn rather than leave it hanging.
+		if contentBuilder.Len() > 0 {
+			yield(finalEvent(), nil)
 		}
 	}
 }

--- a/pkg/runtime/defaults.go
+++ b/pkg/runtime/defaults.go
@@ -46,6 +46,15 @@ const defaultMaxOverflowCompactions = 1
 // allowed to wedge the caller indefinitely.
 const toolsChangedTimeout = 5 * time.Second
 
+// defaultStreamStoppedDeliveryTimeout bounds how long finalizeEventChannel
+// waits to deliver StreamStopped when the event buffer is full. 128 buffered
+// events at roughly a millisecond each for a synchronous per-delta SQLite
+// write (the common back-pressure source, see #4136) drain in ~130ms; 5s is
+// comfortably above that for any consumer still reading, while still bounding
+// teardown once a consumer has abandoned the channel (the #3070 deadlock this
+// replaces). Tests shrink it via the streamStoppedDeliveryTimeout field.
+const defaultStreamStoppedDeliveryTimeout = 5 * time.Second
+
 // defaultToolListTimeout bounds how long EmitStartupInfo waits for a single
 // toolset to enumerate its tools while populating the sidebar. A toolset
 // whose Tools() blocks indefinitely — e.g. an MCP stdio subprocess that

--- a/pkg/runtime/elicitation_test.go
+++ b/pkg/runtime/elicitation_test.go
@@ -209,10 +209,17 @@ func TestLocalRuntime_FinalizeEventChannelEmitsStreamStoppedOnce(t *testing.T) {
 	assert.Equal(t, 1, stopped, "StreamStopped should be emitted exactly once")
 }
 
-func TestLocalRuntime_FinalizeEventChannelDoesNotDeadlockWhenBufferFullAndConsumerGone(t *testing.T) {
+// TestLocalRuntime_FinalizeEventChannelDropsStreamStoppedAfterBoundedTimeout
+// pins the #4136 fix's bound: the StreamStopped send waits for the
+// abandoned-consumer timeout (proving it is a bounded blocking send, not the
+// old plain non-blocking one) but still returns — and still drops the event
+// — rather than hanging forever when nothing ever drains the buffer.
+func TestLocalRuntime_FinalizeEventChannelDropsStreamStoppedAfterBoundedTimeout(t *testing.T) {
 	t.Parallel()
 
 	rt := newElicitationTestRuntime(t)
+	const timeout = 50 * time.Millisecond
+	rt.streamStoppedDeliveryTimeout = timeout
 	sess := session.New()
 	events := make(chan Event, 1)
 	parent := make(chan Event, 1)
@@ -220,6 +227,7 @@ func TestLocalRuntime_FinalizeEventChannelDoesNotDeadlockWhenBufferFullAndConsum
 	rt.elicitation.swap(events)
 
 	done := make(chan struct{})
+	start := time.Now()
 	go func() {
 		rt.finalizeEventChannel(t.Context(), sess, turnEndReasonNormal, parent, events)
 		close(done)
@@ -227,9 +235,13 @@ func TestLocalRuntime_FinalizeEventChannelDoesNotDeadlockWhenBufferFullAndConsum
 
 	select {
 	case <-done:
-	case <-time.After(time.Second):
+	case <-time.After(timeout + 2*time.Second):
 		t.Fatal("finalizeEventChannel deadlocked with a full buffer and no consumer")
 	}
+	elapsed := time.Since(start)
+
+	assert.GreaterOrEqual(t, elapsed, timeout, "the send should wait out the full deadline before giving up")
+	assert.Less(t, elapsed, timeout+2*time.Second, "finalizeEventChannel should return shortly after the deadline, not hang")
 
 	var stopped int
 	for ev := range events {
@@ -237,7 +249,7 @@ func TestLocalRuntime_FinalizeEventChannelDoesNotDeadlockWhenBufferFullAndConsum
 			stopped++
 		}
 	}
-	assert.Zero(t, stopped, "StreamStopped should be dropped instead of blocking when the buffer is full")
+	assert.Zero(t, stopped, "StreamStopped should be dropped instead of blocking forever when the buffer is full and abandoned")
 }
 
 // TestLocalRuntime_FinalizeEventChannelStreamStoppedIsLastBeforeClose pins the

--- a/pkg/runtime/event.go
+++ b/pkg/runtime/event.go
@@ -586,11 +586,13 @@ func (e *SessionCompactionEvent) GetSessionID() string { return e.SessionID }
 // the turnEndReason* classification (normal, error, canceled) so consumers can
 // tell successful completion apart from crashes and user-initiated stops.
 //
-// Delivery is best-effort: it is emitted non-blockingly during teardown and is
-// dropped if the events buffer is full and the consumer has gone away (see
-// finalizeEventChannel). Treat the channel close, not receipt of this event, as
-// the guaranteed terminal signal. Do not assume session-end hooks have finished
-// when this event arrives: it is emitted before they run.
+// Delivery is bounded-blocking: finalizeEventChannel waits (up to a deadline)
+// for the consumer to accept it, so any consumer still draining the channel
+// reliably receives it, and it is dropped only once the consumer has
+// abandoned the channel entirely (#4136). Still, treat the channel close, not
+// receipt of this event, as the guaranteed terminal signal — it remains the
+// only delivery that can never be dropped. Do not assume session-end hooks
+// have finished when this event arrives: it is emitted before they run.
 type StreamStoppedEvent struct {
 	AgentContext
 

--- a/pkg/runtime/event_sink.go
+++ b/pkg/runtime/event_sink.go
@@ -1,5 +1,10 @@
 package runtime
 
+import (
+	"log/slog"
+	"time"
+)
+
 // EventSink is the write side of the runtime's event stream. Methods
 // that produce events accept an EventSink instead of a raw chan Event,
 // decoupling event producers from the channel implementation.
@@ -64,6 +69,41 @@ func (s nonBlockingChannelSink) Emit(e Event) {
 	select {
 	case s.ch <- e:
 	default:
+	}
+}
+
+// boundedChannelSink wraps an event channel with a bounded-blocking send:
+// it waits up to wait for the consumer to accept the event, then drops it.
+// Use this for turn-boundary events that a live, still-draining consumer
+// must reliably receive, but that must not hang teardown indefinitely when
+// the consumer has genuinely gone away (#3070, #4136). Regular runtime code
+// should use the unbounded blocking [channelSink] instead, so ordinary
+// back-pressure is preserved.
+type boundedChannelSink struct {
+	ch   chan Event
+	wait time.Duration
+}
+
+// bounded returns a bounded-blocking sink for sink with the given deadline.
+// If sink wraps a channel directly, the result writes to that channel with a
+// timeout; otherwise, sink is returned unchanged because non-channel sinks
+// (notably [EventSinkFunc] used in tests) do not have an underlying buffer
+// that can fill up.
+func bounded(sink EventSink, wait time.Duration) EventSink {
+	if cs, ok := sink.(*channelSink); ok {
+		return boundedChannelSink{ch: cs.ch, wait: wait}
+	}
+	return sink
+}
+
+func (s boundedChannelSink) Emit(e Event) {
+	defer func() { recover() }() //nolint:errcheck // swallow send-on-closed-channel panic
+	t := time.NewTimer(s.wait)
+	defer t.Stop()
+	select {
+	case s.ch <- e:
+	case <-t.C:
+		slog.Warn("dropping event: consumer did not drain within the delivery deadline", "wait", s.wait)
 	}
 }
 

--- a/pkg/runtime/loop.go
+++ b/pkg/runtime/loop.go
@@ -193,11 +193,16 @@ func (r *LocalRuntime) emitHookDrivenShutdown(
 // "all cleanup done" signal is the channel close (done last, in
 // restoreAndClose) that terminates a `for range`, not the StreamStopped event.
 //
-// Delivery: StreamStopped is best-effort. It is emitted non-blockingly and is
-// dropped when the buffer is full and the consumer has gone away, rather than
-// blocking teardown (a blocking send here is the deadlock #3070 fixed).
-// Consumers must rely on the channel close, not on receiving StreamStopped, as
-// the guaranteed terminal signal.
+// Delivery: StreamStopped is delivered with a bounded blocking send (see
+// [boundedChannelSink]) rather than a plain non-blocking one. A consumer
+// still draining the channel — including one that already got Esc or
+// otherwise cancelled its context, since the TUI keeps draining until close —
+// reliably receives it. It is dropped only if nothing accepts it within
+// streamStoppedTimeout, i.e. the consumer has genuinely abandoned the channel
+// (#4136 fixed the non-blocking drop that caused this; #3070 is why the send
+// is bounded rather than unbounded). Consumers must still rely on the channel
+// close, not on receiving StreamStopped, as the one guaranteed terminal
+// signal.
 func (r *LocalRuntime) finalizeEventChannel(ctx context.Context, sess *session.Session, reason string, prevElicitationCh, events chan Event) {
 	a := r.resolveSessionAgent(sess)
 
@@ -205,10 +210,10 @@ func (r *LocalRuntime) finalizeEventChannel(ctx context.Context, sess *session.S
 		reason = turnEndReasonCanceled
 	}
 
-	// Best-effort, non-blocking on purpose: a blocking send here reintroduces
-	// the #3070 teardown deadlock. See the doc comment for the ordering and
-	// delivery contract.
-	nonBlocking(&channelSink{ch: events}).Emit(StreamStopped(sess.ID, a.Name(), reason))
+	// Bounded, not unbounded: an abandoned consumer must not hang teardown
+	// forever (#3070), but a live one draining past cancellation must still
+	// get this event (#4136) — so this never selects on ctx.Done().
+	bounded(&channelSink{ch: events}, r.streamStoppedTimeout()).Emit(StreamStopped(sess.ID, a.Name(), reason))
 
 	// Execute session end hooks with a context that won't be cancelled so
 	// cleanup hooks run even when the stream was interrupted (e.g. Ctrl+C).
@@ -225,6 +230,17 @@ func (r *LocalRuntime) finalizeEventChannel(ctx context.Context, sess *session.S
 	r.telemetry.RecordSessionEnd(ctx)
 
 	r.elicitation.restoreAndClose(events, prevElicitationCh)
+}
+
+// streamStoppedTimeout returns the bounded-delivery deadline for the
+// StreamStopped emit in finalizeEventChannel, falling back to
+// defaultStreamStoppedDeliveryTimeout when unset (e.g. a *LocalRuntime built
+// directly as a struct literal in tests, bypassing NewLocalRuntime).
+func (r *LocalRuntime) streamStoppedTimeout() time.Duration {
+	if r.streamStoppedDeliveryTimeout > 0 {
+		return r.streamStoppedDeliveryTimeout
+	}
+	return defaultStreamStoppedDeliveryTimeout
 }
 
 // RunStream starts the agent's interaction loop and returns a channel of events.

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -402,6 +402,14 @@ type LocalRuntime struct {
 	// Defaults to defaultToolStartTimeout; overridden via WithToolStartTimeout.
 	toolStartTimeout time.Duration
 
+	// streamStoppedDeliveryTimeout bounds how long finalizeEventChannel
+	// blocks trying to deliver StreamStopped when the event buffer is full.
+	// Defaults to defaultStreamStoppedDeliveryTimeout; tests shrink it to
+	// exercise the drop-when-abandoned path without a real-time wait. Zero
+	// falls back to the default (see streamStoppedTimeout), so runtimes built
+	// directly via a struct literal in tests still get bounded delivery.
+	streamStoppedDeliveryTimeout time.Duration
+
 	// pauseMu guards pauseCh.
 	pauseMu sync.Mutex
 	// pauseCh is non-nil and open while /pause has paused the run loop;
@@ -678,25 +686,26 @@ func NewLocalRuntime(ctx context.Context, agents *team.Team, opts ...Opt) (*Loca
 	}
 
 	r := &LocalRuntime{
-		ctx:                    func() context.Context { return context.WithoutCancel(ctx) },
-		toolMap:                make(map[string]ToolHandlerFunc),
-		liveSessions:           make(map[string]*liveSessionEntry),
-		team:                   agents,
-		agents:                 newAgentRouter(agents, defaultAgent.Name()),
-		resumeChan:             make(chan ResumeRequest),
-		steerQueue:             NewInMemoryMessageQueue(defaultSteerQueueCapacity),
-		followUpQueue:          NewInMemoryMessageQueue(defaultFollowUpQueueCapacity),
-		sessionCompaction:      true,
-		managedOAuth:           true,
-		sessionStore:           session.NewInMemorySessionStore(),
-		fallback:               newFallbackExecutor(),
-		now:                    time.Now,
-		telemetry:              defaultTelemetry{},
-		providerRegistry:       provider.DefaultRegistry(),
-		maxOverflowCompactions: defaultMaxOverflowCompactions,
-		toolListTimeout:        defaultToolListTimeout,
-		toolStartTimeout:       defaultToolStartTimeout,
-		dmrModelLister:         dmrmodels.ListModels,
+		ctx:                          func() context.Context { return context.WithoutCancel(ctx) },
+		toolMap:                      make(map[string]ToolHandlerFunc),
+		liveSessions:                 make(map[string]*liveSessionEntry),
+		team:                         agents,
+		agents:                       newAgentRouter(agents, defaultAgent.Name()),
+		resumeChan:                   make(chan ResumeRequest),
+		steerQueue:                   NewInMemoryMessageQueue(defaultSteerQueueCapacity),
+		followUpQueue:                NewInMemoryMessageQueue(defaultFollowUpQueueCapacity),
+		sessionCompaction:            true,
+		managedOAuth:                 true,
+		sessionStore:                 session.NewInMemorySessionStore(),
+		fallback:                     newFallbackExecutor(),
+		now:                          time.Now,
+		telemetry:                    defaultTelemetry{},
+		providerRegistry:             provider.DefaultRegistry(),
+		maxOverflowCompactions:       defaultMaxOverflowCompactions,
+		toolListTimeout:              defaultToolListTimeout,
+		toolStartTimeout:             defaultToolStartTimeout,
+		streamStoppedDeliveryTimeout: defaultStreamStoppedDeliveryTimeout,
+		dmrModelLister:               dmrmodels.ListModels,
 	}
 	r.bgAgents = agenttool.NewHandler(r)
 

--- a/pkg/runtime/stream_stopped_delivery_test.go
+++ b/pkg/runtime/stream_stopped_delivery_test.go
@@ -1,0 +1,120 @@
+package runtime
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/docker/docker-agent/pkg/agent"
+	"github.com/docker/docker-agent/pkg/session"
+	"github.com/docker/docker-agent/pkg/team"
+)
+
+// slowChoiceObserver stands in for the #4136 repro's synchronous per-delta
+// SQLite write: it sleeps on every AgentChoiceEvent, so the drain goroutine
+// falls behind a model that streams deltas quickly and the runtime's event
+// buffer is full by the time finalizeEventChannel emits StreamStopped.
+type slowChoiceObserver struct{ delay time.Duration }
+
+func (slowChoiceObserver) OnRunStart(context.Context, *session.Session) {}
+
+func (o slowChoiceObserver) OnEvent(_ context.Context, _ *session.Session, event Event) {
+	if _, ok := event.(*AgentChoiceEvent); ok {
+		time.Sleep(o.delay) //nolint:forbidigo // deliberately slow consumer reproduces the #4136 back-pressure race
+	}
+}
+
+// TestRunStream_StreamStoppedDeliveredUnderSlowConsumer is the deterministic
+// regression test for #4136: a runtime whose event consumer can't keep up
+// with the model's delta rate must still deliver exactly one StreamStopped,
+// as the last event before the channel closes. Before the bounded-send fix,
+// the buffer-full non-blocking emit dropped it under this exact shape (see
+// the issue's validation report, table in §2.5).
+func TestRunStream_StreamStoppedDeliveredUnderSlowConsumer(t *testing.T) {
+	t.Parallel()
+
+	builder := newStreamBuilder()
+	const deltas = 300
+	for range deltas {
+		builder.AddContent("abc")
+	}
+	builder.AddStopWithUsage(10, 20)
+
+	prov := &mockProvider{id: "test/mock-model", stream: builder.Build()}
+	root := agent.New("root", "test agent", agent.WithModel(prov))
+	tm := team.New(team.WithAgents(root))
+
+	rt, err := NewLocalRuntime(t.Context(), tm,
+		WithSessionCompaction(false),
+		WithModelStore(mockModelStore{}),
+		WithEventObserver(slowChoiceObserver{delay: time.Millisecond}),
+	)
+	require.NoError(t, err)
+
+	sess := session.New(session.WithUserMessage("hi"))
+	sess.Title = "Unit Test"
+
+	var events []Event
+	for ev := range rt.RunStream(t.Context(), sess) {
+		events = append(events, ev)
+	}
+
+	var stoppedCount, stoppedIdx int
+	for i, ev := range events {
+		if _, ok := ev.(*StreamStoppedEvent); ok {
+			stoppedCount++
+			stoppedIdx = i
+		}
+	}
+	require.Equal(t, 1, stoppedCount, "StreamStopped should be delivered exactly once even under a slow consumer")
+	assert.Equal(t, len(events)-1, stoppedIdx, "StreamStopped must be the last event before the channel closes")
+}
+
+// TestLocalRuntime_FinalizeEventChannelDeliversStreamStoppedToSlowButAliveConsumer
+// covers the middle case between "consumer keeps up" and "consumer is gone":
+// the buffer is full when StreamStopped is emitted, but something reads
+// before the bounded deadline elapses. The bounded send must deliver it
+// rather than treat the momentarily-full buffer as an abandoned consumer.
+func TestLocalRuntime_FinalizeEventChannelDeliversStreamStoppedToSlowButAliveConsumer(t *testing.T) {
+	t.Parallel()
+
+	rt := newElicitationTestRuntime(t)
+	rt.streamStoppedDeliveryTimeout = 2 * time.Second
+	sess := session.New()
+	events := make(chan Event, 1)
+	parent := make(chan Event, 1)
+	events <- Error("buffer already full")
+	rt.elicitation.swap(events)
+
+	done := make(chan struct{})
+	go func() {
+		rt.finalizeEventChannel(t.Context(), sess, turnEndReasonNormal, parent, events)
+		close(done)
+	}()
+
+	// Free the one buffered slot so the bounded send has somewhere to land,
+	// simulating a consumer that is slow but still draining rather than gone.
+	// This is safe regardless of whether finalizeEventChannel's send is
+	// already parked on it: freeing the slot at any point before the
+	// deadline lets the send land.
+	received := <-events
+	_, ok := received.(*ErrorEvent)
+	require.True(t, ok, "expected to drain the pre-seeded event first")
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("finalizeEventChannel did not return after the consumer freed a slot")
+	}
+
+	var stopped int
+	for ev := range events {
+		if _, ok := ev.(*StreamStoppedEvent); ok {
+			stopped++
+		}
+	}
+	assert.Equal(t, 1, stopped, "StreamStopped should be delivered once the consumer drains a slot before the deadline")
+}


### PR DESCRIPTION
## Summary

Fixes #4136: the TUI got stuck on "Working…" after the stream had actually finished, because `finalizeEventChannel` emitted the terminal `StreamStoppedEvent` **non-blockingly** and silently dropped it whenever the runtime's 128-slot event buffer was full at teardown. Under normal streaming back-pressure (e.g. `PersistenceObserver` doing a synchronous per-delta SQLite write, or any consumer slower than the model's delta rate) the buffer is routinely full at exactly that moment, so the TUI/supervisor/leantui — which only clear their busy state on receipt of that event — never learned the stream had ended.

## Change

- `finalizeEventChannel` now delivers `StreamStopped` with a **bounded blocking send** (~5s deadline, new `boundedChannelSink`/`bounded()` helper in `event_sink.go`, mirroring the existing `nonBlocking()`). A consumer still draining the channel — even one that already saw `ctx` cancelled (Esc) but keeps draining to close — reliably receives it. It's dropped only if nothing accepts it within the deadline, i.e. the consumer has genuinely abandoned the channel.
- Deliberately **not** unbounded: a consumer audit found several call sites that legitimately stop reading before close (a2a, acp, cli runner, `LocalRuntime.Run`, embeddedchat, server `RunSession`). An unbounded send there would reintroduce the exact teardown deadlock #3070 fixed, which #3074/#3275 addressed by making this emit non-blocking (and documented delivery as best-effort) in the first place.
- Updated the `finalizeEventChannel`/`StreamStoppedEvent` doc comments to describe the new bounded-delivery contract; channel close remains the one guaranteed terminal signal.
- `pkg/a2a/adapter.go`: the ADK turn-complete event was only ever sent from the `StreamStoppedEvent` case, so a dropped event left the turn hanging. Added a channel-close fallback so it still completes if that event was never delivered.

## Tests

- New `pkg/runtime/stream_stopped_delivery_test.go`: a deterministic regression test reproducing the #4136 race (slow `EventObserver` + ≥250 streamed deltas) asserting exactly one `StreamStopped`, last before close; plus a "slow-but-alive consumer eventually receives it" case. Passes `-count=20` with zero flakes.
- Reworked `TestLocalRuntime_FinalizeEventChannelDoesNotDeadlockWhenBufferFullAndConsumerGone` → `TestLocalRuntime_FinalizeEventChannelDropsStreamStoppedAfterBoundedTimeout`: injects a short timeout, asserts the send waits out the deadline (proving bounded, not instant-drop) and still returns/drops for a genuinely abandoned consumer.
- `TestLocalRuntime_FinalizeEventChannelStreamStoppedIsLastBeforeClose` / `...EmitsStreamStoppedOnce` pass unchanged.

`go build`, `go test ./...`, `golangci-lint run` (v2.13.1) all clean. (`pkg/rag/treesitter` fails in this sandbox only — pre-existing, missing gcc for CGO, unrelated to this change.)

Independent review (sub-agent) returned only low-severity, non-blocking nits (comment verbosity, a defensive suggestion for an unreachable `wait<=0` case, a minor doc-wording ambiguity) — none required changes.
