### PR TITLE
fix(tools,openai): don't inject type:object onto anyOf nodes; handle Responses API response.incomplete/failed

### DIFF
--- a/pkg/model/provider/openai/response_stream.go
+++ b/pkg/model/provider/openai/response_stream.go
@@ -389,14 +389,14 @@ func (a *ResponseStreamAdapter) Recv() (chat.MessageStreamResponse, error) {
 		// and the reason must reach the loop as a finish reason so the empty
 		// turn is explained rather than reported as "stop reason: null".
 		reason := event.Response.IncompleteDetails.Reason
-		slog.Warn("Response incomplete",
+		slog.Debug("Response incomplete",
 			"reason", reason,
 			"response_id", event.Response.ID,
 			"output_items", len(event.Response.Output),
 			"output_tokens", event.Response.Usage.OutputTokens,
 			"reasoning_tokens", event.Response.Usage.OutputTokensDetails.ReasoningTokens,
+			"response_raw", event.Response.RawJSON(),
 		)
-		slog.Debug("Incomplete response payload", "response_raw", event.Response.RawJSON())
 		u := event.Response.Usage
 		if u.TotalTokens > 0 {
 			response.Usage = &chat.Usage{

--- a/pkg/model/provider/openai/response_stream.go
+++ b/pkg/model/provider/openai/response_stream.go
@@ -2,6 +2,7 @@ package openai
 
 import (
 	"cmp"
+	"fmt"
 	"io"
 	"log/slog"
 
@@ -381,11 +382,59 @@ func (a *ResponseStreamAdapter) Recv() (chat.MessageStreamResponse, error) {
 				FinishReason: finishReason,
 			},
 		}
+	case "response.incomplete":
+		// Terminal event: the model stopped before producing a complete
+		// response. incomplete_details.reason is "max_output_tokens" or
+		// "content_filter". Usage is still reported and must not be dropped,
+		// and the reason must reach the loop as a finish reason so the empty
+		// turn is explained rather than reported as "stop reason: null".
+		reason := event.Response.IncompleteDetails.Reason
+		slog.Warn("Response incomplete",
+			"reason", reason,
+			"response_id", event.Response.ID,
+			"output_items", len(event.Response.Output),
+			"output_tokens", event.Response.Usage.OutputTokens,
+			"reasoning_tokens", event.Response.Usage.OutputTokensDetails.ReasoningTokens,
+		)
+		slog.Debug("Incomplete response payload", "response_raw", truncateForLog(event.Response.RawJSON(), 4000))
+		u := event.Response.Usage
+		if u.TotalTokens > 0 {
+			response.Usage = &chat.Usage{
+				InputTokens:       u.InputTokens - u.InputTokensDetails.CachedTokens - u.InputTokensDetails.CacheWriteTokens,
+				OutputTokens:      u.OutputTokens,
+				CachedInputTokens: u.InputTokensDetails.CachedTokens,
+				CacheWriteTokens:  u.InputTokensDetails.CacheWriteTokens,
+				ReasoningTokens:   u.OutputTokensDetails.ReasoningTokens,
+			}
+		}
+		finishReason := chat.FinishReasonLength
+		if reason == "content_filter" {
+			finishReason = chat.FinishReasonRefusal
+		}
+		response.Choices = []chat.MessageStreamChoice{{FinishReason: finishReason}}
+
+	case "response.failed":
+		// Terminal event: the provider failed the response after accepting
+		// the request. Surface it as an error so the loop does not report an
+		// empty turn.
+		e := event.Response.Error
+		slog.Error("Response failed", "code", e.Code, "message", e.Message, "response_id", event.Response.ID)
+		return chat.MessageStreamResponse{}, fmt.Errorf("openai response failed (%s): %s [response_id=%s]", e.Code, e.Message, event.Response.ID)
+
 	default:
 		slog.Info("Unhandled stream event type", "type", event.Type)
+		slog.Debug("Unhandled stream event payload", "type", event.Type, "raw", truncateForLog(event.RawJSON(), 4000))
 	}
 
 	return response, nil
+}
+
+// truncateForLog bounds a raw JSON payload for log output.
+func truncateForLog(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n] + "...(truncated)"
 }
 
 // Close closes the stream

--- a/pkg/model/provider/openai/response_stream.go
+++ b/pkg/model/provider/openai/response_stream.go
@@ -396,7 +396,7 @@ func (a *ResponseStreamAdapter) Recv() (chat.MessageStreamResponse, error) {
 			"output_tokens", event.Response.Usage.OutputTokens,
 			"reasoning_tokens", event.Response.Usage.OutputTokensDetails.ReasoningTokens,
 		)
-		slog.Debug("Incomplete response payload", "response_raw", truncateForLog(event.Response.RawJSON(), 4000))
+		slog.Debug("Incomplete response payload", "response_raw", event.Response.RawJSON())
 		u := event.Response.Usage
 		if u.TotalTokens > 0 {
 			response.Usage = &chat.Usage{
@@ -423,18 +423,10 @@ func (a *ResponseStreamAdapter) Recv() (chat.MessageStreamResponse, error) {
 
 	default:
 		slog.Info("Unhandled stream event type", "type", event.Type)
-		slog.Debug("Unhandled stream event payload", "type", event.Type, "raw", truncateForLog(event.RawJSON(), 4000))
+		slog.Debug("Unhandled stream event payload", "type", event.Type, "raw", event.RawJSON())
 	}
 
 	return response, nil
-}
-
-// truncateForLog bounds a raw JSON payload for log output.
-func truncateForLog(s string, n int) string {
-	if len(s) <= n {
-		return s
-	}
-	return s[:n] + "...(truncated)"
 }
 
 // Close closes the stream

--- a/pkg/model/provider/openai/response_stream_terminal_test.go
+++ b/pkg/model/provider/openai/response_stream_terminal_test.go
@@ -1,0 +1,87 @@
+package openai
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/docker/docker-agent/pkg/chat"
+)
+
+// response.incomplete is a terminal event: it must yield a finish reason and
+// carry usage, instead of being dropped as "unhandled" (which surfaced as an
+// empty turn with stop reason null and zero tokens).
+func TestResponseStream_IncompleteMaxOutputTokens(t *testing.T) {
+	t.Parallel()
+
+	events := decodeEvents(t, []map[string]any{{
+		"type": "response.incomplete",
+		"response": map[string]any{
+			"id":                 "resp_123",
+			"status":             "incomplete",
+			"incomplete_details": map[string]any{"reason": "max_output_tokens"},
+			"output":             []any{},
+			"usage": map[string]any{
+				"input_tokens":          8212,
+				"output_tokens":         4000,
+				"total_tokens":          12212,
+				"input_tokens_details":  map[string]any{"cached_tokens": 0, "cache_write_tokens": 8209},
+				"output_tokens_details": map[string]any{"reasoning_tokens": 4000},
+			},
+		},
+	}})
+
+	a := newResponseStreamAdapter(&fakeEventStream{events: events}, true)
+	resp, err := a.Recv()
+	require.NoError(t, err)
+	require.Len(t, resp.Choices, 1)
+	assert.Equal(t, chat.FinishReasonLength, resp.Choices[0].FinishReason)
+	require.NotNil(t, resp.Usage)
+	assert.Equal(t, int64(4000), resp.Usage.OutputTokens)
+	assert.Equal(t, int64(4000), resp.Usage.ReasoningTokens)
+	assert.Equal(t, int64(8209), resp.Usage.CacheWriteTokens)
+	assert.Equal(t, int64(3), resp.Usage.InputTokens)
+}
+
+func TestResponseStream_IncompleteContentFilter(t *testing.T) {
+	t.Parallel()
+
+	events := decodeEvents(t, []map[string]any{{
+		"type": "response.incomplete",
+		"response": map[string]any{
+			"id":                 "resp_456",
+			"status":             "incomplete",
+			"incomplete_details": map[string]any{"reason": "content_filter"},
+			"output":             []any{},
+		},
+	}})
+
+	a := newResponseStreamAdapter(&fakeEventStream{events: events}, true)
+	resp, err := a.Recv()
+	require.NoError(t, err)
+	require.Len(t, resp.Choices, 1)
+	assert.Equal(t, chat.FinishReasonRefusal, resp.Choices[0].FinishReason)
+}
+
+// response.failed is a terminal event carrying a provider error; it must be
+// returned as an error rather than silently ending the stream.
+func TestResponseStream_FailedReturnsError(t *testing.T) {
+	t.Parallel()
+
+	events := decodeEvents(t, []map[string]any{{
+		"type": "response.failed",
+		"response": map[string]any{
+			"id":     "resp_789",
+			"status": "failed",
+			"error":  map[string]any{"code": "server_error", "message": "upstream exploded"},
+		},
+	}})
+
+	a := newResponseStreamAdapter(&fakeEventStream{events: events}, true)
+	_, err := a.Recv()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "server_error")
+	assert.Contains(t, err.Error(), "upstream exploded")
+	assert.Contains(t, err.Error(), "resp_789")
+}

