### PR TITLE
feat(leantui): remove context usage progress bar

### DIFF
--- a/pkg/leantui/ui/status.go
+++ b/pkg/leantui/ui/status.go
@@ -5,6 +5,8 @@ import (
 	"strconv"
 	"strings"
 
+	"charm.land/lipgloss/v2"
+
 	pathx "github.com/docker/docker-agent/pkg/path"
 	"github.com/docker/docker-agent/pkg/tui/components/toolcommon"
 	"github.com/docker/docker-agent/pkg/tui/styles"
@@ -26,7 +28,7 @@ type StatusModel struct {
 	CostKnown     bool
 
 	// CompactionThreshold is the auto-compaction trigger fraction for the
-	// active agent (0 when unknown); the context bar colors against it.
+	// active agent (0 when unknown); the context percentage colors against it.
 	CompactionThreshold float64
 	// Compacting is true while a session compaction runs.
 	Compacting bool
@@ -35,7 +37,7 @@ type StatusModel struct {
 // RenderStatus builds the two-line footer:
 //
 //	<working dir>  ⎇ <branch>                          <agent>
-//	<context bar> <pct> · <tokens> · <cost>  <model> · <effort>
+//	<pct> · <tokens> · <cost>                 <model> · <effort>
 func RenderStatus(d StatusModel, width int) []string {
 	dir := StSecondary().Render(Truncate(pathx.ShortenHome(d.WorkingDir), max(10, width/2)))
 	left1 := dir
@@ -67,31 +69,30 @@ func RenderStatus(d StatusModel, width int) []string {
 
 // RenderContext renders the context and cost portion of the status.
 func RenderContext(d StatusModel) string {
-	Cost := renderCostSuffix(d)
+	cost := renderCostSuffix(d)
 	if d.ContextLimit <= 0 {
 		if d.Compacting {
-			return StWarning().Render("compacting…") + Cost
+			return StWarning().Render("compacting…") + cost
 		}
 		if d.Tokens > 0 {
-			return StMuted().Render(FormatTokens(d.Tokens)+" tokens") + Cost
+			return StMuted().Render(FormatTokens(d.Tokens)+" tokens") + cost
 		}
-		return RenderBar(0, 0) + StMuted().Render(" 0% · 0/0") + Cost
+		return StMuted().Render("0% · 0/0") + cost
 	}
 
 	pct := float64(d.ContextLength) / float64(d.ContextLimit)
 	if pct > 1 {
 		pct = 1
 	}
-	bar := RenderBar(pct, d.CompactionThreshold)
 	tokens := fmt.Sprintf(" · %s/%s",
 		FormatTokens(d.ContextLength),
 		FormatTokens(d.ContextLimit),
 	)
 	if d.Compacting {
-		return bar + StWarning().Render(" compacting…") + StMuted().Render(tokens) + Cost
+		return StWarning().Render("compacting…") + StMuted().Render(tokens) + cost
 	}
-	label := fmt.Sprintf(" %d%%", int(pct*100+0.5)) + tokens
-	return bar + StMuted().Render(label) + Cost
+	label := fmt.Sprintf("%d%%", int(pct*100+0.5)) + tokens
+	return contextStyle(pct, d.CompactionThreshold).Render(label) + cost
 }
 
 func renderCostSuffix(d StatusModel) string {
@@ -101,21 +102,17 @@ func renderCostSuffix(d StatusModel) string {
 	return StMuted().Render(" · ") + StAccent().Render(toolcommon.FormatCostUSD(d.Cost))
 }
 
-// ContextBarWidth is the cell width of the context-usage gauge.
-const ContextBarWidth = 10
-
-// RenderBar renders the context usage gauge, escalating its color as usage
-// approaches the auto-compaction threshold (0 uses the package default).
-func RenderBar(pct, threshold float64) string {
-	filled := min(int(pct*float64(ContextBarWidth)+0.5), ContextBarWidth)
-	style := StSuccess()
+// contextStyle escalates the context usage color as usage approaches the
+// auto-compaction threshold (0 uses the package default).
+func contextStyle(pct, threshold float64) lipgloss.Style {
 	switch styles.ContextGaugeLevelFor(pct, threshold) {
 	case styles.ContextGaugeCritical:
-		style = StError()
+		return StError()
 	case styles.ContextGaugeWarning:
-		style = StWarning()
+		return StWarning()
+	default:
+		return StMuted()
 	}
-	return style.Render(strings.Repeat("█", filled)) + StMuted().Render(strings.Repeat("░", ContextBarWidth-filled))
 }
 
 // ComposeLine right-aligns right within width, truncating left if necessary.

--- a/pkg/leantui/ui/status_test.go
+++ b/pkg/leantui/ui/status_test.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/charmbracelet/x/ansi"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -33,41 +34,38 @@ func TestComposeLineTruncatesLeft(t *testing.T) {
 	assert.Contains(t, out, "right")
 }
 
-func TestRenderBarWidth(t *testing.T) {
+func TestRenderContext(t *testing.T) {
 	t.Parallel()
-	assert.Equal(t, ContextBarWidth, DisplayWidth(RenderBar(0.5, 0)))
-	assert.Equal(t, ContextBarWidth, DisplayWidth(RenderBar(0, 0)))
-	assert.Equal(t, ContextBarWidth, DisplayWidth(RenderBar(1, 0)))
-	assert.Equal(t, ContextBarWidth, DisplayWidth(RenderBar(1.5, 0))) // clamped
-	assert.Equal(t, ContextBarWidth, DisplayWidth(RenderBar(0.8, 0.5)))
+	tests := []struct {
+		name string
+		d    StatusModel
+		want string
+	}{
+		{"before any usage", StatusModel{}, "0% · 0/0"},
+		{"limit known before usage", StatusModel{ContextLimit: 200_000}, "0% · 0/200.0k"},
+		{"usage within limit", StatusModel{ContextLength: 24_000, ContextLimit: 200_000}, "12% · 24.0k/200.0k"},
+		{"usage over limit clamps the percentage", StatusModel{ContextLength: 15_000, ContextLimit: 10_000}, "100% · 15.0k/10.0k"},
+		{"tokens without a known limit", StatusModel{Tokens: 1_200}, "1.2k tokens"},
+		{"compacting keeps the token counts", StatusModel{ContextLength: 9_000, ContextLimit: 10_000, Compacting: true}, "compacting… · 9.0k/10.0k"},
+		{"compacting without a known limit", StatusModel{Compacting: true}, "compacting…"},
+		{"cost is appended when known", StatusModel{ContextLength: 5_000, ContextLimit: 10_000, Cost: 0.05, CostKnown: true}, "50% · 5.0k/10.0k · $0.05"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, ansi.Strip(RenderContext(tt.d)))
+		})
+	}
 }
 
-func TestRenderContextShowsZerosBeforeUsage(t *testing.T) {
+func TestContextStyleEscalatesTowardsTheThreshold(t *testing.T) {
 	t.Parallel()
-	out := RenderContext(StatusModel{})
-	assert.NotContains(t, out, "context")
-	assert.Contains(t, out, "0% · 0/0")
-}
+	render := func(pct, threshold float64) string { return contextStyle(pct, threshold).Render("x") }
 
-func TestRenderContextCompacting(t *testing.T) {
-	t.Parallel()
-	d := StatusModel{ContextLength: 9_000, ContextLimit: 10_000, Compacting: true}
-
-	out := RenderContext(d)
-	assert.Contains(t, out, "compacting…")
-	assert.NotContains(t, out, "90%", "the percentage yields to the compacting indicator")
-	assert.Contains(t, out, "9.0k/10.0k", "token counts stay visible while compacting")
-
-	d.Compacting = false
-	out = RenderContext(d)
-	assert.Contains(t, out, "90%")
-	assert.NotContains(t, out, "compacting…")
-}
-
-func TestRenderContextCompactingWithoutLimit(t *testing.T) {
-	t.Parallel()
-	out := RenderContext(StatusModel{Compacting: true})
-	assert.Contains(t, out, "compacting…")
+	assert.Equal(t, StMuted().Render("x"), render(0.5, 0))
+	assert.Equal(t, StWarning().Render("x"), render(0.7, 0))
+	assert.Equal(t, StError().Render("x"), render(0.95, 0))
+	assert.Equal(t, StError().Render("x"), render(0.48, 0.5), "a configured threshold moves the bands")
 }
 
 func TestRenderStatusFitsWidth(t *testing.T) {


### PR DESCRIPTION
## What

Removes the context-usage progress bar (`██████░░░░`) from the lean TUI footer.

The second footer line goes from:

```
██████░░░░ 60% · 120.0k/200.0k · $0.05        openai/gpt-5 · high
```

to:

```
60% · 120.0k/200.0k · $0.05                   openai/gpt-5 · high
```

## Details

- Dropped `ui.RenderBar` and the `ContextBarWidth` constant.
- The auto-compaction threshold still drives color escalation — it now colors the context text (normal → muted, warning, critical) instead of the gauge, so `StatusModel.CompactionThreshold` stays meaningful.
- Compaction state is unchanged: `compacting… · 9.0k/10.0k`.

## Tests

The scattered `Contains`/`NotContains` assertions on `RenderContext` are replaced by one table test asserting the **exact** ANSI-stripped output for every state (no usage, known limit, over-limit clamp, tokens without a limit, compacting with and without a limit, cost), plus a small test pinning the color-escalation bands.

## Validation

`go build ./pkg/...`, `go vet ./pkg/leantui/...`, `go test ./pkg/leantui/... ./pkg/tui/...` — all green.
