### PR TITLE
feat(tools): non-blocking StartableToolSet status check (#4073)

### DIFF
--- a/pkg/runtime/agent_inspector_test.go
+++ b/pkg/runtime/agent_inspector_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -138,6 +139,85 @@ func TestAgentConfigInfo_Inspector(t *testing.T) {
 	assert.Equal(t, "git", git.Name)
 	assert.Equal(t, ToolsetStopped, git.State)
 	assert.Equal(t, []string{"status", "commit"}, git.Tools, "stopped toolset reports its declared allow-list")
+}
+
+// blockingNamedToolSet is a minimal Startable toolset whose Start blocks
+// until release is closed, modeling a toolset whose Start legitimately runs
+// for a long time in the background (e.g. RAG indexing a large knowledge
+// base, #4073).
+type blockingNamedToolSet struct {
+	entered chan struct{}
+	release chan struct{}
+}
+
+func (b *blockingNamedToolSet) Tools(context.Context) ([]tools.Tool, error) { return nil, nil }
+func (b *blockingNamedToolSet) Start(context.Context) error {
+	close(b.entered)
+	<-b.release
+	return nil
+}
+func (b *blockingNamedToolSet) Stop(context.Context) error { return nil }
+
+// TestAgentConfigInfo_ToolsetMidStartReportsStartingWithDeclaredTools pins
+// the #4073 fix end-to-end: while a toolset's Start is still running,
+// AgentConfigInfo (and the AgentToolsetStatuses it builds on) must not block
+// behind it, the lifecycle state must read as Starting rather than
+// Ready/Stopped, and the declared `tools:` allow-list is reported since no
+// live tool list exists yet.
+func TestAgentConfigInfo_ToolsetMidStartReportsStartingWithDeclaredTools(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	prov := &mockProvider{id: "openai/gpt-5"}
+
+	inner := &blockingNamedToolSet{entered: make(chan struct{}), release: make(chan struct{})}
+	ragTS := tools.WithName(inner, "docs")
+
+	root := agent.New("root", "", agent.WithModel(prov), agent.WithToolSets(ragTS))
+
+	cfg := latest.AgentConfig{
+		Name: "root",
+		Toolsets: []latest.Toolset{
+			{Type: "rag", Name: "docs", Tools: []string{"search_docs"}},
+		},
+	}
+
+	tm := team.New(
+		team.WithAgents(root),
+		team.WithAgentConfigs(map[string]latest.AgentConfig{"root": cfg}),
+	)
+	r := &LocalRuntime{team: tm, agents: newAgentRouter(tm, "root")}
+
+	startable := root.ToolSets()[0].(*tools.StartableToolSet)
+	startDone := make(chan error, 1)
+	go func() { startDone <- startable.Start(ctx) }()
+	<-inner.entered
+
+	infoDone := make(chan AgentConfigInfo, 1)
+	go func() { infoDone <- r.AgentConfigInfo(ctx, "root") }()
+
+	var got AgentConfigInfo
+	select {
+	case got = <-infoDone:
+	case <-time.After(5 * time.Second):
+		t.Fatal("AgentConfigInfo blocked behind an in-flight Start instead of reporting Starting")
+	}
+
+	require.Len(t, got.Toolsets, 1)
+	docs := got.Toolsets[0]
+	assert.Equal(t, "docs", docs.Name)
+	assert.Equal(t, ToolsetStarted, docs.State, "the Starting lifecycle state buckets as started/serving, not stopped or error")
+	assert.Equal(t, []string{"search_docs"}, docs.Tools, "mid-start toolset falls back to the declared allow-list, not an empty live list")
+
+	statuses := r.AgentToolsetStatuses("root")
+	require.Len(t, statuses, 1)
+	assert.Equal(t, lifecycle.StateStarting, statuses[0].State, "the underlying lifecycle state must read as Starting while the Start is in flight")
+
+	close(inner.release)
+	require.NoError(t, <-startDone)
+
+	statuses = r.AgentToolsetStatuses("root")
+	assert.Equal(t, lifecycle.StateReady, statuses[0].State, "settled start reports Ready")
 }
 
 // TestAgentConfigInfo_Degrades verifies graceful degradation: an unknown agent

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -1029,13 +1029,17 @@ func toolsetStateBucket(s lifecycle.State) ToolsetState {
 }
 
 // startedToolNames returns the live tool names of ts, but only when it is a
-// started toolset; the boolean is false for not-yet-started toolsets so the
-// caller can fall back to the declared allow-list. context.TODO is safe here:
-// the toolset is already started, so listing returns its cached tools without
-// a cancellable round-trip.
+// started toolset; the boolean is false for a not-yet-started toolset, or one
+// whose Start is still in flight, so the caller can fall back to the declared
+// allow-list without blocking on a long-running Start (e.g. RAG indexing).
+// context.TODO is safe here: the toolset is already started, so listing
+// returns its cached tools without a cancellable round-trip.
 func startedToolNames(ctx context.Context, ts tools.ToolSet) ([]string, bool) {
 	s, ok := tools.As[*tools.StartableToolSet](ts)
-	if !ok || !s.IsStarted() {
+	if !ok {
+		return nil, false
+	}
+	if started, _ := s.TryState(); !started {
 		return nil, false
 	}
 	tl, err := s.Tools(ctx)
@@ -1190,11 +1194,24 @@ func toolsetStatusFor(ts tools.ToolSet) tools.ToolsetStatus {
 	return status
 }
 
+// lifecycleStateForUnsupervised reports the lifecycle state of a toolset with
+// no Statable supervisor, using the wrapper's own non-blocking status probe
+// so a toolset whose Start is legitimately still running (e.g. RAG indexing
+// a large knowledge base) never stalls a status/introspection caller.
 func lifecycleStateForUnsupervised(ts tools.ToolSet) lifecycle.State {
-	if s, ok := ts.(*tools.StartableToolSet); ok && !s.IsStarted() {
-		return lifecycle.StateStopped
+	s, ok := ts.(*tools.StartableToolSet)
+	if !ok {
+		return lifecycle.StateReady
 	}
-	return lifecycle.StateReady
+	started, inFlight := s.TryState()
+	switch {
+	case inFlight:
+		return lifecycle.StateStarting
+	case !started:
+		return lifecycle.StateStopped
+	default:
+		return lifecycle.StateReady
+	}
 }
 
 // nameFor picks a stable, user-visible name for a toolset. We look for

--- a/pkg/runtime/toolsetstatus_test.go
+++ b/pkg/runtime/toolsetstatus_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -96,4 +97,36 @@ func TestToolsetStatusFor_UnwrapsStartable(t *testing.T) {
 	require.ErrorIs(t, got.LastError, want)
 	assert.Equal(t, 5, got.RestartCount)
 	assert.Equal(t, "mcp(remote host=example.com)", got.Description)
+}
+
+// TestToolsetStatusFor_UnsupervisedReportsStartingWithoutBlocking pins the
+// #4073 motivation for the non-blocking status probe: a toolset with no
+// Statable supervisor whose Start is still running (e.g. RAG indexing a
+// large knowledge base) must report lifecycle.StateStarting rather than
+// blocking toolsetStatusFor until Start settles.
+func TestToolsetStatusFor_UnsupervisedReportsStartingWithoutBlocking(t *testing.T) {
+	t.Parallel()
+
+	release := make(chan struct{})
+	inner := &inFlightStartToolSet{entered: make(chan struct{}), release: release}
+	wrapped := tools.NewStartable(inner)
+
+	startDone := make(chan error, 1)
+	go func() { startDone <- wrapped.Start(t.Context()) }()
+	<-inner.entered
+
+	resultCh := make(chan tools.ToolsetStatus, 1)
+	go func() { resultCh <- toolsetStatusFor(wrapped) }()
+
+	select {
+	case status := <-resultCh:
+		assert.Equal(t, lifecycle.StateStarting, status.State, "a mid-start toolset must report Starting, not block or misreport")
+	case <-time.After(5 * time.Second):
+		t.Fatal("toolsetStatusFor blocked behind an in-flight Start instead of reporting Starting")
+	}
+
+	close(release)
+	require.NoError(t, <-startDone)
+
+	assert.Equal(t, lifecycle.StateReady, toolsetStatusFor(wrapped).State, "settled start reports Ready")
 }

--- a/pkg/tools/startable.go
+++ b/pkg/tools/startable.go
@@ -265,11 +265,12 @@ type StartableToolSet struct {
 	ToolSet
 
 	// mu serializes lifecycle operations (Start/Stop) and guards started
-	// and the failure streaks. TryStart and TryIsStarted use TryLock to
-	// detect an in-flight lifecycle operation without blocking (#4001);
-	// StopIfStarted uses LockContext so shutdown deadlines are honored even
-	// when an in-flight Start ignores cancellation and keeps the lock past
-	// them. Every holder must release through unlock — never mu.Unlock
+	// and the failure streaks. TryStart, TryIsStarted and TryState use
+	// TryLock to detect an in-flight lifecycle operation without blocking
+	// (#4001); StopIfStarted uses LockContext so shutdown deadlines are
+	// honored even when an in-flight Start ignores cancellation and keeps
+	// the lock past them. Every holder must release through unlock — never
+	// mu.Unlock
 	// directly — so a stop request abandoned by a timed-out StopIfStarted
 	// is consumed by whichever holder releases the lock next.
 	mu      lifecycleMutex
@@ -355,17 +356,37 @@ func (s *StartableToolSet) IsStarted() bool {
 // collecting tools for a turn) rather than stall behind a wedged Start
 // (#4001); callers that need the settled state must use IsStarted.
 func (s *StartableToolSet) TryIsStarted() bool {
-	if !s.mu.TryLock() {
-		return false
-	}
-	started := s.started
-	// The release handshake may consume a pending StopIfStarted request and
-	// stop the toolset this probe just observed started: report a reaped
-	// start as not-ready rather than as started.
-	if s.unlock() {
-		return false
-	}
+	started, _ := s.TryState()
 	return started
+}
+
+// TryState is the non-blocking status probe backing TryIsStarted, returning
+// the extra inFlight bit callers need to distinguish "not started" from
+// "a lifecycle operation is running right now" — most notably a Start that
+// legitimately keeps running for a long time (e.g. RAG indexing a large
+// knowledge base) past the caller's own wait budget. Status/introspection
+// surfaces that must never block behind such a Start use TryState instead
+// of the blocking IsStarted.
+//
+// Outcomes:
+//   - (false, true): another lifecycle operation (Start/Stop/Tools) holds
+//     the single-flight lock; started carries no information.
+//   - (false, false): settled and not started.
+//   - (true, false): settled and started.
+//
+// As with TryIsStarted, the release handshake may consume a pending
+// StopIfStarted request and stop the toolset this probe just observed
+// started: that case reports (false, false) — reaped, not in flight —
+// rather than a started toolset that no longer is.
+func (s *StartableToolSet) TryState() (started, inFlight bool) {
+	if !s.mu.TryLock() {
+		return false, true
+	}
+	started = s.started
+	if s.unlock() {
+		return false, false
+	}
+	return started, false
 }
 
 // Start starts the toolset with single-flight semantics.
@@ -709,8 +730,8 @@ func (s *StartableToolSet) stopLocked(ctx context.Context) error {
 // and, when the toolset is started, stops it. The requester may have timed
 // out and returned long ago, so the stop runs under context.WithoutCancel
 // of the request ctx and a failure can only be logged. It reports whether
-// any request was settled, so non-blocking probes (TryIsStarted) can avoid
-// reporting a started toolset this very release just reaped.
+// any request was settled, so non-blocking probes (TryIsStarted, TryState)
+// can avoid reporting a started toolset this very release just reaped.
 //
 // Each round settles one request; the lock is released by the round that
 // finds none. Re-checking after a stop keeps stopRequestMu holds brief

--- a/pkg/tools/startable_test.go
+++ b/pkg/tools/startable_test.go
@@ -783,6 +783,42 @@ func TestStartableToolSet_TryStartSkipsInFlightStart(t *testing.T) {
 	assert.Check(t, is.Equal(inner.calls.Load(), int32(1)))
 }
 
+// TestStartableToolSet_TryState pins the non-blocking status probe used by
+// runtime status/introspection paths that must never block behind a
+// legitimately long-running Start (e.g. RAG indexing a large knowledge
+// base, #4073): unstarted reports (false, false), an in-flight Start
+// reports (false, true) instead of blocking, and the settled state after
+// release reports (true, false).
+func TestStartableToolSet_TryState(t *testing.T) {
+	t.Parallel()
+
+	inner := &blockingToolSet{entered: make(chan struct{}), release: make(chan struct{})}
+	s := tools.NewStartable(inner)
+
+	started, inFlight := s.TryState()
+	assert.Check(t, is.Equal(started, false), "TryState reports unstarted before any Start")
+	assert.Check(t, is.Equal(inFlight, false), "TryState reports not in flight before any Start")
+
+	// Always unblock the wedged Start so no goroutine outlives the test.
+	release := sync.OnceFunc(func() { close(inner.release) })
+	t.Cleanup(release)
+
+	startDone := make(chan error, 1)
+	go func() { startDone <- s.Start(t.Context()) }()
+	<-inner.entered
+
+	started, inFlight = s.TryState()
+	assert.Check(t, is.Equal(started, false), "TryState must not report started while Start is in flight")
+	assert.Check(t, is.Equal(inFlight, true), "TryState must report in flight without blocking on the wedged Start")
+
+	release()
+	assert.NilError(t, <-startDone)
+
+	started, inFlight = s.TryState()
+	assert.Check(t, is.Equal(started, true), "TryState reports started once settled")
+	assert.Check(t, is.Equal(inFlight, false), "TryState reports not in flight once settled")
+}
+
 // TestStartableToolSet_TryStartRunsStartLogic verifies that when the lock is
 // free, TryStart behaves exactly like Start: a failure records the
 // once-per-streak warning and a subsequent success latches the started state.
@@ -1100,6 +1136,29 @@ func TestStartableToolSet_TryIsStartedReportsReapedStart(t *testing.T) {
 	s.ExportedPublishStopRequest(t.Context())
 
 	assert.Check(t, is.Equal(s.TryIsStarted(), false), "TryIsStarted must not report started after its own release reaped the toolset")
+	assert.Check(t, is.Equal(inner.stops.Load(), int32(1)), "the pending request must stop the toolset on release")
+	assert.Check(t, is.Equal(s.IsStarted(), false))
+}
+
+// TestStartableToolSet_TryState_ReportsReapedStart is the TryState analogue
+// of TestStartableToolSet_TryIsStartedReportsReapedStart above: when a
+// pending shutdown request is consumed as TryState releases the lock, the
+// toolset it just observed started is stopped again, and TryState must
+// report (false, false) — reaped, not in flight — rather than a started
+// toolset that no longer is.
+func TestStartableToolSet_TryState_ReportsReapedStart(t *testing.T) {
+	t.Parallel()
+
+	inner := &blockingToolSet{entered: make(chan struct{}), release: make(chan struct{})}
+	close(inner.release) // Start completes immediately
+	s := tools.NewStartable(inner)
+	assert.NilError(t, s.Start(t.Context()))
+
+	s.ExportedPublishStopRequest(t.Context())
+
+	started, inFlight := s.TryState()
+	assert.Check(t, is.Equal(started, false), "TryState must not report started after its own release reaped the toolset")
+	assert.Check(t, is.Equal(inFlight, false), "a reaped start is settled, not in flight")
 	assert.Check(t, is.Equal(inner.stops.Load(), int32(1)), "the pending request must stop the toolset on release")
 	assert.Check(t, is.Equal(s.IsStarted(), false))
 }


### PR DESCRIPTION
🤖 **Automated implementer agent** — *this comment was posted by the implementer bot from Docker Agentic Platform, not by a human developer*

## Why

Part of #4073. A follow-up change to that issue will make the RAG toolset's `Start()` legitimately run for a long time in the background (indexing a large knowledge base). Runtime status/introspection code that currently calls the blocking `StartableToolSet.IsStarted()` — `startedToolNames` and `lifecycleStateForUnsupervised` in `pkg/runtime/runtime.go` — would hang behind such a Start instead of reporting status promptly.

This PR is independent and self-contained: it does not depend on any other RAG-specific work landing first.

## What changed

- Added `TryState() (started bool, inFlight bool)` to `StartableToolSet` (`pkg/tools/startable.go`): a non-blocking variant of `IsStarted()`/`TryIsStarted()` that also reports whether a lifecycle operation is currently in flight, correctly handling the pending-stop-reap case (mirrors `TryIsStarted`'s handshake). `TryIsStarted` is now expressed in terms of `TryState`.
- `pkg/runtime/runtime.go`: `startedToolNames` and `lifecycleStateForUnsupervised` now use `TryState()` instead of blocking `IsStarted()`, reporting `lifecycle.StateStarting` for a mid-start toolset.

## Testing

- New unit tests for `TryState()` (unstarted / in-flight / settled / reaped) in `pkg/tools/startable_test.go`.
- New runtime tests verifying non-blocking status reporting and the `Starting` state, including an end-to-end `AgentConfigInfo` test with a toolset whose `Start` is wedged, in `pkg/runtime/toolsetstatus_test.go` and `pkg/runtime/agent_inspector_test.go`.
- `task lint` and `task test` both pass clean.

Does not close #4073 — other parts of that issue are being worked in parallel.