--- a/pkg/model/provider/openai/schema_anyof_test.go
+++ b/pkg/model/provider/openai/schema_anyof_test.go
@@ -1,0 +1,50 @@
+package openai
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Regression: an optional property whose shape is expressed only through
+// anyOf (Atlassian MCP getConfluenceSpaces.expand, Notion MCP filter values)
+// must not gain a sibling "type" during normalization. "type" ANDs with
+// anyOf, so {"anyOf":[string,array],"type":["object","null"]} is
+// unsatisfiable; OpenAI's Responses API then answers with an instant
+// status=incomplete / max_output_tokens and zero tokens instead of a 400.
+func TestConvertParametersToSchema_AnyOfPropertyKeepsNoSiblingType(t *testing.T) {
+	t.Parallel()
+
+	src := `{
+	  "type": "object",
+	  "properties": {
+	    "cloudId": {"type": "string"},
+	    "expand": {
+	      "anyOf": [{"type": "string"}, {"type": "array", "items": {"type": "string"}}],
+	      "description": "Properties to expand"
+	    }
+	  },
+	  "required": ["cloudId"]
+	}`
+	var params map[string]any
+	require.NoError(t, json.Unmarshal([]byte(src), &params))
+
+	out, _, err := ConvertParametersToSchema(params)
+	require.NoError(t, err)
+
+	props := out["properties"].(map[string]any)
+	expand := props["expand"].(map[string]any)
+
+	_, hasType := expand["type"]
+	assert.False(t, hasType, "anyOf node must not get a sibling type: %v", expand)
+	_, hasAddProps := expand["additionalProperties"]
+	assert.False(t, hasAddProps, "anyOf node must not get additionalProperties: %v", expand)
+	assert.Len(t, expand["anyOf"], 2)
+
+	// The property still becomes required (all-required contract) — as an
+	// optional anyOf it must be made nullable via an extra null variant or
+	// left as-is, but never via a sibling type.
+	assert.ElementsMatch(t, []any{"cloudId", "expand"}, out["required"])
+}

