### PR TITLE
fix(rag): atomic per-file vector store persistence (#4073)

### DIFF
--- a/pkg/rag/strategy/chunked_embeddings_database.go
+++ b/pkg/rag/strategy/chunked_embeddings_database.go
@@ -85,19 +85,18 @@ func (d *chunkedVectorDB) createSchema(ctx context.Context) error {
 	return err
 }
 
-// AddDocumentWithEmbedding implements vectorStoreDB.
-// For chunked-embeddings, the embeddingInput parameter is ignored.
-func (d *chunkedVectorDB) AddDocumentWithEmbedding(ctx context.Context, doc database.Document, embedding []float64, _ string) error {
-	if len(embedding) == 0 {
-		return errors.New("embedding is required for vector database")
+// ReplaceFileDocuments implements vectorStoreDB.
+// It atomically replaces a file's indexed state in a single transaction:
+// delete the existing row (cascades to its chunks) -> insert the files row
+// with the final hash -> insert every chunk. If any step fails the whole
+// transaction rolls back, leaving the previous version (if any) intact.
+// For chunked-embeddings, embeddingInputs is ignored.
+func (d *chunkedVectorDB) ReplaceFileDocuments(ctx context.Context, meta database.FileMetadata, docs []database.Document, embeddings [][]float64, embeddingInputs []string) error {
+	if len(docs) == 0 {
+		return errors.New("replace file documents: at least one document is required; use DeleteDocumentsByPath for an empty file")
 	}
-	if len(embedding) != d.vectorDimensions {
-		return fmt.Errorf("embedding dimension mismatch: got %d, expected %d", len(embedding), d.vectorDimensions)
-	}
-
-	embJSON, err := json.Marshal(embedding)
-	if err != nil {
-		return fmt.Errorf("failed to marshal embedding: %w", err)
+	if len(docs) != len(embeddings) || len(docs) != len(embeddingInputs) {
+		return fmt.Errorf("replace file documents: got %d docs, %d embeddings, %d embedding inputs", len(docs), len(embeddings), len(embeddingInputs))
 	}
 
 	tx, err := d.db.BeginTx(ctx, nil)
@@ -106,24 +105,41 @@ func (d *chunkedVectorDB) AddDocumentWithEmbedding(ctx context.Context, doc data
 	}
 	defer func() { _ = tx.Rollback() }()
 
-	_, err = tx.ExecContext(ctx,
-		fmt.Sprintf(`INSERT INTO %s (source_path, file_hash, indexed_at)
-		 VALUES (?, ?, CURRENT_TIMESTAMP)
-		 ON CONFLICT(source_path) 
-		 DO UPDATE SET file_hash = excluded.file_hash, indexed_at = CURRENT_TIMESTAMP`, d.filesTable),
-		doc.SourcePath, doc.FileHash)
-	if err != nil {
-		return fmt.Errorf("failed to upsert file metadata: %w", err)
+	if _, err := tx.ExecContext(ctx, fmt.Sprintf("DELETE FROM %s WHERE source_path = ?", d.filesTable), meta.SourcePath); err != nil {
+		return fmt.Errorf("failed to delete old file row: %w", err)
 	}
 
 	_, err = tx.ExecContext(ctx,
-		fmt.Sprintf(`INSERT INTO %s (source_path, chunk_index, content, embedding)
-		 VALUES (?, ?, ?, ?)
-		 ON CONFLICT(source_path, chunk_index) 
-		 DO UPDATE SET content = excluded.content, embedding = excluded.embedding`, d.chunksTable),
-		doc.SourcePath, doc.ChunkIndex, doc.Content, embJSON)
+		fmt.Sprintf(`INSERT INTO %s (source_path, file_hash, indexed_at) VALUES (?, ?, CURRENT_TIMESTAMP)`, d.filesTable),
+		meta.SourcePath, meta.FileHash)
 	if err != nil {
-		return fmt.Errorf("failed to upsert chunk: %w", err)
+		return fmt.Errorf("failed to insert file metadata: %w", err)
+	}
+
+	chunkStmt, err := tx.PrepareContext(ctx,
+		fmt.Sprintf(`INSERT INTO %s (source_path, chunk_index, content, embedding) VALUES (?, ?, ?, ?)`, d.chunksTable))
+	if err != nil {
+		return fmt.Errorf("failed to prepare chunk insert: %w", err)
+	}
+	defer chunkStmt.Close()
+
+	for i, doc := range docs {
+		embedding := embeddings[i]
+		if len(embedding) == 0 {
+			return errors.New("embedding is required for vector database")
+		}
+		if len(embedding) != d.vectorDimensions {
+			return fmt.Errorf("embedding dimension mismatch: got %d, expected %d", len(embedding), d.vectorDimensions)
+		}
+
+		embJSON, err := json.Marshal(embedding)
+		if err != nil {
+			return fmt.Errorf("failed to marshal embedding: %w", err)
+		}
+
+		if _, err := chunkStmt.ExecContext(ctx, doc.SourcePath, doc.ChunkIndex, doc.Content, embJSON); err != nil {
+			return fmt.Errorf("failed to insert chunk %d: %w", doc.ChunkIndex, err)
+		}
 	}
 
 	return tx.Commit()
@@ -209,16 +225,6 @@ func (d *chunkedVectorDB) GetFileMetadata(ctx context.Context, sourcePath string
 	}
 
 	return &metadata, nil
-}
-
-func (d *chunkedVectorDB) SetFileMetadata(ctx context.Context, metadata database.FileMetadata) error {
-	_, err := d.db.ExecContext(ctx,
-		fmt.Sprintf(`INSERT INTO %s (source_path, file_hash, indexed_at)
-		 VALUES (?, ?, CURRENT_TIMESTAMP)
-		 ON CONFLICT(source_path) 
-		 DO UPDATE SET file_hash = excluded.file_hash, indexed_at = CURRENT_TIMESTAMP`, d.filesTable),
-		metadata.SourcePath, metadata.FileHash)
-	return err
 }
 
 func (d *chunkedVectorDB) GetAllFileMetadata(ctx context.Context) ([]database.FileMetadata, error) {

--- a/pkg/rag/strategy/semantic_embeddings_database.go
+++ b/pkg/rag/strategy/semantic_embeddings_database.go
@@ -92,19 +92,17 @@ func (d *semanticVectorDB) createSchema(ctx context.Context) error {
 	return nil
 }
 
-// AddDocumentWithEmbedding implements vectorStoreDB.
-// For semantic-embeddings, the embeddingInput contains the LLM-generated summary.
-func (d *semanticVectorDB) AddDocumentWithEmbedding(ctx context.Context, doc database.Document, embedding []float64, embeddingInput string) error {
-	if len(embedding) == 0 {
-		return errors.New("embedding is required for vector database")
+// ReplaceFileDocuments implements vectorStoreDB.
+// It atomically replaces a file's indexed state in a single transaction:
+// delete the existing row (cascades to its chunks) -> insert the files row
+// with the final hash -> insert every chunk. If any step fails the whole
+// transaction rolls back, leaving the previous version (if any) intact.
+func (d *semanticVectorDB) ReplaceFileDocuments(ctx context.Context, meta database.FileMetadata, docs []database.Document, embeddings [][]float64, embeddingInputs []string) error {
+	if len(docs) == 0 {
+		return errors.New("replace file documents: at least one document is required; use DeleteDocumentsByPath for an empty file")
 	}
-	if len(embedding) != d.vectorDimensions {
-		return fmt.Errorf("embedding dimension mismatch: got %d, expected %d", len(embedding), d.vectorDimensions)
-	}
-
-	embJSON, err := json.Marshal(embedding)
-	if err != nil {
-		return fmt.Errorf("failed to marshal embedding: %w", err)
+	if len(docs) != len(embeddings) || len(docs) != len(embeddingInputs) {
+		return fmt.Errorf("replace file documents: got %d docs, %d embeddings, %d embedding inputs", len(docs), len(embeddings), len(embeddingInputs))
 	}
 
 	tx, err := d.db.BeginTx(ctx, nil)
@@ -113,24 +111,41 @@ func (d *semanticVectorDB) AddDocumentWithEmbedding(ctx context.Context, doc dat
 	}
 	defer func() { _ = tx.Rollback() }()
 
-	_, err = tx.ExecContext(ctx,
-		fmt.Sprintf(`INSERT INTO %s (source_path, file_hash, indexed_at)
-		 VALUES (?, ?, CURRENT_TIMESTAMP)
-		 ON CONFLICT(source_path) 
-		 DO UPDATE SET file_hash = excluded.file_hash, indexed_at = CURRENT_TIMESTAMP`, d.filesTable),
-		doc.SourcePath, doc.FileHash)
-	if err != nil {
-		return fmt.Errorf("failed to upsert file metadata: %w", err)
+	if _, err := tx.ExecContext(ctx, fmt.Sprintf("DELETE FROM %s WHERE source_path = ?", d.filesTable), meta.SourcePath); err != nil {
+		return fmt.Errorf("failed to delete old file row: %w", err)
 	}
 
 	_, err = tx.ExecContext(ctx,
-		fmt.Sprintf(`INSERT INTO %s (source_path, chunk_index, content, embedding, embedding_input)
-		 VALUES (?, ?, ?, ?, ?)
-		 ON CONFLICT(source_path, chunk_index) 
-		 DO UPDATE SET content = excluded.content, embedding = excluded.embedding, embedding_input = excluded.embedding_input`, d.chunksTable),
-		doc.SourcePath, doc.ChunkIndex, doc.Content, embJSON, embeddingInput)
+		fmt.Sprintf(`INSERT INTO %s (source_path, file_hash, indexed_at) VALUES (?, ?, CURRENT_TIMESTAMP)`, d.filesTable),
+		meta.SourcePath, meta.FileHash)
 	if err != nil {
-		return fmt.Errorf("failed to upsert chunk: %w", err)
+		return fmt.Errorf("failed to insert file metadata: %w", err)
+	}
+
+	chunkStmt, err := tx.PrepareContext(ctx,
+		fmt.Sprintf(`INSERT INTO %s (source_path, chunk_index, content, embedding, embedding_input) VALUES (?, ?, ?, ?, ?)`, d.chunksTable))
+	if err != nil {
+		return fmt.Errorf("failed to prepare chunk insert: %w", err)
+	}
+	defer chunkStmt.Close()
+
+	for i, doc := range docs {
+		embedding := embeddings[i]
+		if len(embedding) == 0 {
+			return errors.New("embedding is required for vector database")
+		}
+		if len(embedding) != d.vectorDimensions {
+			return fmt.Errorf("embedding dimension mismatch: got %d, expected %d", len(embedding), d.vectorDimensions)
+		}
+
+		embJSON, err := json.Marshal(embedding)
+		if err != nil {
+			return fmt.Errorf("failed to marshal embedding: %w", err)
+		}
+
+		if _, err := chunkStmt.ExecContext(ctx, doc.SourcePath, doc.ChunkIndex, doc.Content, embJSON, embeddingInputs[i]); err != nil {
+			return fmt.Errorf("failed to insert chunk %d: %w", doc.ChunkIndex, err)
+		}
 	}
 
 	return tx.Commit()
@@ -218,16 +233,6 @@ func (d *semanticVectorDB) GetFileMetadata(ctx context.Context, sourcePath strin
 	}
 
 	return &metadata, nil
-}
-
-func (d *semanticVectorDB) SetFileMetadata(ctx context.Context, metadata database.FileMetadata) error {
-	_, err := d.db.ExecContext(ctx,
-		fmt.Sprintf(`INSERT INTO %s (source_path, file_hash, indexed_at)
-		 VALUES (?, ?, CURRENT_TIMESTAMP)
-		 ON CONFLICT(source_path) 
-		 DO UPDATE SET file_hash = excluded.file_hash, indexed_at = CURRENT_TIMESTAMP`, d.filesTable),
-		metadata.SourcePath, metadata.FileHash)
-	return err
 }
 
 func (d *semanticVectorDB) GetAllFileMetadata(ctx context.Context) ([]database.FileMetadata, error) {

--- a/pkg/rag/strategy/vector_store.go
+++ b/pkg/rag/strategy/vector_store.go
@@ -25,11 +25,17 @@ import (
 
 // vectorStoreDB is the internal database interface used by VectorStore.
 type vectorStoreDB interface {
-	AddDocumentWithEmbedding(ctx context.Context, doc database.Document, embedding []float64, embeddingInput string) error
+	// ReplaceFileDocuments atomically replaces a file's indexed state: the
+	// file's existing row and chunks are deleted, a row with the final hash
+	// is inserted, then every chunk in docs is inserted, all in one
+	// transaction. Callers must invoke this only after every model call for
+	// the file (embeddings, embedding inputs) has already succeeded, so a
+	// file is always either fully indexed (old or new version) or absent -
+	// never left half-written by an interruption.
+	ReplaceFileDocuments(ctx context.Context, meta database.FileMetadata, docs []database.Document, embeddings [][]float64, embeddingInputs []string) error
 	SearchSimilarVectors(ctx context.Context, queryEmbedding []float64, limit int) ([]VectorSearchResultData, error)
 	DeleteDocumentsByPath(ctx context.Context, sourcePath string) error
 	GetFileMetadata(ctx context.Context, sourcePath string) (*database.FileMetadata, error)
-	SetFileMetadata(ctx context.Context, metadata database.FileMetadata) error
 	GetAllFileMetadata(ctx context.Context) ([]database.FileMetadata, error)
 	DeleteFileMetadata(ctx context.Context, sourcePath string) error
 	Close() error
@@ -542,6 +548,16 @@ func (s *VectorStore) loadExistingHashes(ctx context.Context) error {
 	defer s.fileHashesMu.Unlock()
 
 	for _, meta := range metadata {
+		if meta.ChunkCount == 0 {
+			// A files row with zero chunks cannot be produced by this version
+			// (atomic ReplaceFileDocuments always writes >=1 chunk, or the file
+			// is absent entirely). It is a leftover from the pre-fix premature-
+			// hash bug (an interruption mid-file left the hash recorded with no
+			// chunks stored) - treat it as not indexed so it gets re-indexed.
+			slog.WarnContext(ctx, "File metadata has zero chunks, treating as not indexed",
+				"path", meta.SourcePath)
+			continue
+		}
 		s.fileHashes[meta.SourcePath] = meta.FileHash
 		slog.DebugContext(ctx, "Loaded file hash from metadata",
 			"path", meta.SourcePath,
@@ -584,10 +600,6 @@ func (s *VectorStore) indexFile(ctx context.Context, filePath string) error {
 		return fmt.Errorf("failed to hash file: %w", err)
 	}
 
-	if err := s.db.DeleteDocumentsByPath(ctx, filePath); err != nil {
-		return fmt.Errorf("failed to delete old documents: %w", err)
-	}
-
 	chunks, err := chunk.ProcessFile(ctx, s.docProcessor, filePath)
 	if err != nil {
 		return fmt.Errorf("failed to process file: %w", err)
@@ -611,6 +623,14 @@ func (s *VectorStore) indexFile(ctx context.Context, filePath string) error {
 
 	if len(validChunks) == 0 {
 		slog.DebugContext(ctx, "No valid chunks in file", "path", filePath)
+		// A file with no chunks has nothing to keep indexed; drop any
+		// previous version so stale chunks don't linger.
+		if err := s.db.DeleteDocumentsByPath(ctx, filePath); err != nil {
+			return fmt.Errorf("failed to delete old documents: %w", err)
+		}
+		s.fileHashesMu.Lock()
+		delete(s.fileHashes, filePath)
+		s.fileHashesMu.Unlock()
 		return nil
 	}
 
@@ -639,40 +659,28 @@ func (s *VectorStore) indexFile(ctx context.Context, filePath string) error {
 		return fmt.Errorf("embedding count mismatch: got %d embeddings for %d chunks", len(embeddings), len(validChunks))
 	}
 
-	// Store all documents
-	storedChunks := 0
+	// All model calls succeeded - persist the new version atomically. Until
+	// this call commits, the previous version (if any) remains intact, so an
+	// interruption here never leaves the file half-written or wrongly marked
+	// as up to date.
+	docs := make([]database.Document, len(validChunks))
 	for i, ch := range validChunks {
-		// Check for context cancellation
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		default:
-		}
-
-		doc := database.Document{
-			ID:         fmt.Sprintf("%s_%d_%d", filePath, ch.Index, time.Now().UnixNano()),
+		docs[i] = database.Document{
+			ID:         fmt.Sprintf("%s_%d", filePath, ch.Index),
 			SourcePath: filePath,
 			ChunkIndex: ch.Index,
 			Content:    ch.Content,
 			FileHash:   fileHash,
 		}
-
-		// Pass embedding and embedding input separately - the database implementation
-		// decides what to store based on strategy type (chunked vs semantic)
-		if err := s.db.AddDocumentWithEmbedding(ctx, doc, embeddings[i], chunkContents[i]); err != nil {
-			return fmt.Errorf("failed to add document: %w", err)
-		}
-
-		storedChunks++
 	}
 
 	metadata := database.FileMetadata{
 		SourcePath: filePath,
 		FileHash:   fileHash,
-		ChunkCount: storedChunks,
+		ChunkCount: len(docs),
 	}
-	if err := s.db.SetFileMetadata(ctx, metadata); err != nil {
-		return fmt.Errorf("failed to update file metadata: %w", err)
+	if err := s.db.ReplaceFileDocuments(ctx, metadata, docs, embeddings, chunkContents); err != nil {
+		return fmt.Errorf("failed to replace file documents: %w", err)
 	}
 
 	// Update fileHashes map with mutex protection for concurrent indexing
@@ -680,7 +688,7 @@ func (s *VectorStore) indexFile(ctx context.Context, filePath string) error {
 	s.fileHashes[filePath] = fileHash
 	s.fileHashesMu.Unlock()
 
-	slog.DebugContext(ctx, "Indexed file", "path", filePath, "chunks", storedChunks)
+	slog.DebugContext(ctx, "Indexed file", "path", filePath, "chunks", len(docs))
 	return nil
 }
 

--- a/pkg/rag/strategy/vector_store_db_test.go
+++ b/pkg/rag/strategy/vector_store_db_test.go
@@ -1,0 +1,231 @@
+package strategy
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/docker/docker-agent/pkg/rag/database"
+)
+
+// testVectorDimensions and testDocPath are fixed across the atomicity tests
+// below - only the DB behavior under test varies.
+const (
+	testVectorDimensions = 3
+	testDocPath          = "/a.txt"
+)
+
+// vectorDBFactory constructs a vectorStoreDB backend for the atomicity tests
+// below, so they can run identically against both the semantic-embeddings
+// and chunked-embeddings SQLite implementations.
+type vectorDBFactory struct {
+	name string
+	new  func(ctx context.Context, dbPath string) (vectorStoreDB, error)
+}
+
+var vectorDBFactories = []vectorDBFactory{
+	{
+		name: "semantic",
+		new: func(ctx context.Context, dbPath string) (vectorStoreDB, error) {
+			return newSemanticVectorDB(ctx, dbPath, testVectorDimensions, "semantic")
+		},
+	},
+	{
+		name: "chunked",
+		new: func(ctx context.Context, dbPath string) (vectorStoreDB, error) {
+			return newChunkedVectorDB(ctx, dbPath, testVectorDimensions, "chunked")
+		},
+	},
+}
+
+func newTestDB(t *testing.T, factory vectorDBFactory) vectorStoreDB {
+	t.Helper()
+	dbPath := filepath.Join(t.TempDir(), "test.db")
+	db, err := factory.new(t.Context(), dbPath)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+	return db
+}
+
+func docsFor(contents ...string) []database.Document {
+	docs := make([]database.Document, len(contents))
+	for i, c := range contents {
+		docs[i] = database.Document{
+			ID:         testDocPath,
+			SourcePath: testDocPath,
+			ChunkIndex: i,
+			Content:    c,
+			FileHash:   "irrelevant",
+		}
+	}
+	return docs
+}
+
+func embeddingsFor(n int) [][]float64 {
+	embeddings := make([][]float64, n)
+	for i := range embeddings {
+		vec := make([]float64, testVectorDimensions)
+		for j := range vec {
+			vec[j] = float64(i*testVectorDimensions + j)
+		}
+		embeddings[i] = vec
+	}
+	return embeddings
+}
+
+func inputsFor(prefix string, n int) []string {
+	inputs := make([]string, n)
+	for i := range inputs {
+		inputs[i] = prefix
+	}
+	return inputs
+}
+
+func TestReplaceFileDocuments_WritesFileAndChunks(t *testing.T) {
+	t.Parallel()
+	for _, factory := range vectorDBFactories {
+		t.Run(factory.name, func(t *testing.T) {
+			t.Parallel()
+			db := newTestDB(t, factory)
+			ctx := t.Context()
+
+			docs := docsFor("chunk one", "chunk two")
+			meta := database.FileMetadata{SourcePath: testDocPath, FileHash: "hash-v1", ChunkCount: len(docs)}
+			require.NoError(t, db.ReplaceFileDocuments(ctx, meta, docs, embeddingsFor(2), inputsFor("summary", 2)))
+
+			all, err := db.GetAllFileMetadata(ctx)
+			require.NoError(t, err)
+			require.Len(t, all, 1)
+			assert.Equal(t, "hash-v1", all[0].FileHash)
+			assert.Equal(t, 2, all[0].ChunkCount)
+
+			results, err := db.SearchSimilarVectors(ctx, embeddingsFor(1)[0], 10)
+			require.NoError(t, err)
+			require.Len(t, results, 2)
+			gotContents := []string{results[0].Content, results[1].Content}
+			assert.ElementsMatch(t, []string{"chunk one", "chunk two"}, gotContents)
+		})
+	}
+}
+
+func TestReplaceFileDocuments_ReplacesFewerChunksLeavesNoStaleData(t *testing.T) {
+	t.Parallel()
+	for _, factory := range vectorDBFactories {
+		t.Run(factory.name, func(t *testing.T) {
+			t.Parallel()
+			db := newTestDB(t, factory)
+			ctx := t.Context()
+
+			v1 := docsFor("one", "two", "three")
+			require.NoError(t, db.ReplaceFileDocuments(ctx, database.FileMetadata{SourcePath: testDocPath, FileHash: "v1", ChunkCount: 3}, v1, embeddingsFor(3), inputsFor("s", 3)))
+
+			v2 := docsFor("only")
+			require.NoError(t, db.ReplaceFileDocuments(ctx, database.FileMetadata{SourcePath: testDocPath, FileHash: "v2", ChunkCount: 1}, v2, embeddingsFor(1), inputsFor("s", 1)))
+
+			all, err := db.GetAllFileMetadata(ctx)
+			require.NoError(t, err)
+			require.Len(t, all, 1)
+			assert.Equal(t, "v2", all[0].FileHash)
+			assert.Equal(t, 1, all[0].ChunkCount, "stale chunks from v1 must not remain")
+
+			results, err := db.SearchSimilarVectors(ctx, embeddingsFor(1)[0], 10)
+			require.NoError(t, err)
+			require.Len(t, results, 1)
+			assert.Equal(t, "only", results[0].Content)
+		})
+	}
+}
+
+func TestReplaceFileDocuments_RollsBackOnBadChunkLeavingPreviousVersionIntact(t *testing.T) {
+	t.Parallel()
+	for _, factory := range vectorDBFactories {
+		t.Run(factory.name, func(t *testing.T) {
+			t.Parallel()
+			db := newTestDB(t, factory)
+			ctx := t.Context()
+
+			v1 := docsFor("one", "two")
+			require.NoError(t, db.ReplaceFileDocuments(ctx, database.FileMetadata{SourcePath: testDocPath, FileHash: "v1", ChunkCount: 2}, v1, embeddingsFor(2), inputsFor("s", 2)))
+
+			// v2 has a bad final embedding (wrong dimension) - the whole
+			// transaction must roll back, leaving v1 exactly as it was.
+			v2 := docsFor("new one", "new two")
+			badEmbeddings := embeddingsFor(2)
+			badEmbeddings[1] = []float64{1, 2} // wrong dimension
+			err := db.ReplaceFileDocuments(ctx, database.FileMetadata{SourcePath: testDocPath, FileHash: "v2", ChunkCount: 2}, v2, badEmbeddings, inputsFor("s", 2))
+			require.Error(t, err)
+
+			all, err := db.GetAllFileMetadata(ctx)
+			require.NoError(t, err)
+			require.Len(t, all, 1, "v1's file row must still be present")
+			assert.Equal(t, "v1", all[0].FileHash, "hash must not have moved to v2")
+			assert.Equal(t, 2, all[0].ChunkCount)
+
+			results, err := db.SearchSimilarVectors(ctx, embeddingsFor(1)[0], 10)
+			require.NoError(t, err)
+			require.Len(t, results, 2, "v1's chunks must be untouched")
+			gotContents := []string{results[0].Content, results[1].Content}
+			assert.ElementsMatch(t, []string{"one", "two"}, gotContents, "v1's chunk content must be byte-identical")
+		})
+	}
+}
+
+func TestDeleteDocumentsByPath_CascadesChunksToZero(t *testing.T) {
+	t.Parallel()
+	for _, factory := range vectorDBFactories {
+		t.Run(factory.name, func(t *testing.T) {
+			t.Parallel()
+			db := newTestDB(t, factory)
+			ctx := t.Context()
+
+			docs := docsFor("one", "two")
+			require.NoError(t, db.ReplaceFileDocuments(ctx, database.FileMetadata{SourcePath: testDocPath, FileHash: "v1", ChunkCount: 2}, docs, embeddingsFor(2), inputsFor("s", 2)))
+
+			require.NoError(t, db.DeleteDocumentsByPath(ctx, testDocPath))
+
+			all, err := db.GetAllFileMetadata(ctx)
+			require.NoError(t, err)
+			assert.Empty(t, all)
+
+			results, err := db.SearchSimilarVectors(ctx, embeddingsFor(1)[0], 10)
+			require.NoError(t, err)
+			assert.Empty(t, results)
+		})
+	}
+}
+
+func TestReplaceFileDocuments_SemanticEmbeddingInputRoundTrips(t *testing.T) {
+	t.Parallel()
+	db := newTestDB(t, vectorDBFactories[0]) // semantic
+	ctx := t.Context()
+
+	docs := docsFor("raw chunk content")
+	require.NoError(t, db.ReplaceFileDocuments(ctx, database.FileMetadata{SourcePath: testDocPath, FileHash: "v1", ChunkCount: 1}, docs, embeddingsFor(1), []string{"LLM-generated summary"}))
+
+	results, err := db.SearchSimilarVectors(ctx, embeddingsFor(1)[0], 10)
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	assert.Equal(t, "LLM-generated summary", results[0].EmbeddingInput)
+	assert.Equal(t, "raw chunk content", results[0].Content)
+}
+
+func TestReplaceFileDocuments_RejectsEmptyDocs(t *testing.T) {
+	t.Parallel()
+	for _, factory := range vectorDBFactories {
+		t.Run(factory.name, func(t *testing.T) {
+			t.Parallel()
+			db := newTestDB(t, factory)
+			ctx := t.Context()
+
+			err := db.ReplaceFileDocuments(ctx, database.FileMetadata{SourcePath: testDocPath, FileHash: "v1", ChunkCount: 0}, nil, nil, nil)
+			require.Error(t, err, "replacing with zero documents must be rejected, not silently recreate the zero-chunk-row anomaly this fix targets")
+
+			all, err := db.GetAllFileMetadata(ctx)
+			require.NoError(t, err)
+			assert.Empty(t, all)
+		})
+	}
+}

--- a/pkg/rag/strategy/vector_store_test.go
+++ b/pkg/rag/strategy/vector_store_test.go
@@ -82,13 +82,32 @@ func (f *fakeEmbeddingProvider) CreateEmbedding(context.Context, string) (*base.
 type fakeVectorDB struct {
 	mu       sync.Mutex
 	metadata map[string]database.FileMetadata
+	docs     map[string][]database.Document
+
+	// onReplace, when set, is invoked for every ReplaceFileDocuments call
+	// before it takes effect. Returning an error simulates a commit failure
+	// (e.g. an interruption): the metadata/docs for that file are left
+	// exactly as they were before the call.
+	onReplace func(ctx context.Context, meta database.FileMetadata) error
 }
 
 func newFakeVectorDB() *fakeVectorDB {
-	return &fakeVectorDB{metadata: make(map[string]database.FileMetadata)}
+	return &fakeVectorDB{
+		metadata: make(map[string]database.FileMetadata),
+		docs:     make(map[string][]database.Document),
+	}
 }
 
-func (db *fakeVectorDB) AddDocumentWithEmbedding(context.Context, database.Document, []float64, string) error {
+func (db *fakeVectorDB) ReplaceFileDocuments(ctx context.Context, meta database.FileMetadata, docs []database.Document, _ [][]float64, _ []string) error {
+	if db.onReplace != nil {
+		if err := db.onReplace(ctx, meta); err != nil {
+			return err
+		}
+	}
+	db.mu.Lock()
+	defer db.mu.Unlock()
+	db.metadata[meta.SourcePath] = meta
+	db.docs[meta.SourcePath] = docs
 	return nil
 }
 
@@ -96,7 +115,15 @@ func (db *fakeVectorDB) SearchSimilarVectors(context.Context, []float64, int) ([
 	return nil, nil
 }
 
-func (db *fakeVectorDB) DeleteDocumentsByPath(context.Context, string) error { return nil }
+func (db *fakeVectorDB) DeleteDocumentsByPath(_ context.Context, sourcePath string) error {
+	db.mu.Lock()
+	defer db.mu.Unlock()
+	// Mirrors the real DBs: DeleteDocumentsByPath deletes the files row,
+	// which cascades to remove its chunks and drops the metadata too.
+	delete(db.docs, sourcePath)
+	delete(db.metadata, sourcePath)
+	return nil
+}
 
 func (db *fakeVectorDB) GetFileMetadata(_ context.Context, sourcePath string) (*database.FileMetadata, error) {
 	db.mu.Lock()
@@ -105,13 +132,6 @@ func (db *fakeVectorDB) GetFileMetadata(_ context.Context, sourcePath string) (*
 		return &meta, nil
 	}
 	return nil, nil
-}
-
-func (db *fakeVectorDB) SetFileMetadata(_ context.Context, meta database.FileMetadata) error {
-	db.mu.Lock()
-	defer db.mu.Unlock()
-	db.metadata[meta.SourcePath] = meta
-	return nil
 }
 
 func (db *fakeVectorDB) GetAllFileMetadata(context.Context) ([]database.FileMetadata, error) {
@@ -128,10 +148,45 @@ func (db *fakeVectorDB) DeleteFileMetadata(_ context.Context, sourcePath string)
 	db.mu.Lock()
 	defer db.mu.Unlock()
 	delete(db.metadata, sourcePath)
+	delete(db.docs, sourcePath)
 	return nil
 }
 
 func (db *fakeVectorDB) Close() error { return nil }
+
+// writeTestDocs creates n small text files under dir and returns their paths.
+func writeTestDocs(t *testing.T, dir string, n int) []string {
+	t.Helper()
+	docPaths := make([]string, 0, n)
+	for i := range n {
+		path := filepath.Join(dir, fmt.Sprintf("doc%d.txt", i))
+		require.NoError(t, os.WriteFile(path, fmt.Appendf(nil, "document %d content", i), 0o644))
+		docPaths = append(docPaths, path)
+	}
+	return docPaths
+}
+
+// newVectorStoreWithDB builds a VectorStore over a caller-supplied fake DB, so
+// tests can construct two stores (simulating a restart) that share the same
+// underlying persisted state.
+func newVectorStoreWithDB(fake *fakeEmbeddingProvider, db *fakeVectorDB) *VectorStore {
+	return newVectorStoreWithDBAndConcurrency(fake, db, 1)
+}
+
+// newVectorStoreWithDBAndConcurrency is newVectorStoreWithDB with a
+// caller-chosen FileIndexConcurrency, so tests can exercise the concurrent
+// errgroup path (e.g. racing writes to firstGateArmingErr) instead of the
+// strictly sequential default.
+func newVectorStoreWithDBAndConcurrency(fake *fakeEmbeddingProvider, db *fakeVectorDB, fileIndexConcurrency int) *VectorStore {
+	return NewVectorStore(VectorStoreConfig{
+		Name:                 "test",
+		Database:             db,
+		Embedder:             embed.New(fake),
+		EmbeddingConcurrency: 1,
+		FileIndexConcurrency: fileIndexConcurrency,
+		Chunking:             ChunkingConfig{Size: 1024, Overlap: 0},
+	})
+}
 
 func newTestVectorStore(t *testing.T, embedErr error) (*VectorStore, *fakeEmbeddingProvider, []string) {
 	t.Helper()
@@ -146,23 +201,10 @@ func newTestVectorStoreWithConcurrency(t *testing.T, embedErr error, fileIndexCo
 	t.Helper()
 
 	dir := t.TempDir()
-	const fileCount = 5
-	docPaths := make([]string, 0, fileCount)
-	for i := range fileCount {
-		path := filepath.Join(dir, fmt.Sprintf("doc%d.txt", i))
-		require.NoError(t, os.WriteFile(path, fmt.Appendf(nil, "document %d content", i), 0o644))
-		docPaths = append(docPaths, path)
-	}
+	docPaths := writeTestDocs(t, dir, 5)
 
 	fake := &fakeEmbeddingProvider{err: embedErr}
-	store := NewVectorStore(VectorStoreConfig{
-		Name:                 "test",
-		Database:             newFakeVectorDB(),
-		Embedder:             embed.New(fake),
-		EmbeddingConcurrency: 1,
-		FileIndexConcurrency: fileIndexConcurrency,
-		Chunking:             ChunkingConfig{Size: 1024, Overlap: 0},
-	})
+	store := newVectorStoreWithDBAndConcurrency(fake, newFakeVectorDB(), fileIndexConcurrency)
 
 	return store, fake, docPaths
 }
@@ -316,4 +358,144 @@ func TestBuildEmbeddingInputsFallsBackOnTransientError(t *testing.T) {
 	err := store.Initialize(t.Context(), docPaths, ChunkingConfig{Size: 1024})
 	require.NoError(t, err, "transient LLM errors keep the raw-content fallback behavior")
 	assert.Equal(t, int64(len(docPaths)), fake.calls.Load())
+}
+
+// TestIndexFile_InterruptedCommitLeavesHashUnrecorded verifies the core D2
+// invariant: an interruption between "embeddings computed" and "commit"
+// must never leave a file's new hash recorded without its chunks. Here the
+// interruption is simulated by cancelling the ctx passed to
+// ReplaceFileDocuments right before it would take effect.
+func TestIndexFile_InterruptedCommitLeavesHashUnrecorded(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	docPaths := writeTestDocs(t, dir, 1)
+	path := docPaths[0]
+
+	db := newFakeVectorDB()
+	ctx, cancel := context.WithCancel(t.Context())
+	db.onReplace = func(ctx context.Context, _ database.FileMetadata) error {
+		cancel()
+		return ctx.Err()
+	}
+
+	fake := &fakeEmbeddingProvider{}
+	store := newVectorStoreWithDB(fake, db)
+
+	err := store.indexFile(ctx, path)
+	require.Error(t, err)
+	require.ErrorIs(t, err, context.Canceled)
+
+	all, dbErr := db.GetAllFileMetadata(t.Context())
+	require.NoError(t, dbErr)
+	assert.Empty(t, all, "an interrupted commit must leave no file metadata behind")
+
+	needsIndexing, err := store.needsIndexing(t.Context(), path)
+	require.NoError(t, err)
+	assert.True(t, needsIndexing, "file must still be considered not indexed after the interruption")
+
+	// Resume: a fresh store reloading hashes from the same (uncorrupted) db
+	// with a working ctx must re-index the file, never skip it.
+	db.onReplace = nil
+	fake2 := &fakeEmbeddingProvider{}
+	store2 := newVectorStoreWithDB(fake2, db)
+	require.NoError(t, store2.Initialize(t.Context(), docPaths, ChunkingConfig{Size: 1024}))
+	assert.Equal(t, int64(1), fake2.calls.Load(), "resume must re-embed the interrupted file")
+
+	all, dbErr = db.GetAllFileMetadata(t.Context())
+	require.NoError(t, dbErr)
+	assert.Len(t, all, 1)
+}
+
+// TestResumeAfterInterruption_SkipsCompletedFiles verifies that after a run
+// where one file fails transiently mid-commit, a second Initialize over the
+// same persisted state re-indexes only that file - completed files are
+// never re-embedded.
+func TestResumeAfterInterruption_SkipsCompletedFiles(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	docPaths := writeTestDocs(t, dir, 5)
+	failPath := docPaths[2]
+
+	db := newFakeVectorDB()
+	var failedOnce atomic.Bool
+	db.onReplace = func(_ context.Context, meta database.FileMetadata) error {
+		if meta.SourcePath == failPath && !failedOnce.Swap(true) {
+			return errors.New("simulated transient commit failure")
+		}
+		return nil
+	}
+
+	fake1 := &fakeEmbeddingProvider{}
+	store1 := newVectorStoreWithDB(fake1, db)
+	require.NoError(t, store1.Initialize(t.Context(), docPaths, ChunkingConfig{Size: 1024}),
+		"a transient per-file failure must not abort the whole run")
+	assert.Equal(t, int64(len(docPaths)), fake1.calls.Load(), "every file is attempted on the first run")
+
+	all, err := db.GetAllFileMetadata(t.Context())
+	require.NoError(t, err)
+	assert.Len(t, all, len(docPaths)-1, "the failed file must not have committed")
+
+	fake2 := &fakeEmbeddingProvider{}
+	store2 := newVectorStoreWithDB(fake2, db)
+	require.NoError(t, store2.Initialize(t.Context(), docPaths, ChunkingConfig{Size: 1024}))
+	assert.Equal(t, int64(1), fake2.calls.Load(), "resume must only re-embed the still-missing file, not the completed ones")
+
+	all, err = db.GetAllFileMetadata(t.Context())
+	require.NoError(t, err)
+	assert.Len(t, all, len(docPaths), "all files must be indexed after resume")
+}
+
+// TestLoadExistingHashes_SkipsZeroChunkMetadata covers the self-heal path for
+// files left half-written by a pre-fix binary: a files row can exist with
+// file_hash set but zero chunks. It must not be treated as indexed.
+func TestLoadExistingHashes_SkipsZeroChunkMetadata(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	docPaths := writeTestDocs(t, dir, 1)
+	path := docPaths[0]
+
+	db := newFakeVectorDB()
+	db.mu.Lock()
+	db.metadata[path] = database.FileMetadata{SourcePath: path, FileHash: "stale-hash-from-pre-fix-binary", ChunkCount: 0}
+	db.mu.Unlock()
+
+	fake := &fakeEmbeddingProvider{}
+	store := newVectorStoreWithDB(fake, db)
+
+	require.NoError(t, store.loadExistingHashes(t.Context()))
+
+	needsIndexing, err := store.needsIndexing(t.Context(), path)
+	require.NoError(t, err)
+	assert.True(t, needsIndexing, "a zero-chunk metadata row must not be treated as indexed")
+}
+
+// TestIndexFile_FileBecomesEmptyCleansUpPreviousVersion covers the
+// len(validChunks) == 0 branch: a file that was previously indexed but has
+// no valid chunks on a later pass must have its old row/chunks removed and
+// its in-memory hash cleared, not left stale.
+func TestIndexFile_FileBecomesEmptyCleansUpPreviousVersion(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	docPaths := writeTestDocs(t, dir, 1)
+	path := docPaths[0]
+
+	db := newFakeVectorDB()
+	fake := &fakeEmbeddingProvider{}
+	store := newVectorStoreWithDB(fake, db)
+
+	require.NoError(t, store.indexFile(t.Context(), path))
+	all, err := db.GetAllFileMetadata(t.Context())
+	require.NoError(t, err)
+	require.Len(t, all, 1, "file must be indexed with its initial content")
+
+	require.NoError(t, os.WriteFile(path, nil, 0o644))
+	require.NoError(t, store.indexFile(t.Context(), path))
+
+	all, err = db.GetAllFileMetadata(t.Context())
+	require.NoError(t, err)
+	assert.Empty(t, all, "an emptied file must have no leftover metadata/chunks")
+
+	needsIndexing, err := store.needsIndexing(t.Context(), path)
+	require.NoError(t, err)
+	assert.True(t, needsIndexing, "fileHashes entry must be cleared so the file is re-checked")
 }


### PR DESCRIPTION
🤖 **Automated implementer agent** — *this comment was posted by the implementer bot from Docker Agentic Platform, not by a human developer*

Part of #4073 (part 1 of a 3-PR arc — T2/T3 build on top of this; not closing #4073 here).

## Bug

`AddDocumentWithEmbedding` upserted a file's `_files` row with the **new** hash on the *first* chunk stored (the chunks FK requires the row to exist first), and `indexFile` deleted the file's old chunks *before* the expensive embedding model calls ran. An interruption mid-file (crash, timeout, process exit) left a file that looked fully indexed (hash matches) but had missing/zero chunks — permanently skipped on every future resume, since the hash check passes.

## Fix

Replace per-chunk persistence with one atomic transaction per file:

```go
vectorStoreDB.ReplaceFileDocuments(ctx, meta, docs, embeddings, embeddingInputs) error
```

Implemented in both `semanticVectorDB` and `chunkedVectorDB` as a single SQLite transaction: delete the file's row (cascades to its chunks) → insert the row with the **final** hash → insert every chunk → commit. `indexFile` now calls this exactly once, only after every model call for the file has succeeded, and the early `DeleteDocumentsByPath` + per-chunk store loop are gone. A file is therefore always either fully indexed (old or new version) or absent — never half-written.

`AddDocumentWithEmbedding`/`SetFileMetadata` are removed from the `vectorStoreDB` interface (confirmed no other callers; BM25's separate `SetFileMetadata`/`bm25DB` interface is untouched, out of scope).

Self-heal (cheap, included): `loadExistingHashes` now treats a files row with `ChunkCount == 0` as not-indexed, recovering files left half-written by a pre-fix binary — no schema change needed since chunk count is already computed live via `COUNT()` join. A persisted `chunk_count` column was considered and deferred (unnecessary complexity for what the live COUNT already gives us).

## Tests

- `ReplaceFileDocuments` atomicity/rollback against real temp-file SQLite DBs for both backends, including a case that corrupts the *last* chunk's embedding dimension to prove the whole transaction rolls back, not just that row; plus fewer-chunks replacement, cascade-delete, semantic `embedding_input` round-trip, and an empty-docs guard.
- Cancellation between "embeddings computed" and "commit" leaves the file's hash unrecorded and the file re-indexed on resume.
- Resume after an interrupted run re-indexes only the missing/failed file — asserted via embedder call counts, not just outcomes.
- The "file becomes empty" cleanup path in `indexFile`.

## Validation

`go build ./...`, `task lint` (golangci-lint v2.13.1, `go run ./lint .`, `go mod tidy --diff`), and `go test ./...` all pass. The only failures are pre-existing `pkg/rag/treesitter` CGO-dependent tests (no `gcc` in this sandbox), unrelated to this change and already failing on `main`.
