### PR TITLE
fix(openai): reject oneOf/allOf and validate $defs/$ref before enabling strict mode (#4106)

### DIFF
--- a/pkg/model/provider/openai/schema.go
+++ b/pkg/model/provider/openai/schema.go
@@ -1,8 +1,11 @@
 package openai
 
 import (
+	"iter"
 	"maps"
 	"slices"
+	"strconv"
+	"strings"
 
 	"github.com/openai/openai-go/v3/shared"
 
@@ -27,19 +30,68 @@ func ConvertParametersToSchema(params any) (shared.FunctionParameters, bool, err
 	return fixSchemaArrayItems(removeFormatFields(ensureTypeFields(makeAllRequired(p)))), strict, nil
 }
 
+// childSchemas yields every direct sub-schema of node. Both the strict
+// compatibility check and the normalization walker use it so they cannot
+// drift. $ref is deliberately not followed: every local target lives in a
+// container walked here (or is the root), and following refs would loop on
+// recursive schemas.
+func childSchemas(node map[string]any) iter.Seq[map[string]any] {
+	return func(yield func(map[string]any) bool) {
+		for _, key := range []string{"properties", "patternProperties", "$defs", "definitions"} {
+			if m, ok := node[key].(map[string]any); ok {
+				for _, v := range m {
+					if sub, ok := v.(map[string]any); ok && !yield(sub) {
+						return
+					}
+				}
+			}
+		}
+
+		for _, key := range []string{"anyOf", "oneOf", "allOf", "prefixItems"} {
+			if arr, ok := node[key].([]any); ok {
+				for _, v := range arr {
+					if sub, ok := v.(map[string]any); ok && !yield(sub) {
+						return
+					}
+				}
+			}
+		}
+
+		for _, key := range []string{"items", "additionalProperties", "not", "if", "then", "else", "contains", "propertyNames"} {
+			if sub, ok := node[key].(map[string]any); ok && !yield(sub) {
+				return
+			}
+		}
+	}
+}
+
+// strictUnsupportedKeywords lists keywords OpenAI Structured Outputs rejects
+// regardless of their content. oneOf is absent from OpenAI's supported-type
+// list and is rejected in practice (#4106); the rest are documented as
+// unsupported composition keywords.
+var strictUnsupportedKeywords = []string{
+	"oneOf", "allOf", "not", "if", "then", "else", "dependentRequired", "dependentSchemas",
+}
+
 // isStrictCompatible reports whether the schema can use OpenAI strict mode.
-// Strict mode requires every object node to have additionalProperties: false.
-// Schema-form additionalProperties (a map) and additionalProperties: true are
-// both incompatible.
+// Strict mode requires every object node to have additionalProperties: false,
+// forbids composition keywords other than anyOf, and only allows $ref nodes
+// that are local, resolvable, and free of sibling keywords.
 //
 // The decision is per-tool and all-or-nothing: a single non-compliant node
 // anywhere in the schema disables strict mode for the whole tool. The walk
 // stops at the first incompatible node.
 func isStrictCompatible(schema map[string]any) bool {
-	return !hasIncompatibleNode(schema)
+	return !hasIncompatibleNode(schema, schema)
 }
 
-func hasIncompatibleNode(node map[string]any) bool {
+func hasIncompatibleNode(root, node map[string]any) bool {
+	for _, kw := range strictUnsupportedKeywords {
+		if _, ok := node[kw]; ok {
+			return true
+		}
+	}
+
 	if v, ok := node["additionalProperties"]; ok {
 		switch t := v.(type) {
 		case map[string]any:
@@ -51,77 +103,93 @@ func hasIncompatibleNode(node map[string]any) bool {
 		}
 	}
 
-	if properties, ok := node["properties"].(map[string]any); ok {
-		for _, v := range properties {
-			if sub, ok := v.(map[string]any); ok && hasIncompatibleNode(sub) {
-				return true
-			}
-		}
-	}
-
-	for _, keyword := range []string{"anyOf", "oneOf", "allOf"} {
-		if variants, ok := node[keyword].([]any); ok {
-			for _, v := range variants {
-				if sub, ok := v.(map[string]any); ok && hasIncompatibleNode(sub) {
-					return true
-				}
-			}
-		}
-	}
-
-	if items, ok := node["items"].(map[string]any); ok && hasIncompatibleNode(items) {
+	if ref, ok := node["$ref"]; ok && !isStrictCompatibleRef(root, node, ref) {
 		return true
 	}
 
-	if prefixItems, ok := node["prefixItems"].([]any); ok {
-		for _, v := range prefixItems {
-			if sub, ok := v.(map[string]any); ok && hasIncompatibleNode(sub) {
-				return true
-			}
+	for sub := range childSchemas(node) {
+		if hasIncompatibleNode(root, sub) {
+			return true
 		}
 	}
-
 	return false
 }
 
+// isStrictCompatibleRef reports whether a $ref node is compatible with
+// OpenAI strict mode: the ref must be a string, a local JSON pointer ("#" or
+// "#/...") that resolves within root, and the node must have no sibling
+// keywords.
+//
+// The no-siblings rule follows the official openai-python SDK
+// (_ensure_strict_json_schema), which inlines any $ref carrying sibling keys
+// because OpenAI rejects e.g. {"$ref": "...", "description": "..."} — see
+// openai-python#1631. We mark such nodes non-strict instead of inlining,
+// since $defs/$ref are documented as supported and inlining would break
+// recursive schemas.
+func isStrictCompatibleRef(root, node map[string]any, ref any) bool {
+	refStr, ok := ref.(string)
+	if !ok {
+		return false
+	}
+	if refStr != "#" && !strings.HasPrefix(refStr, "#/") {
+		return false
+	}
+	if _, ok := resolveJSONPointer(root, refStr); !ok {
+		return false
+	}
+	// No sibling keywords: the node must contain nothing but "$ref".
+	return len(node) == 1
+}
+
+// resolveJSONPointer resolves a local JSON pointer (e.g. "#/$defs/thing" or
+// "#") against root, per RFC 6901. It only descends through map[string]any
+// and []any nodes; anything else, or a missing key/out-of-range index, fails
+// resolution rather than panicking.
+func resolveJSONPointer(root map[string]any, pointer string) (map[string]any, bool) {
+	pointer = strings.TrimPrefix(pointer, "#")
+	if pointer == "" {
+		return root, true
+	}
+	if !strings.HasPrefix(pointer, "/") {
+		return nil, false
+	}
+
+	var current any = root
+	for tok := range strings.SplitSeq(pointer[1:], "/") {
+		tok = strings.ReplaceAll(tok, "~1", "/")
+		tok = strings.ReplaceAll(tok, "~0", "~")
+
+		switch node := current.(type) {
+		case map[string]any:
+			v, ok := node[tok]
+			if !ok {
+				return nil, false
+			}
+			current = v
+		case []any:
+			idx, err := strconv.Atoi(tok)
+			if err != nil || idx < 0 || idx >= len(node) {
+				return nil, false
+			}
+			current = node[idx]
+		default:
+			return nil, false
+		}
+	}
+
+	m, ok := current.(map[string]any)
+	return m, ok
+}
+
 // walkSchema calls fn on the given schema node, then recursively walks into
-// properties, anyOf/oneOf/allOf variants, array items, and additionalProperties.
+// every sub-schema childSchemas yields (properties, patternProperties,
+// $defs/definitions, anyOf/oneOf/allOf/prefixItems variants, items,
+// additionalProperties, and the remaining single-schema keywords). $ref is
+// never followed, so recursive schemas terminate.
 func walkSchema(schema map[string]any, fn func(map[string]any)) {
 	fn(schema)
-
-	if properties, ok := schema["properties"].(map[string]any); ok {
-		for _, v := range properties {
-			if sub, ok := v.(map[string]any); ok {
-				walkSchema(sub, fn)
-			}
-		}
-	}
-
-	for _, keyword := range []string{"anyOf", "oneOf", "allOf"} {
-		if variants, ok := schema[keyword].([]any); ok {
-			for _, v := range variants {
-				if sub, ok := v.(map[string]any); ok {
-					walkSchema(sub, fn)
-				}
-			}
-		}
-	}
-
-	if items, ok := schema["items"].(map[string]any); ok {
-		walkSchema(items, fn)
-	}
-
-	if prefixItems, ok := schema["prefixItems"].([]any); ok {
-		for _, v := range prefixItems {
-			if sub, ok := v.(map[string]any); ok {
-				walkSchema(sub, fn)
-			}
-		}
-	}
-
-	// additionalProperties can be a boolean or an object schema
-	if additionalProps, ok := schema["additionalProperties"].(map[string]any); ok {
-		walkSchema(additionalProps, fn)
+	for sub := range childSchemas(schema) {
+		walkSchema(sub, fn)
 	}
 }
 
@@ -130,12 +198,21 @@ func walkSchema(schema map[string]any, fn func(map[string]any)) {
 // set. It runs on every schema regardless of strict-mode compatibility, so
 // schema-form additionalProperties (e.g. Notion's dictionary value shape) is
 // preserved — only missing/true/nil values are forced to `false`.
+//
+// $ref nodes are left untouched (no additionalProperties/type injection): a
+// newly-required $ref property is instead wrapped as
+// {"anyOf": [<$ref>, {"type": "null"}]}, OpenAI's documented pattern for an
+// optional reference, so the model isn't forced to always emit it.
 func makeAllRequired(schema shared.FunctionParameters) shared.FunctionParameters {
 	if schema == nil {
 		schema = map[string]any{"type": "object", "properties": map[string]any{}}
 	}
 
 	walkSchema(schema, func(node map[string]any) {
+		if _, ok := node["$ref"]; ok {
+			return
+		}
+
 		isObject := false
 		if typeVal, ok := node["type"]; ok {
 			switch t := typeVal.(type) {
@@ -179,7 +256,11 @@ func makeAllRequired(schema shared.FunctionParameters) shared.FunctionParameters
 			newRequired = append(newRequired, propName)
 			if !originallyRequired[propName] {
 				if propMap, ok := properties[propName].(map[string]any); ok {
-					if t, ok := propMap["type"].(string); ok {
+					if _, isRef := propMap["$ref"]; isRef {
+						properties[propName] = map[string]any{
+							"anyOf": []any{propMap, map[string]any{"type": "null"}},
+						}
+					} else if t, ok := propMap["type"].(string); ok {
 						propMap["type"] = []string{t, "null"}
 					}
 				}
@@ -192,15 +273,38 @@ func makeAllRequired(schema shared.FunctionParameters) shared.FunctionParameters
 	return schema
 }
 
+// isCompositionNode reports whether node describes its shape via $ref or a
+// composition keyword (anyOf/oneOf/allOf) rather than its own "type". A
+// "type" sibling combines with these via AND, so injecting one is only safe
+// when every variant already shares it — otherwise the schema becomes
+// unsatisfiable (e.g. a newly-required $ref property wrapped as
+// {"anyOf": [<$ref>, {"type": "null"}]} would gain a conflicting
+// "type": "object" and could never validate as null, or as anything at all
+// if the ref target isn't itself an object). Nodes like this are left
+// without an injected type; OpenAI's own examples show anyOf/$ref nodes
+// with no sibling type.
+func isCompositionNode(node map[string]any) bool {
+	for _, kw := range []string{"$ref", "anyOf", "oneOf", "allOf"} {
+		if _, ok := node[kw]; ok {
+			return true
+		}
+	}
+	return false
+}
+
 // ensureTypeFields ensures every schema node that is a map has a "type" key.
 // OpenAI Responses API requires all schema nodes to have an explicit type.
 // Nodes with "properties" default to "object"; other nodes default to "object" as well.
+// $ref/anyOf/oneOf/allOf nodes are left as leaves — see isCompositionNode.
 func ensureTypeFields(schema shared.FunctionParameters) shared.FunctionParameters {
 	if schema == nil {
 		return nil
 	}
 
 	walkSchema(schema, func(node map[string]any) {
+		if isCompositionNode(node) {
+			return
+		}
 		if _, hasType := node["type"]; !hasType {
 			node["type"] = "object"
 		}

--- a/pkg/model/provider/openai/schema_test.go
+++ b/pkg/model/provider/openai/schema_test.go
@@ -504,6 +504,282 @@ func TestIsStrictCompatible(t *testing.T) {
 			},
 			want: false,
 		},
+		{
+			// T1: the exact schema from issue #4106.
+			name: "issue 4106 - oneOf property",
+			schema: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"value": map[string]any{
+						"oneOf": []any{
+							map[string]any{"type": "integer"},
+							map[string]any{"type": "string"},
+						},
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			// T2: allOf at property level.
+			name: "allOf at property level",
+			schema: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"value": map[string]any{
+						"allOf": []any{
+							map[string]any{"type": "string"},
+						},
+					},
+				},
+			},
+			want: false,
+		},
+		// T3: each disqualifying composition keyword, at root and nested.
+		{
+			name:   "root not",
+			schema: map[string]any{"type": "object", "not": map[string]any{"type": "string"}},
+			want:   false,
+		},
+		{
+			name: "nested if/then/else",
+			schema: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"value": map[string]any{
+						"if":   map[string]any{"type": "string"},
+						"then": map[string]any{"type": "string"},
+						"else": map[string]any{"type": "number"},
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name:   "root dependentRequired",
+			schema: map[string]any{"type": "object", "dependentRequired": map[string]any{"a": []any{"b"}}},
+			want:   false,
+		},
+		{
+			name:   "root dependentSchemas",
+			schema: map[string]any{"type": "object", "dependentSchemas": map[string]any{"a": map[string]any{"type": "object"}}},
+			want:   false,
+		},
+		{
+			// T4: oneOf nested inside anyOf variant, items, and $defs - proves recursion reaches it.
+			name: "oneOf nested inside anyOf variant",
+			schema: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"value": map[string]any{
+						"anyOf": []any{
+							map[string]any{"type": "string"},
+							map[string]any{"oneOf": []any{map[string]any{"type": "integer"}}},
+						},
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "oneOf nested inside items",
+			schema: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"list": map[string]any{
+						"type":  "array",
+						"items": map[string]any{"oneOf": []any{map[string]any{"type": "integer"}}},
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "oneOf nested inside $defs",
+			schema: map[string]any{
+				"type": "object",
+				"$defs": map[string]any{
+					"thing": map[string]any{"oneOf": []any{map[string]any{"type": "integer"}}},
+				},
+			},
+			want: false,
+		},
+		{
+			// T5: existing anyOf fixture (chrome-devtools) must still be compatible - don't over-gate.
+			name: "anyOf with clean variants stays compatible",
+			schema: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"viewport": map[string]any{
+						"anyOf": []any{
+							map[string]any{
+								"type": "object",
+								"properties": map[string]any{
+									"width":  map[string]any{"type": "number"},
+									"height": map[string]any{"type": "number"},
+								},
+								"required":             []any{"width", "height"},
+								"additionalProperties": false,
+							},
+							map[string]any{"type": "null"},
+						},
+					},
+				},
+				"required":             []any{"viewport"},
+				"additionalProperties": false,
+			},
+			want: true,
+		},
+		{
+			// T6: $defs / definitions with a schema-form or true additionalProperties.
+			name: "$defs additionalProperties true is incompatible",
+			schema: map[string]any{
+				"type": "object",
+				"$defs": map[string]any{
+					"thing": map[string]any{"type": "object", "additionalProperties": true},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "definitions additionalProperties schema-form is incompatible",
+			schema: map[string]any{
+				"type": "object",
+				"definitions": map[string]any{
+					"thing": map[string]any{"type": "object", "additionalProperties": map[string]any{"type": "string"}},
+				},
+			},
+			want: false,
+		},
+		// T7: $ref variants.
+		{
+			name: "$ref to missing $defs entry is incompatible",
+			schema: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"p": map[string]any{"$ref": "#/$defs/missing"},
+				},
+				"$defs": map[string]any{"thing": map[string]any{"type": "string"}},
+			},
+			want: false,
+		},
+		{
+			name: "$ref to external file is incompatible",
+			schema: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"p": map[string]any{"$ref": "other.json#/x"},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "$ref to absolute URL is incompatible",
+			schema: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"p": map[string]any{"$ref": "https://example.com/schema.json"},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "non-string $ref is incompatible",
+			schema: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"p": map[string]any{"$ref": 42},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "escaped pointer that resolves is compatible",
+			schema: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"p": map[string]any{"$ref": "#/$defs/a~1b~0c"},
+				},
+				"$defs":    map[string]any{"a/b~c": map[string]any{"type": "string"}},
+				"required": []any{"p"},
+			},
+			want: true,
+		},
+		{
+			// T8: $ref with sibling description is incompatible (conservative rule; see design doc §3.3).
+			name: "$ref with sibling description is incompatible",
+			schema: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"p": map[string]any{"$ref": "#/$defs/thing", "description": "a thing"},
+				},
+				"$defs":    map[string]any{"thing": map[string]any{"type": "string"}},
+				"required": []any{"p"},
+			},
+			want: false,
+		},
+		{
+			// T9: recursive schemas via $ref must not cause infinite recursion.
+			name: "root self-reference via items",
+			schema: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"children": map[string]any{
+						"type":  "array",
+						"items": map[string]any{"$ref": "#"},
+					},
+				},
+				"required": []any{"children"},
+			},
+			want: true,
+		},
+		{
+			name: "linked-list self-reference via $defs",
+			schema: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"head": map[string]any{"$ref": "#/$defs/node"},
+				},
+				"required": []any{"head"},
+				"$defs": map[string]any{
+					"node": map[string]any{
+						"type": "object",
+						"properties": map[string]any{
+							"value": map[string]any{"type": "number"},
+							"next": map[string]any{
+								"anyOf": []any{
+									map[string]any{"$ref": "#/$defs/node"},
+									map[string]any{"type": "null"},
+								},
+							},
+						},
+						"required": []any{"value", "next"},
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			// T13: patternProperties value schemas must not be gated.
+			name: "patternProperties is not gated",
+			schema: map[string]any{
+				"type": "object",
+				"patternProperties": map[string]any{
+					"^S_": map[string]any{"type": "string"},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "oneOf nested inside patternProperties is still gated",
+			schema: map[string]any{
+				"type": "object",
+				"patternProperties": map[string]any{
+					"^S_": map[string]any{"oneOf": []any{map[string]any{"type": "string"}}},
+				},
+			},
+			want: false,
+		},
 	}
 
 	for _, tc := range cases {
@@ -511,6 +787,277 @@ func TestIsStrictCompatible(t *testing.T) {
 			assert.Equal(t, tc.want, isStrictCompatible(tc.schema))
 		})
 	}
+}
+
+// TestIsStrictCompatible_Invariant is T10: normalization must never turn a
+// strict-compatible schema into an incompatible one. This is what would have
+// caught the $ref-pollution defect (issue #4106 finding 3), where the shared
+// ensurePropertyTypes helper injected "type": "object" onto $ref nodes,
+// which downstream normalization then widened with additionalProperties.
+func TestIsStrictCompatible_Invariant(t *testing.T) {
+	t.Parallel()
+
+	fixtures := []struct {
+		name   string
+		schema map[string]any
+	}{
+		{
+			name:   "empty schema",
+			schema: map[string]any{"type": "object", "properties": map[string]any{}},
+		},
+		{
+			name: "anyOf with clean variants (chrome-devtools)",
+			schema: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"viewport": map[string]any{
+						"anyOf": []any{
+							map[string]any{
+								"type": "object",
+								"properties": map[string]any{
+									"width":  map[string]any{"type": "number"},
+									"height": map[string]any{"type": "number"},
+								},
+								"required": []any{"width", "height"},
+							},
+							map[string]any{"type": "null"},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "required $ref property",
+			schema: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"p": map[string]any{"$ref": "#/$defs/thing"},
+				},
+				"required": []any{"p"},
+				"$defs":    map[string]any{"thing": map[string]any{"type": "string"}},
+			},
+		},
+		{
+			name: "optional $ref property",
+			schema: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"p": map[string]any{"$ref": "#/$defs/thing"},
+				},
+				"$defs": map[string]any{"thing": map[string]any{"type": "string"}},
+			},
+		},
+		{
+			name: "clean $defs referenced by required property",
+			schema: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"thing": map[string]any{"$ref": "#/$defs/thing"},
+				},
+				"required": []any{"thing"},
+				"$defs": map[string]any{
+					"thing": map[string]any{
+						"type": "object",
+						"properties": map[string]any{
+							"name": map[string]any{"type": "string"},
+						},
+						"required": []any{"name"},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range fixtures {
+		t.Run(tc.name, func(t *testing.T) {
+			require.True(t, isStrictCompatible(tc.schema), "fixture must be strict-compatible before normalization")
+
+			output, strict, err := ConvertParametersToSchema(tc.schema)
+			require.NoError(t, err)
+			assert.True(t, strict)
+			assert.True(t, isStrictCompatible(output), "normalization must not introduce a strict incompatibility")
+		})
+	}
+}
+
+// TestConvertParametersToSchema_Issue4106 is T1's pipeline-level assertion:
+// the exact schema from the issue must round-trip as strict: false, without
+// error, rather than being sent to OpenAI as strict: true and rejected.
+func TestConvertParametersToSchema_Issue4106(t *testing.T) {
+	t.Parallel()
+	schema := map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"value": map[string]any{
+				"oneOf": []any{
+					map[string]any{"type": "integer"},
+					map[string]any{"type": "string"},
+				},
+			},
+		},
+	}
+
+	_, strict, err := ConvertParametersToSchema(schema)
+	require.NoError(t, err)
+	assert.False(t, strict)
+}
+
+// TestMakeAllRequired_DefsNormalization is T11: $defs entries must be
+// normalized the same as any other object node (all properties required,
+// newly-required ones nullable, additionalProperties: false, format removed).
+func TestMakeAllRequired_DefsNormalization(t *testing.T) {
+	t.Parallel()
+	schema := shared.FunctionParameters{
+		"type": "object",
+		"properties": map[string]any{
+			"thing": map[string]any{"$ref": "#/$defs/thing"},
+		},
+		"required": []any{"thing"},
+		"$defs": map[string]any{
+			"thing": map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"name": map[string]any{"type": "string"},
+					"url":  map[string]any{"type": "string", "format": "uri"},
+				},
+				"required": []any{"name"},
+			},
+		},
+	}
+
+	updated := removeFormatFields(makeAllRequired(schema))
+
+	thing := updated["$defs"].(map[string]any)["thing"].(map[string]any)
+	assert.Equal(t, false, thing["additionalProperties"])
+
+	required := thing["required"].([]any)
+	assert.Len(t, required, 2)
+	assert.Contains(t, required, "name")
+	assert.Contains(t, required, "url")
+
+	url := thing["properties"].(map[string]any)["url"].(map[string]any)
+	assert.Equal(t, []string{"string", "null"}, url["type"])
+	assert.NotContains(t, url, "format")
+
+	name := thing["properties"].(map[string]any)["name"].(map[string]any)
+	assert.Equal(t, "string", name["type"])
+}
+
+// TestMakeAllRequired_RefLeaf is T12: a required $ref property is left as a
+// bare $ref node (no type/additionalProperties siblings injected), while a
+// newly-required (optional) $ref property is wrapped as
+// {"anyOf": [<$ref>, {"type": "null"}]} so the model isn't forced to always
+// emit it.
+func TestMakeAllRequired_RefLeaf(t *testing.T) {
+	t.Parallel()
+	schema := shared.FunctionParameters{
+		"type": "object",
+		"properties": map[string]any{
+			"required_ref": map[string]any{"$ref": "#/$defs/thing"},
+			"optional_ref": map[string]any{"$ref": "#/$defs/thing"},
+		},
+		"required": []any{"required_ref"},
+		"$defs": map[string]any{
+			"thing": map[string]any{"type": "string"},
+		},
+	}
+
+	updated := makeAllRequired(schema)
+
+	required := updated["required"].([]any)
+	assert.Len(t, required, 2)
+	assert.Contains(t, required, "required_ref")
+	assert.Contains(t, required, "optional_ref")
+
+	properties := updated["properties"].(map[string]any)
+
+	requiredRef := properties["required_ref"].(map[string]any)
+	assert.Equal(t, map[string]any{"$ref": "#/$defs/thing"}, requiredRef)
+
+	optionalRef := properties["optional_ref"].(map[string]any)
+	anyOf, ok := optionalRef["anyOf"].([]any)
+	require.True(t, ok, "optional $ref property must be wrapped in anyOf")
+	require.Len(t, anyOf, 2)
+	assert.Equal(t, map[string]any{"$ref": "#/$defs/thing"}, anyOf[0])
+	assert.Equal(t, map[string]any{"type": "null"}, anyOf[1])
+}
+
+// TestEnsureTypeFields_RefLeaf ensures ensureTypeFields never injects a
+// "type" key into a $ref node.
+func TestEnsureTypeFields_RefLeaf(t *testing.T) {
+	t.Parallel()
+	schema := shared.FunctionParameters{
+		"type": "object",
+		"properties": map[string]any{
+			"p": map[string]any{"$ref": "#/$defs/thing"},
+		},
+		"$defs": map[string]any{"thing": map[string]any{"type": "string"}},
+	}
+
+	updated := ensureTypeFields(schema)
+
+	p := updated["properties"].(map[string]any)["p"].(map[string]any)
+	assert.NotContains(t, p, "type")
+	assert.Equal(t, "#/$defs/thing", p["$ref"])
+}
+
+// TestEnsureTypeFields_CompositionNodesLeftAsLeaves ensures ensureTypeFields
+// never injects a "type" onto an anyOf/oneOf/allOf node. A "type" sibling
+// combines with these keywords via AND, so injecting one can make the
+// schema unsatisfiable unless every variant already shares it — exactly
+// what happened to the anyOf+null wrapper makeAllRequired creates for a
+// newly-required $ref property (see TestConvertParametersToSchema_OptionalRefIsActuallyNullable).
+func TestEnsureTypeFields_CompositionNodesLeftAsLeaves(t *testing.T) {
+	t.Parallel()
+	schema := shared.FunctionParameters{
+		"type": "object",
+		"properties": map[string]any{
+			"withAnyOf": map[string]any{
+				"anyOf": []any{
+					map[string]any{"$ref": "#/$defs/thing"},
+					map[string]any{"type": "null"},
+				},
+			},
+		},
+		"$defs": map[string]any{"thing": map[string]any{"type": "string"}},
+	}
+
+	updated := ensureTypeFields(schema)
+
+	withAnyOf := updated["properties"].(map[string]any)["withAnyOf"].(map[string]any)
+	assert.NotContains(t, withAnyOf, "type")
+}
+
+// TestConvertParametersToSchema_OptionalRefIsActuallyNullable is a
+// regression test for the anyOf+null wrapper makeAllRequired creates for a
+// newly-required $ref property. The wrapper must not gain a "type" sibling
+// from ensureTypeFields: "type": "object" alongside
+// "anyOf": [<$ref>, {"type": "null"}]" requires the value to be both an
+// object and (the ref target or null), which is unsatisfiable whenever the
+// ref target isn't itself an object — and even when it is, it silently
+// excludes the null branch, defeating the whole point of the wrap.
+func TestConvertParametersToSchema_OptionalRefIsActuallyNullable(t *testing.T) {
+	t.Parallel()
+	schema := map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"p": map[string]any{"$ref": "#/$defs/thing"},
+		},
+		"$defs": map[string]any{"thing": map[string]any{"type": "string"}},
+	}
+
+	result, strict, err := ConvertParametersToSchema(schema)
+	require.NoError(t, err)
+	assert.True(t, strict)
+
+	p := result["properties"].(map[string]any)["p"].(map[string]any)
+	assert.NotContains(t, p, "type", "the anyOf wrapper must not gain a conflicting type sibling")
+
+	anyOf, ok := p["anyOf"].([]any)
+	require.True(t, ok)
+	require.Len(t, anyOf, 2)
+	assert.Equal(t, map[string]any{"$ref": "#/$defs/thing"}, anyOf[0])
+	assert.Equal(t, map[string]any{"type": "null"}, anyOf[1])
 }
 
 func TestConvertParametersToSchema_NotionStylePreservesShape(t *testing.T) {

--- a/pkg/tools/schema.go
+++ b/pkg/tools/schema.go
@@ -135,6 +135,9 @@ func removeNullFromType(prop map[string]any) {
 // ensurePropertyTypes recursively walks a JSON Schema map and ensures
 // every property has a "type" set, defaulting to "object" if missing.
 // It descends into nested "properties" and array "items".
+// $ref nodes are skipped: a $ref's type is defined by its target, and
+// injecting one adds a sibling keyword that providers like OpenAI reject
+// on $ref nodes under strict mode.
 func ensurePropertyTypes(schema map[string]any) {
 	props, ok := schema["properties"].(map[string]any)
 	if !ok {
@@ -144,6 +147,10 @@ func ensurePropertyTypes(schema map[string]any) {
 	for _, v := range props {
 		prop, ok := v.(map[string]any)
 		if !ok {
+			continue
+		}
+
+		if _, isRef := prop["$ref"]; isRef {
 			continue
 		}
 

--- a/pkg/tools/schema_test.go
+++ b/pkg/tools/schema_test.go
@@ -227,3 +227,46 @@ func TestSchemaToMap_StripsNullFromRequiredArrayTypes(t *testing.T) {
 		"required": []any{"paths"},
 	}, m)
 }
+
+// T14: ensurePropertyTypes must not inject a "type" key into a $ref node.
+// Doing so pollutes the node with a sibling keyword, which providers like
+// OpenAI reject on $ref nodes under strict mode (see docker/docker-agent#4106).
+func TestSchemaToMap_RefPropertyLeftAsLeaf(t *testing.T) {
+	t.Parallel()
+	m, err := SchemaToMap(map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"p": map[string]any{"$ref": "#/$defs/thing"},
+		},
+		"$defs": map[string]any{
+			"thing": map[string]any{"type": "string"},
+		},
+	})
+	require.NoError(t, err)
+
+	p := m["properties"].(map[string]any)["p"].(map[string]any)
+	assert.Equal(t, map[string]any{"$ref": "#/$defs/thing"}, p, "$ref node must be left as a leaf, no injected type")
+}
+
+func TestSchemaToMap_RefPropertyInNestedObjectLeftAsLeaf(t *testing.T) {
+	t.Parallel()
+	m, err := SchemaToMap(map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"config": map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"p": map[string]any{"$ref": "#/$defs/thing"},
+				},
+			},
+		},
+		"$defs": map[string]any{
+			"thing": map[string]any{"type": "string"},
+		},
+	})
+	require.NoError(t, err)
+
+	config := m["properties"].(map[string]any)["config"].(map[string]any)
+	p := config["properties"].(map[string]any)["p"].(map[string]any)
+	assert.Equal(t, map[string]any{"$ref": "#/$defs/thing"}, p, "$ref node must be left as a leaf, no injected type")
+}


### PR DESCRIPTION
🤖 **Automated implementer agent** — *this comment was posted by the implementer bot from Docker Agentic Platform, not by a human developer*

Closes #4106.

## Problem

`isStrictCompatible`/`hasIncompatibleNode` only checked `additionalProperties`, never rejected `oneOf`/`allOf`/other composition keywords OpenAI Structured Outputs doesn't support, and neither it nor the schema normalizer (`walkSchema`) traversed `$defs`/`definitions`. A tool whose schema used `oneOf` (the issue's repro) or had an unnormalized `$defs` entry was sent to OpenAI with `strict: true` and rejected with HTTP 400, killing the whole request.

A third, related defect found during design: the shared `pkg/tools/schema.go` `ensurePropertyTypes` helper injected `type: "object"` onto `$ref` nodes, which downstream normalization then widened with `additionalProperties`/nullable-type — producing a `$ref` node with sibling keywords, which OpenAI strict mode rejects.

## Fix

- `pkg/model/provider/openai/schema.go`: shared `childSchemas` iterator (`iter.Seq`) used by both the compatibility check and the normalizer, covering `properties`/`patternProperties`/`$defs`/`definitions`/`anyOf`/`oneOf`/`allOf`/`prefixItems`/`items`/`additionalProperties`/`not`/`if`/`then`/`else`/`contains`/`propertyNames`.
- `hasIncompatibleNode` rejects `oneOf, allOf, not, if, then, else, dependentRequired, dependentSchemas` outright, and validates `$ref` nodes via a small local JSON-pointer resolver (string, local `#`/`#/...`, resolvable, no sibling keywords).
- `$ref` nodes are treated as leaves by `makeAllRequired`/`ensureTypeFields` (no `type`/`additionalProperties` injection). A newly-required (optional) `$ref` property is wrapped as `{"anyOf": [<$ref>, {"type": "null"}]}`, OpenAI's documented optional-reference pattern — with `ensureTypeFields` also skipping `anyOf`/`oneOf`/`allOf` nodes so this wrapper doesn't get a conflicting `type` sibling (a real bug an earlier draft of this PR had, caught in review).
- `pkg/tools/schema.go`'s `ensurePropertyTypes` skips `$ref` nodes (the root cause of the pollution above).

## Testing

- New test coverage in `pkg/model/provider/openai/schema_test.go` (T1–T14 from the design doc, plus an invariant test: normalizing a strict-compatible schema must never make it incompatible) and `pkg/tools/schema_test.go`.
- `task build`, `task test`, `task lint` all green (full suite, including `go mod tidy --diff` and the project's custom `go run ./lint .` cops).
- **Not automated**: a live-API check of whether OpenAI accepts a `$ref` node with a `description` sibling under `strict: true` (would relax the current conservative "no sibling keywords" rule to "no siblings other than `description`", per the `openai-python` SDK precedent this design follows). No OpenAI API key was available in this environment. Documented as a follow-up rather than blocking this fix.

## Out of scope

Structured Outputs size limits, root-level `anyOf` rejection, `anyOf`-typed optional property nullable-widening (pre-existing, unrelated gap), and inlining `$ref` (rejected approach — would break recursive schemas).