--- a/pkg/model/provider/schema_test.go
+++ b/pkg/model/provider/schema_test.go
@@ -193,7 +193,6 @@ func TestNonStringEnumSchemaForGemini(t *testing.T) {
               "enum": ["1", "2.5"]
             },
             "state": {
-              "type": "object",
               "anyOf": [
                 {"type": "string", "enum": ["open"]},
                 {"type": "number", "enum": ["0"]}

--- a/pkg/tools/schema.go
+++ b/pkg/tools/schema.go
@@ -138,6 +138,15 @@ func removeNullFromType(prop map[string]any) {
 // $ref nodes are skipped: a $ref's type is defined by its target, and
 // injecting one adds a sibling keyword that providers like OpenAI reject
 // on $ref nodes under strict mode.
+// Composition nodes (anyOf/oneOf/allOf) are skipped for the same reason:
+// their shape is the union/intersection of their variants, and a sibling
+// "type" ANDs with the composition. Injecting "object" onto e.g.
+// {"anyOf": [{"type":"string"}, {"type":"array"}]} (Atlassian MCP
+// getConfluenceSpaces.expand, Notion MCP filters) makes the schema
+// unsatisfiable; OpenAI's Responses API then returns an instant
+// status=incomplete / reason=max_output_tokens with zero tokens instead of
+// a 400, which surfaces as an "empty response" turn. The variants
+// themselves are still walked so their own properties get typed.
 func ensurePropertyTypes(schema map[string]any) {
 	props, ok := schema["properties"].(map[string]any)
 	if !ok {
@@ -154,6 +163,24 @@ func ensurePropertyTypes(schema map[string]any) {
 			continue
 		}
 
+		if isCompositionSchema(prop) {
+			for _, kw := range compositionKeywords {
+				variants, ok := prop[kw].([]any)
+				if !ok {
+					continue
+				}
+				for _, variant := range variants {
+					if vm, ok := variant.(map[string]any); ok {
+						ensurePropertyTypes(vm)
+						if items, ok := vm["items"].(map[string]any); ok {
+							ensurePropertyTypes(items)
+						}
+					}
+				}
+			}
+			continue
+		}
+
 		if prop["type"] == nil {
 			prop["type"] = "object"
 		}
@@ -166,6 +193,20 @@ func ensurePropertyTypes(schema map[string]any) {
 			ensurePropertyTypes(items)
 		}
 	}
+}
+
+// compositionKeywords are the JSON Schema keywords whose node shape is
+// defined by their variants rather than by an own "type".
+var compositionKeywords = []string{"anyOf", "oneOf", "allOf"}
+
+// isCompositionSchema reports whether node uses anyOf/oneOf/allOf.
+func isCompositionSchema(node map[string]any) bool {
+	for _, kw := range compositionKeywords {
+		if _, ok := node[kw]; ok {
+			return true
+		}
+	}
+	return false
 }
 
 func ConvertSchema(params, v any) error {


### PR DESCRIPTION
> 🤖 **Automated architect agent** — *this PR was opened by the architect bot from Docker Agentic Platform, not by a human engineer*

## Symptom
Any OpenAI model (`gpt-5.6-terra`/`sol`, `gpt-6-astra` via Responses) with the **Atlassian (Jira) or Notion remote MCP server** attached ends every turn in ~2 s with:

> Model openai/gpt-5.6-terra returned an empty response (stop reason: null)…

0 input / 0 output tokens, no error. Grafana MCP works; Anthropic works with all three — which hid the cause.

## Root cause (two bugs)
1. **`pkg/tools/schema.go` → `ensurePropertyTypes`** stamps `type: "object"` on every typeless property, including composition nodes. For `getConfluenceSpaces.expand` = `{"anyOf":[string, array<string>]}` the tool schema becomes `{"anyOf":[…], "type":["object","null"], "additionalProperties":false}` — unsatisfiable (`type` ANDs with `anyOf`). OpenAI's Responses API answers with an **instant `status=incomplete`, `incomplete_details.reason=max_output_tokens`, empty output, 0 tokens** — not a 400. The `isCompositionNode` guard added in #4106 lives downstream in the openai package and never gets the chance: the type is already injected.
2. **`response_stream.go`** has no case for `response.incomplete` / `response.failed`; both hit `default`, get logged at INFO and dropped → no usage, no finish reason → "stop reason: null".

## Fix
- `ensurePropertyTypes` skips `anyOf`/`oneOf`/`allOf` nodes (as it already does for `$ref`) and walks their variants.
- Responses adapter handles `response.incomplete` (usage + finish reason `length`, or `refusal` for `content_filter`; reason + `response_id` logged) and `response.failed` (returned as an error with code/message/response_id). Unhandled-event payloads logged at DEBUG.
- Gemini enum test fixture corrected (it pinned the buggy sibling `type`).
- Regression tests for both.

## Verification
Bisected live against api.openai.com with the real Atlassian tool list: swapping only the runtime-normalised `tools[]` into an otherwise-working raw request reproduces the failure; per-tool bisection isolates `getConfluenceSpaces`. With this branch, `cagent run` + Jira MCP and + Notion MCP on `gpt-5.6-terra` both answer normally (before: every turn `incomplete/max_output_tokens`, 0 tokens).

`go test ./pkg/tools/... ./pkg/model/... ./pkg/runtime/... ./pkg/teamloader/... ./pkg/config/...` green.
