### PR TITLE
docs: auto-update for merged PRs (2026-09-04)

### DIFF
--- a/docs/features/tui/index.md
+++ b/docs/features/tui/index.md
@@ -63,6 +63,8 @@ The lean TUI supports **steering** and **follow-ups** while the agent is running
 
 The lean TUI supports a focused set of slash commands: `/new`, `/sessions`, `/compact`, `/model`, `/effort`, `/clear`, `/help`, `/exit` (alias: `/quit`), plus any agent-defined commands. Type `/model` (or `/model <provider/model>`) to switch the active model inline — the command opens a fuzzy-searchable list of available models. Type `/sessions` (or `/sessions <session-id>`) to browse and resume past sessions from the current working directory.
 
+Prefix a message with `!` to run it as a shell command directly, without going through the agent — for example `!git status`. The command runs in your default shell and its output is shown inline in the transcript. Bang commands are disabled in read-only sessions.
+
 ## Slash Commands
 
 Type `/` during a session to see available commands, or press <kbd>Ctrl</kbd>+<kbd>K</kbd> for the command palette:

--- a/docs/tools/shell/index.md
+++ b/docs/tools/shell/index.md
@@ -22,9 +22,10 @@ The shell tool automatically detects and names the resolved shell interpreter (e
 For example:
 
 - On Linux with bash: "Executes the given shell command with bash on Linux."
-- On Windows with PowerShell: "Executes the given shell command with powershell on Windows. Use Windows PowerShell 5.1 syntax: chain commands with ";" (not "&&"), and avoid POSIX commands/flags like "ls -la"."
+- On Windows with PowerShell 5.1: "Executes the given shell command with powershell on Windows. Windows PowerShell dialect. Chain commands with ";" (not "&&"; "&&" is a parse error on 5.1). POSIX utilities are not available — use Select-String (not grep), Select-Object -First N (not head), -Last N (not tail), Measure-Object -Line (not wc -l), Get-Content (not cat), Expand-Archive (not gunzip/tar). "ls -la" fails — use "ls" or "Get-ChildItem"."
+- On Windows with cmd.exe: "Executes the given shell command with cmd on Windows. cmd.exe syntax, not POSIX. No POSIX utilities (grep, head, tail, wc, cat), no POSIX flags on built-ins, and variable expansion uses %VAR% (not $VAR)."
 
-This reduces wasted turns where models assume POSIX syntax on Windows or vice versa.
+Each description also points the model at `get_environment_info` for edge cases the static hint does not cover. This reduces wasted turns where models assume POSIX syntax on Windows or vice versa.
 
 ## Configuration
 

--- a/docs/tools/shell/index.md
+++ b/docs/tools/shell/index.md
@@ -27,6 +27,10 @@ For example:
 
 Each description also points the model at `get_environment_info` for edge cases the static hint does not cover. This reduces wasted turns where models assume POSIX syntax on Windows or vice versa.
 
+### Dialect-error correction
+
+If a command still fails with a known shell-dialect error (for example PowerShell's `'&&' is not a valid statement separator`, a `cmd.exe`/`pwsh` "not recognized" error, or a POSIX-style `2>/dev/null` redirection on Windows), the tool prepends a `[shell-hint]` line to the output pointing the model at the corrective syntax before it retries. Hints are gated on the resolved shell so they only fire for genuine dialect mismatches (e.g. a PowerShell `&&` hint never fires for `pwsh`, which supports `&&` natively).
+
 ## Configuration
 
 ```yaml


### PR DESCRIPTION
## Documentation updates

This PR brings `/docs` back in sync with source code merged into `main` in the
last 36 hours. Two documentation gaps were found and fixed:

- **`docs/tools/shell/index.md`**
  - Updated the "Shell interpreter detection" example descriptions to match
    the current PowerShell/cmd.exe tool-description text (which now names
    the concrete POSIX-utility substitutes, e.g. `Select-String` for `grep`,
    `Select-Object -First N` for `head`), and added a `cmd.exe` example.
    Reflects docker/docker-agent#4140.
  - Added a new "Dialect-error correction" subsection documenting the
    `[shell-hint]` output prefix the shell tool now emits when a command
    fails with a known shell-dialect error (e.g. PowerShell's `&&` parse
    error, or a POSIX `2>/dev/null` redirect on Windows). Reflects
    docker/docker-agent#4141.

- **`docs/features/tui/index.md`**
  - Documented the new lean-TUI bang-command support: prefixing a message
    with `!` runs it as a raw shell command instead of sending it to the
    agent, and this is disabled in read-only sessions. Reflects
    docker/docker-agent#4122.

All other PRs merged in the window either shipped their own documentation
updates already (verified for accuracy against the corresponding code, e.g.
docker/docker-agent#4148, #4144, #4142, #4145, #4139, #4108, #4150) or made
internal/test-only changes with no user-facing documentation impact.

### Source PRs reviewed
- docker/docker-agent#4155, #4154, #4150, #4148, #4147, #4146, #4145, #4144,
  #4143, #4142, #4141, #4140, #4139, #4138, #4131, #4130, #4129, #4128,
  #4127, #4126, #4125, #4124, #4123, #4122, #4121, #4120, #4119, #4118,
  #4110, #4108
