### PR TITLE
feat: forward the encrypted agent config to the Docker models gateway

### DIFF
--- a/cmd/root/pull.go
+++ b/cmd/root/pull.go
@@ -39,7 +39,7 @@ artifact is unprotected or the check does not pass.`,
 	}
 
 	cmd.PersistentFlags().BoolVar(&flags.force, "force", false, "Force pull even if the configuration already exists locally")
-	cmd.Flags().StringVar(&flags.keyFile, "key", "", "Path to a key file (PEM/OpenSSH) or symmetric secret used to verify the agent")
+	cmd.Flags().StringVar(&flags.keyFile, "key", "", "Path to a key file (PEM/OpenSSH) or symmetric secret used to verify the agent (or set "+envEncryptKey+" with the secret inline)")
 
 	return cmd
 }
@@ -59,6 +59,11 @@ func (f *pullFlags) runPullCommand(cmd *cobra.Command, args []string) (commandEr
 	if f.keyFile != "" {
 		var err error
 		if key, err = protect.LoadKey(f.keyFile); err != nil {
+			return err
+		}
+	} else if secret := os.Getenv(envEncryptKey); secret != "" {
+		var err error
+		if key, err = protect.ParseKey([]byte(secret)); err != nil {
 			return err
 		}
 	}

--- a/cmd/root/push.go
+++ b/cmd/root/push.go
@@ -1,9 +1,9 @@
 package root
 
 import (
-	"errors"
 	"fmt"
 	"log/slog"
+	"os"
 
 	"github.com/spf13/cobra"
 
@@ -49,22 +49,41 @@ OpenSSH key markers.
 		RunE: flags.runPushCommand,
 	}
 
-	cmd.Flags().StringVar(&flags.keyFile, "key", "", "Path to a key file (PEM/OpenSSH) or symmetric secret used to protect the agent")
+	cmd.Flags().StringVar(&flags.keyFile, "key", "", "Path to a key file (PEM/OpenSSH) or symmetric secret used to protect the agent (or set "+envEncryptKey+" with the secret inline)")
 	cmd.Flags().BoolVar(&flags.encrypt, "encrypt", false, "Also embed an encrypted copy of the agent in the annotations (requires --key)")
 
 	return cmd
 }
 
-func (f *pushFlags) protection() (oci.PackageOption, error) {
-	if f.keyFile == "" {
-		if f.encrypt {
-			return nil, errors.New("--encrypt requires --key")
-		}
-		return nil, nil
+// envEncryptKey is an alternative to --key for callers that prefer not to write
+// the secret to a file: its value is used as the symmetric secret directly
+// (never a file path). The --key flag takes precedence when both are set.
+const envEncryptKey = "DOCKER_AGENT_ENCRYPT_KEY"
+
+// resolveKey loads the protection key from the --key flag (a file path) or,
+// when the flag is empty, from the [envEncryptKey] environment variable (an
+// inline symmetric secret). It returns a nil key and nil error when neither is
+// set, so callers can treat "no key" as "no protection".
+func (f *pushFlags) resolveKey() (*protect.Key, error) {
+	if f.keyFile != "" {
+		return protect.LoadKey(f.keyFile)
 	}
-	key, err := protect.LoadKey(f.keyFile)
+	if secret := os.Getenv(envEncryptKey); secret != "" {
+		return protect.ParseKey([]byte(secret))
+	}
+	return nil, nil
+}
+
+func (f *pushFlags) protection() (oci.PackageOption, error) {
+	key, err := f.resolveKey()
 	if err != nil {
 		return nil, err
+	}
+	if key == nil {
+		if f.encrypt {
+			return nil, fmt.Errorf("--encrypt requires --key or %s", envEncryptKey)
+		}
+		return nil, nil
 	}
 	mode := protect.ModeSign
 	if f.encrypt {

--- a/cmd/root/run.go
+++ b/cmd/root/run.go
@@ -885,6 +885,7 @@ func (f *runExecFlags) runtimeOpts(loadResult *teamloader.LoadResult, runConfig 
 		Models:             loadResult.Models,
 		Providers:          loadResult.Providers,
 		ModelsGateway:      runConfig.ModelsGateway,
+		EncryptedConfig:    loadResult.EncryptedConfig,
 		EnvProvider:        runConfig.EnvProvider(),
 		ProviderRegistry:   loadResult.ProviderRegistry,
 		AgentDefaultModels: loadResult.AgentDefaultModels,

--- a/pkg/config/runtime.go
+++ b/pkg/config/runtime.go
@@ -42,6 +42,14 @@ type Config struct {
 	Models         map[string]latest.ModelConfig
 	Providers      map[string]latest.ProviderConfig
 
+	// EncryptedConfig is an opaque, encrypted representation of the full agent
+	// YAML (as produced by `docker agent share push --key --encrypt`). When set
+	// and the configured models gateway is a trusted Docker gateway, it is
+	// forwarded to the gateway on every request via the
+	// `X-Cagent-Encrypted-Config` header. It is ignored for non-Docker
+	// gateways and when no gateway is configured.
+	EncryptedConfig string
+
 	// Flavors are the config flavor patches to enable when loading agent
 	// configs, applied in order. Names a config does not define are ignored.
 	Flavors []string

--- a/pkg/config/sources.go
+++ b/pkg/config/sources.go
@@ -167,6 +167,15 @@ func (a urlSource) storeEncryptedConfig(ctx context.Context, enc, encPath string
 	}
 }
 
+// clearEncryptedConfig drops any in-memory encrypted config so that, until the
+// next successful capture, no (potentially stale) value is forwarded to the
+// gateway. The on-disk sidecar is left untouched. Safe to call concurrently.
+func (a urlSource) clearEncryptedConfig() {
+	if a.encryptedConfig != nil {
+		a.encryptedConfig.Store(nil)
+	}
+}
+
 // adoptCachedEncryptedConfig loads the encrypted config cached on disk and, if
 // present, records it in memory so it is forwarded to the Docker models gateway
 // on subsequent model requests. When wantDigest is non-empty (the server sent
@@ -331,9 +340,25 @@ func (a urlSource) read(ctx context.Context, cacheDir, cachePath, etagPath, encP
 			// digest the server sent (when present). If it is missing or stale,
 			// self-heal by forcing a full reload so we get the config again.
 			wantDigest := resp.Header.Get(httpclient.EncryptedConfigDigestHeader)
-			if wantDigest != "" && !forceReload && !a.adoptCachedEncryptedConfig(ctx, encPath, wantDigest) {
-				slog.DebugContext(ctx, "304 received but cached encrypted config is missing or stale; forcing a reload", "url", a.url)
-				return a.read(ctx, cacheDir, cachePath, etagPath, encPath, true)
+			if wantDigest != "" && !a.adoptCachedEncryptedConfig(ctx, encPath, wantDigest) {
+				if !forceReload {
+					slog.DebugContext(ctx, "304 received but cached encrypted config is missing or stale; forcing a reload", "url", a.url)
+					return a.read(ctx, cacheDir, cachePath, etagPath, encPath, true)
+				}
+				// We already forced a reload (Cache-Control: no-cache), yet the
+				// server answered 304 again with a digest we still cannot match
+				// from cache. A forced reload is supposed to bypass caching and
+				// return a fresh 200 carrying the full config, so a second 304 is
+				// a server/protocol violation we cannot recover from here.
+				//
+				// The YAML config itself is valid and cached, so we do NOT fail
+				// the whole config load over it — that would keep the agent from
+				// starting for what is only an encrypted-config-forwarding issue.
+				// Instead we leave the encrypted config unset (nothing stale or
+				// mismatched is forwarded to the gateway; the proxy-side check
+				// fails open for a missing header) and warn loudly.
+				a.clearEncryptedConfig()
+				slog.WarnContext(ctx, "Server returned 304 to a forced reload but the cached encrypted agent config does not match the advertised digest; forwarding no encrypted config for this URL", "url", a.url, "want_digest", wantDigest)
 			}
 			if wantDigest == "" {
 				// No digest advertised: best-effort adopt whatever is cached.

--- a/pkg/config/sources.go
+++ b/pkg/config/sources.go
@@ -14,6 +14,7 @@ import (
 	"path/filepath"
 	"slices"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/docker/docker-agent/pkg/environment"
@@ -25,6 +26,18 @@ type Source interface {
 	Name() string
 	ParentDir() string
 	Read(ctx context.Context) ([]byte, error)
+}
+
+// EncryptedConfigSource is implemented by sources that may discover an
+// encrypted representation of the agent config while reading it (for example a
+// trusted Docker URL that returns the X-Cagent-Encrypted-Config response
+// header). Callers can type-assert a Source to this interface after Read to
+// pick up the value, which is then forwarded to a trusted Docker models gateway
+// on subsequent model requests.
+type EncryptedConfigSource interface {
+	// EncryptedConfig returns the encrypted config captured during the most
+	// recent successful Read, or "" if none was seen. Safe to call concurrently.
+	EncryptedConfig() string
 }
 
 type Sources map[string]Source
@@ -103,15 +116,113 @@ type urlSource struct {
 	// sources_test.go), which exists because tests use httptest.NewServer
 	// (plain HTTP, 127.0.0.1).
 	unsafe bool
+	// encryptedConfig captures the X-Cagent-Encrypted-Config response header
+	// seen on a successful fetch from a trusted Docker URL. It is a pointer so
+	// the value-receiver Read can persist the captured value back onto the
+	// pointer the caller holds, and so concurrent readers see a consistent
+	// value.
+	encryptedConfig *atomic.Pointer[string]
 }
 
 // NewURLSource creates a new URL source. If envProvider is non-nil, it will be used
 // to look up GITHUB_TOKEN for authentication when fetching from GitHub URLs.
 func NewURLSource(rawURL string, envProvider environment.Provider) Source {
 	return &urlSource{
-		url:         rawURL,
-		envProvider: envProvider,
+		url:             rawURL,
+		envProvider:     envProvider,
+		encryptedConfig: &atomic.Pointer[string]{},
 	}
+}
+
+// EncryptedConfig returns the encrypted agent config captured from the
+// X-Cagent-Encrypted-Config response header during the most recent successful
+// Read from a trusted Docker URL, or "" if none was seen. It implements
+// [EncryptedConfigSource].
+func (a urlSource) EncryptedConfig() string {
+	if a.encryptedConfig == nil {
+		return ""
+	}
+	if v := a.encryptedConfig.Load(); v != nil {
+		return *v
+	}
+	return ""
+}
+
+// storeEncryptedConfig records enc both in memory (for this process) and on
+// disk (encPath, next to the cached YAML) so a later run that revalidates the
+// URL and gets a 304 — which no longer carries the full config, only its digest
+// — can recover the value from disk instead of the response.
+func (a urlSource) storeEncryptedConfig(ctx context.Context, enc, encPath string) {
+	if a.encryptedConfig != nil {
+		a.encryptedConfig.Store(&enc)
+	}
+	// Ensure the cache directory exists: captureEncryptedConfig may run before
+	// the YAML-caching block that creates it (e.g. this fetch returns early).
+	if err := os.MkdirAll(filepath.Dir(encPath), 0o700); err != nil {
+		slog.DebugContext(ctx, "Failed to create cache dir for encrypted agent config", "url", a.url, "error", err)
+		return
+	}
+	if err := os.WriteFile(encPath, []byte(enc), 0o600); err != nil {
+		slog.DebugContext(ctx, "Failed to cache encrypted agent config", "url", a.url, "error", err)
+	}
+}
+
+// adoptCachedEncryptedConfig loads the encrypted config cached on disk and, if
+// present, records it in memory so it is forwarded to the Docker models gateway
+// on subsequent model requests. When wantDigest is non-empty (the server sent
+// X-Cagent-Encrypted-Config-Digest on a 304), the cached value is only adopted
+// if its digest matches, so a stale cache is never replayed. It reports whether
+// a usable, matching value was adopted.
+func (a urlSource) adoptCachedEncryptedConfig(ctx context.Context, encPath, wantDigest string) bool {
+	if a.encryptedConfig == nil {
+		return false
+	}
+	if !isTrustedDockerURL(a.url) {
+		return false
+	}
+	data, err := os.ReadFile(encPath)
+	if err != nil || len(data) == 0 {
+		return false
+	}
+	enc := string(data)
+	if wantDigest != "" && encryptedConfigDigest(enc) != wantDigest {
+		slog.DebugContext(ctx, "Cached encrypted agent config does not match server digest; discarding", "url", a.url)
+		return false
+	}
+	a.encryptedConfig.Store(&enc)
+	slog.DebugContext(ctx, "Recovered encrypted agent config from cache", "url", a.url)
+	return true
+}
+
+// captureEncryptedConfig records the X-Cagent-Encrypted-Config response header
+// when the fetch targets a trusted Docker URL. The trust check mirrors the
+// Docker JWT injection so the value is never captured from an untrusted host.
+// The full value only appears on a 200; on a 304 the server sends just the
+// digest, so the 304 path recovers the value from disk instead (see
+// [urlSource.adoptCachedEncryptedConfig]).
+func (a urlSource) captureEncryptedConfig(ctx context.Context, resp *http.Response, encPath string) {
+	if a.encryptedConfig == nil || resp == nil {
+		return
+	}
+	if !isTrustedDockerURL(a.url) {
+		return
+	}
+	enc := resp.Header.Get(httpclient.EncryptedConfigHeader)
+	if enc == "" {
+		return
+	}
+	a.storeEncryptedConfig(ctx, enc, encPath)
+	slog.DebugContext(ctx, "Captured encrypted agent config from Docker source response header", "url", a.url)
+}
+
+// encryptedConfigDigest returns the "sha256:<hex>" fingerprint of enc, matching
+// the format a trusted Docker source sends in X-Cagent-Encrypted-Config-Digest.
+func encryptedConfigDigest(enc string) string {
+	if enc == "" {
+		return ""
+	}
+	sum := sha256.Sum256([]byte(enc))
+	return "sha256:" + hex.EncodeToString(sum[:])
 }
 
 func (a urlSource) Name() string {
@@ -138,11 +249,26 @@ func (a urlSource) Read(ctx context.Context) ([]byte, error) {
 	urlHash := hashURL(a.url)
 	cachePath := filepath.Join(cacheDir, urlHash)
 	etagPath := cachePath + ".etag"
+	// encPath sidecars the cached YAML with the encrypted agent config captured
+	// from the X-Cagent-Encrypted-Config header on a 200, so a later 304 (which
+	// carries only the digest) can recover it.
+	encPath := cachePath + ".enc"
 
-	// Read cached ETag if available
+	return a.read(ctx, cacheDir, cachePath, etagPath, encPath, false)
+}
+
+// read performs the conditional fetch and caching. When forceReload is true it
+// skips the If-None-Match revalidation so the server answers with a fresh 200
+// (never a 304); this is the self-healing path taken when a 304 arrives but the
+// encrypted config could not be recovered from cache (missing or digest
+// mismatch).
+func (a urlSource) read(ctx context.Context, cacheDir, cachePath, etagPath, encPath string, forceReload bool) ([]byte, error) {
+	// Read cached ETag if available (skipped when forcing a reload).
 	cachedETag := ""
-	if etagData, err := os.ReadFile(etagPath); err == nil {
-		cachedETag = string(etagData)
+	if !forceReload {
+		if etagData, err := os.ReadFile(etagPath); err == nil {
+			cachedETag = string(etagData)
+		}
 	}
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, a.url, http.NoBody)
@@ -150,9 +276,17 @@ func (a urlSource) Read(ctx context.Context) ([]byte, error) {
 		return nil, fmt.Errorf("creating request: %w", err)
 	}
 
-	// Include If-None-Match header if we have a cached ETag
+	// Include If-None-Match header if we have a cached ETag and are not forcing
+	// a full reload.
 	if cachedETag != "" {
 		req.Header.Set("If-None-Match", cachedETag)
+	}
+	// On a forced reload, ask any intermediary (and the origin) not to answer
+	// from cache, so we are guaranteed a fresh 200 carrying the full encrypted
+	// config rather than another 304.
+	if forceReload {
+		req.Header.Set("Cache-Control", "no-cache")
+		req.Header.Set("Pragma", "no-cache")
 	}
 
 	a.addGitHubAuth(ctx, req)
@@ -179,15 +313,32 @@ func (a urlSource) Read(ctx context.Context) ([]byte, error) {
 		// Network error - try to use cached version
 		if cachedData, cacheErr := os.ReadFile(cachePath); cacheErr == nil {
 			slog.DebugContext(ctx, "Network error fetching URL, using cached version", "url", a.url, "error", err)
+			a.adoptCachedEncryptedConfig(ctx, encPath, "")
 			return cachedData, nil
 		}
 		return nil, fmt.Errorf("%w: fetching %s: %w", ErrSourceFetchFailed, a.url, err)
 	}
 	defer resp.Body.Close()
 
+	// Capture the full encrypted agent config header. It is present on a 200
+	// (and persisted to encPath); a 304 carries only the digest, handled below.
+	a.captureEncryptedConfig(ctx, resp, encPath)
+
 	// 304 Not Modified - return cached content
 	if resp.StatusCode == http.StatusNotModified {
 		if cachedData, cacheErr := os.ReadFile(cachePath); cacheErr == nil {
+			// Recover the encrypted config from disk, verifying it against the
+			// digest the server sent (when present). If it is missing or stale,
+			// self-heal by forcing a full reload so we get the config again.
+			wantDigest := resp.Header.Get(httpclient.EncryptedConfigDigestHeader)
+			if wantDigest != "" && !forceReload && !a.adoptCachedEncryptedConfig(ctx, encPath, wantDigest) {
+				slog.DebugContext(ctx, "304 received but cached encrypted config is missing or stale; forcing a reload", "url", a.url)
+				return a.read(ctx, cacheDir, cachePath, etagPath, encPath, true)
+			}
+			if wantDigest == "" {
+				// No digest advertised: best-effort adopt whatever is cached.
+				a.adoptCachedEncryptedConfig(ctx, encPath, "")
+			}
 			slog.DebugContext(ctx, "URL not modified, using cached version", "url", a.url)
 			return cachedData, nil
 		}
@@ -198,6 +349,7 @@ func (a urlSource) Read(ctx context.Context) ([]byte, error) {
 		// HTTP error - try to use cached version
 		if cachedData, cacheErr := os.ReadFile(cachePath); cacheErr == nil {
 			slog.DebugContext(ctx, "HTTP error fetching URL, using cached version", "url", a.url, "status", resp.Status)
+			a.adoptCachedEncryptedConfig(ctx, encPath, "")
 			return cachedData, nil
 		}
 		return nil, fmt.Errorf("%w: fetching %s: %s", ErrSourceFetchFailed, a.url, resp.Status)

--- a/pkg/config/sources_test.go
+++ b/pkg/config/sources_test.go
@@ -1014,3 +1014,60 @@ func TestURLSource_SelfHealsOn304DigestMismatch(t *testing.T) {
 		"stale config must be replaced by the forced reload")
 	assert.Equal(t, 1, forced, "digest mismatch must trigger exactly one forced reload")
 }
+
+// TestURLSource_ForcedReloadStill304 verifies the guard against a misbehaving
+// server that answers 304 even to a forced reload (Cache-Control: no-cache),
+// advertising a digest the cache cannot satisfy. This must NOT loop, must NOT
+// error the whole config load (the YAML is valid and cached), and must forward
+// no encrypted config (nothing stale/mismatched leaks to the gateway).
+func TestURLSource_ForcedReloadStill304(t *testing.T) {
+	paths.SetDataDir(t.TempDir())
+	t.Cleanup(func() { paths.SetDataDir("") })
+
+	const staleEnc = "OLD-BLOB"
+	const freshDigest = "sha256:0000000000000000000000000000000000000000000000000000000000000000"
+	const etag = "sha256:abc"
+	const body = "version: \"2\"\n"
+
+	var total, notModified, forced int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		total++
+		if r.Header.Get("Cache-Control") == "no-cache" {
+			// Misbehaving: 304 to a forced reload, advertising a digest that
+			// never matches the cached config.
+			forced++
+			w.Header().Set(httpclient.EncryptedConfigDigestHeader, freshDigest)
+			w.WriteHeader(http.StatusNotModified)
+			return
+		}
+		if r.Header.Get("If-None-Match") == etag {
+			notModified++
+			w.Header().Set(httpclient.EncryptedConfigDigestHeader, freshDigest)
+			w.WriteHeader(http.StatusNotModified)
+			return
+		}
+		w.Header().Set("ETag", etag)
+		w.Header().Set(httpclient.EncryptedConfigHeader, staleEnc)
+		w.Header().Set(httpclient.EncryptedConfigDigestHeader, digestOf(staleEnc))
+		_, _ = w.Write([]byte(body))
+	}))
+	t.Cleanup(server.Close)
+
+	// Prime the YAML+ETag+.enc cache with the stale config.
+	src1 := newURLSourceForTest(server.URL, nil)
+	_, err := src1.Read(t.Context())
+	require.NoError(t, err)
+	require.Equal(t, staleEnc, src1.(EncryptedConfigSource).EncryptedConfig())
+
+	// A fresh read now 304s (digest mismatch) -> forces a reload -> the server
+	// 304s AGAIN. The read must still succeed with the valid cached YAML, forward
+	// no encrypted config, and issue exactly one forced reload (no loop).
+	src2 := newURLSourceForTest(server.URL, nil)
+	data, err := src2.Read(t.Context())
+	require.NoError(t, err, "a misbehaving server must not fail the whole config load")
+	assert.Equal(t, body, string(data))
+	assert.Empty(t, src2.(EncryptedConfigSource).EncryptedConfig(),
+		"no encrypted config must be forwarded when a forced reload cannot recover a matching one")
+	assert.Equal(t, 1, notModified, "exactly one conditional 304 before forcing a reload")
+	assert.Equal(t, 1, forced, "the forced reload must be attempted exactly once (no retry loop)")
+}

--- a/pkg/config/sources_test.go
+++ b/pkg/config/sources_test.go
@@ -13,6 +13,8 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/docker/docker-agent/pkg/environment"
+	"github.com/docker/docker-agent/pkg/httpclient"
+	"github.com/docker/docker-agent/pkg/paths"
 )
 
 // newURLSourceForTest constructs a urlSource that bypasses the HTTPS-only and
@@ -21,9 +23,10 @@ import (
 // binds to 127.0.0.1 over plain HTTP.
 func newURLSourceForTest(rawURL string, envProvider environment.Provider) Source {
 	return &urlSource{
-		url:         rawURL,
-		envProvider: envProvider,
-		unsafe:      true,
+		url:             rawURL,
+		envProvider:     envProvider,
+		unsafe:          true,
+		encryptedConfig: &atomic.Pointer[string]{},
 	}
 }
 
@@ -832,4 +835,182 @@ func TestIsLocalhostHTTPHost(t *testing.T) {
 			assert.Equal(t, tt.expected, isLocalhostHTTPHost(tt.host))
 		})
 	}
+}
+
+// digestOf mirrors the server's X-Cagent-Encrypted-Config-Digest format.
+func digestOf(enc string) string {
+	return encryptedConfigDigest(enc)
+}
+
+func TestURLSource_CapturesEncryptedConfigHeader(t *testing.T) {
+	paths.SetDataDir(t.TempDir())
+	t.Cleanup(func() { paths.SetDataDir("") })
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set(httpclient.EncryptedConfigHeader, "ENCRYPTED-BLOB")
+		_, _ = w.Write([]byte("version: \"2\"\n"))
+	}))
+	t.Cleanup(server.Close)
+
+	// httptest binds to 127.0.0.1, which IsTrustedDockerURL treats as trusted,
+	// so the response header is captured.
+	source := newURLSourceForTest(server.URL, nil)
+	_, err := source.Read(t.Context())
+	require.NoError(t, err)
+
+	ecs, ok := source.(EncryptedConfigSource)
+	require.True(t, ok, "urlSource must implement EncryptedConfigSource")
+	assert.Equal(t, "ENCRYPTED-BLOB", ecs.EncryptedConfig())
+}
+
+func TestURLSource_NoEncryptedConfigHeader(t *testing.T) {
+	paths.SetDataDir(t.TempDir())
+	t.Cleanup(func() { paths.SetDataDir("") })
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("version: \"2\"\n"))
+	}))
+	t.Cleanup(server.Close)
+
+	source := newURLSourceForTest(server.URL, nil)
+	_, err := source.Read(t.Context())
+	require.NoError(t, err)
+
+	ecs, ok := source.(EncryptedConfigSource)
+	require.True(t, ok)
+	assert.Empty(t, ecs.EncryptedConfig())
+}
+
+// TestURLSource_RecoversEncryptedConfigFrom304 verifies that after a 200 that
+// cached the encrypted config, a subsequent 304 (carrying only the digest,
+// not the full blob) recovers the value from disk.
+func TestURLSource_RecoversEncryptedConfigFrom304(t *testing.T) {
+	paths.SetDataDir(t.TempDir())
+	t.Cleanup(func() { paths.SetDataDir("") })
+
+	const enc = "ENCRYPTED-BLOB"
+	const etag = "sha256:abc"
+	const body = "version: \"2\"\n"
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("If-None-Match") == etag {
+			w.Header().Set(httpclient.EncryptedConfigDigestHeader, digestOf(enc))
+			w.WriteHeader(http.StatusNotModified)
+			return
+		}
+		w.Header().Set("ETag", etag)
+		w.Header().Set(httpclient.EncryptedConfigHeader, enc)
+		w.Header().Set(httpclient.EncryptedConfigDigestHeader, digestOf(enc))
+		_, _ = w.Write([]byte(body))
+	}))
+	t.Cleanup(server.Close)
+
+	src1 := newURLSourceForTest(server.URL, nil)
+	_, err := src1.Read(t.Context())
+	require.NoError(t, err)
+	require.Equal(t, enc, src1.(EncryptedConfigSource).EncryptedConfig())
+
+	// Fresh source (empty in-memory state): server 304s, value recovered from disk.
+	src2 := newURLSourceForTest(server.URL, nil)
+	data, err := src2.Read(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, body, string(data))
+	assert.Equal(t, enc, src2.(EncryptedConfigSource).EncryptedConfig(),
+		"encrypted config must be recovered from cache on a 304")
+}
+
+// TestURLSource_SelfHealsOn304WithoutCachedConfig verifies that a 304 with no
+// cached config forces a full reload to recover it.
+func TestURLSource_SelfHealsOn304WithoutCachedConfig(t *testing.T) {
+	paths.SetDataDir(t.TempDir())
+	t.Cleanup(func() { paths.SetDataDir("") })
+
+	const enc = "ENCRYPTED-BLOB"
+	const etag = "sha256:abc"
+	const body = "version: \"2\"\n"
+
+	var notModified, forced int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Cache-Control") == "no-cache" {
+			forced++
+			w.Header().Set("ETag", etag)
+			w.Header().Set(httpclient.EncryptedConfigHeader, enc)
+			w.Header().Set(httpclient.EncryptedConfigDigestHeader, digestOf(enc))
+			_, _ = w.Write([]byte(body))
+			return
+		}
+		if r.Header.Get("If-None-Match") == etag {
+			notModified++
+			w.Header().Set(httpclient.EncryptedConfigDigestHeader, digestOf(enc))
+			w.WriteHeader(http.StatusNotModified)
+			return
+		}
+		w.Header().Set("ETag", etag)
+		w.Header().Set(httpclient.EncryptedConfigHeader, enc)
+		w.Header().Set(httpclient.EncryptedConfigDigestHeader, digestOf(enc))
+		_, _ = w.Write([]byte(body))
+	}))
+	t.Cleanup(server.Close)
+
+	// Prime the YAML+ETag cache, then delete the .enc sidecar.
+	src1 := newURLSourceForTest(server.URL, nil)
+	_, err := src1.Read(t.Context())
+	require.NoError(t, err)
+	encPath := filepath.Join(getURLCacheDir(), hashURL(server.URL)+".enc")
+	require.NoError(t, os.Remove(encPath))
+
+	src2 := newURLSourceForTest(server.URL, nil)
+	data, err := src2.Read(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, body, string(data))
+	assert.Equal(t, enc, src2.(EncryptedConfigSource).EncryptedConfig(),
+		"self-heal must recover the encrypted config")
+	assert.Equal(t, 1, notModified, "exactly one 304 before self-healing")
+	assert.Equal(t, 1, forced, "exactly one forced reload")
+}
+
+// TestURLSource_SelfHealsOn304DigestMismatch verifies a stale cached config is
+// discarded and force-reloaded when the server's digest no longer matches.
+func TestURLSource_SelfHealsOn304DigestMismatch(t *testing.T) {
+	paths.SetDataDir(t.TempDir())
+	t.Cleanup(func() { paths.SetDataDir("") })
+
+	const staleEnc = "OLD-BLOB"
+	const freshEnc = "NEW-BLOB"
+	const etag = "sha256:abc"
+	const body = "version: \"2\"\n"
+
+	var forced int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Cache-Control") == "no-cache" {
+			forced++
+			w.Header().Set("ETag", etag)
+			w.Header().Set(httpclient.EncryptedConfigHeader, freshEnc)
+			w.Header().Set(httpclient.EncryptedConfigDigestHeader, digestOf(freshEnc))
+			_, _ = w.Write([]byte(body))
+			return
+		}
+		if r.Header.Get("If-None-Match") == etag {
+			w.Header().Set(httpclient.EncryptedConfigDigestHeader, digestOf(freshEnc))
+			w.WriteHeader(http.StatusNotModified)
+			return
+		}
+		w.Header().Set("ETag", etag)
+		w.Header().Set(httpclient.EncryptedConfigHeader, staleEnc)
+		w.Header().Set(httpclient.EncryptedConfigDigestHeader, digestOf(staleEnc))
+		_, _ = w.Write([]byte(body))
+	}))
+	t.Cleanup(server.Close)
+
+	src1 := newURLSourceForTest(server.URL, nil)
+	_, err := src1.Read(t.Context())
+	require.NoError(t, err)
+	require.Equal(t, staleEnc, src1.(EncryptedConfigSource).EncryptedConfig())
+
+	src2 := newURLSourceForTest(server.URL, nil)
+	_, err = src2.Read(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, freshEnc, src2.(EncryptedConfigSource).EncryptedConfig(),
+		"stale config must be replaced by the forced reload")
+	assert.Equal(t, 1, forced, "digest mismatch must trigger exactly one forced reload")
 }

--- a/pkg/embeddedchat/embeddedchat.go
+++ b/pkg/embeddedchat/embeddedchat.go
@@ -157,6 +157,7 @@ func New(ctx context.Context, cfg Config) (*Session, error) {
 			Models:             loaded.Models,
 			Providers:          loaded.Providers,
 			ModelsGateway:      runConfig.ModelsGateway,
+			EncryptedConfig:    loaded.EncryptedConfig,
 			EnvProvider:        runConfig.EnvProvider(),
 			ProviderRegistry:   loaded.ProviderRegistry,
 			AgentDefaultModels: loaded.AgentDefaultModels,

--- a/pkg/httpclient/client.go
+++ b/pkg/httpclient/client.go
@@ -32,6 +32,20 @@ type HTTPOptions struct {
 
 type Opt func(*HTTPOptions)
 
+// EncryptedConfigHeader is the HTTP header that carries the encrypted agent
+// config. docker-agent sends it on requests to a trusted Docker gateway, and a
+// trusted Docker source may return it when the agent YAML is fetched so the
+// value can be replayed on subsequent model requests.
+const EncryptedConfigHeader = "X-Cagent-Encrypted-Config"
+
+// EncryptedConfigDigestHeader carries a short SHA-256 fingerprint (hex,
+// "sha256:...") of the encrypted agent config. A trusted Docker source sends it
+// alongside the full config on a 200, and — crucially — alone on a 304 Not
+// Modified response, where the full config is omitted to preserve the bandwidth
+// savings of conditional requests. A client that cached the config from an
+// earlier 200 uses the digest to confirm the cached value is still current.
+const EncryptedConfigDigestHeader = "X-Cagent-Encrypted-Config-Digest"
+
 func NewHTTPClient(ctx context.Context, opts ...Opt) *http.Client {
 	httpOptions := HTTPOptions{
 		Header:   make(http.Header),

--- a/pkg/model/provider/base/gateway.go
+++ b/pkg/model/provider/base/gateway.go
@@ -74,6 +74,24 @@ func GatewayHTTPOptions(gatewayURL *url.URL, defaultBaseURL string, cfg *latest.
 		httpclient.WithModelName(cfg.Name),
 		httpclient.WithQuery(gatewayURL.Query()),
 	}
+	// Forward the encrypted agent config to trusted Docker gateways only. The
+	// gateway string here is the full URL; reuse the same trust check the
+	// Docker JWT injection relies on so we never leak the value to third-party
+	// gateways.
+	if enc := modelOpts.EncryptedConfig(); enc != "" {
+		if environment.IsTrustedDockerURL(gatewayURL.String()) {
+			opts = append(opts, httpclient.WithHeader(httpclient.EncryptedConfigHeader, enc))
+			slog.Debug("Forwarding encrypted agent config to Docker gateway",
+				"header", httpclient.EncryptedConfigHeader,
+				"gateway", gatewayURL.String(),
+				"provider", cfg.Provider,
+				"model", cfg.Model,
+				"value_length", len(enc))
+		} else {
+			slog.Debug("Not forwarding encrypted agent config: gateway is not a trusted Docker URL",
+				"gateway", gatewayURL.String())
+		}
+	}
 	if modelOpts.GeneratingTitle() {
 		opts = append(opts, httpclient.WithHeader("X-Cagent-GeneratingTitle", "1"))
 	}

--- a/pkg/model/provider/options/options.go
+++ b/pkg/model/provider/options/options.go
@@ -11,6 +11,7 @@ import (
 
 type ModelOptions struct {
 	gateway          string
+	encryptedConfig  string
 	structuredOutput *latest.StructuredOutput
 	generatingTitle  bool
 	compacting       bool
@@ -24,6 +25,12 @@ type ModelOptions struct {
 
 func (c *ModelOptions) Gateway() string {
 	return c.gateway
+}
+
+// EncryptedConfig returns the opaque encrypted agent YAML to forward to a
+// trusted Docker models gateway, or "" when none was set.
+func (c *ModelOptions) EncryptedConfig() string {
+	return c.encryptedConfig
 }
 
 func (c *ModelOptions) StructuredOutput() *latest.StructuredOutput {
@@ -107,6 +114,14 @@ func Apply(opts ...Opt) ModelOptions {
 func WithGateway(gateway string) Opt {
 	return func(cfg *ModelOptions) {
 		cfg.gateway = gateway
+	}
+}
+
+// WithEncryptedConfig records the opaque encrypted agent YAML to forward to a
+// trusted Docker models gateway. An empty value is a no-op.
+func WithEncryptedConfig(encryptedConfig string) Opt {
+	return func(cfg *ModelOptions) {
+		cfg.encryptedConfig = encryptedConfig
 	}
 }
 
@@ -212,6 +227,9 @@ func FromModelOptions(m ModelOptions) []Opt {
 	var out []Opt
 	if g := m.Gateway(); g != "" {
 		out = append(out, WithGateway(g))
+	}
+	if m.encryptedConfig != "" {
+		out = append(out, WithEncryptedConfig(m.encryptedConfig))
 	}
 	if m.structuredOutput != nil {
 		out = append(out, WithStructuredOutput(m.structuredOutput))

--- a/pkg/runtime/model_switcher.go
+++ b/pkg/runtime/model_switcher.go
@@ -161,6 +161,10 @@ type ModelSwitcherConfig struct {
 	Providers map[string]latest.ProviderConfig
 	// ModelsGateway is the gateway URL if configured
 	ModelsGateway string
+	// EncryptedConfig is the opaque encrypted agent YAML forwarded to a trusted
+	// Docker models gateway on every request (X-Cagent-Encrypted-Config header).
+	// Empty disables forwarding.
+	EncryptedConfig string
 	// EnvProvider provides access to environment variables
 	EnvProvider environment.Provider
 	// ProviderRegistry instantiates providers for runtime model switching.
@@ -874,6 +878,7 @@ func modelHasAnthropicAuth(m latest.ModelConfig, providers map[string]latest.Pro
 func (r *LocalRuntime) createProviderFromConfig(ctx context.Context, cfg *latest.ModelConfig) (provider.Provider, error) {
 	opts := []options.Opt{
 		options.WithGateway(r.modelSwitcherCfg.ModelsGateway),
+		options.WithEncryptedConfig(r.modelSwitcherCfg.EncryptedConfig),
 		options.WithProviders(r.modelSwitcherCfg.Providers),
 	}
 

--- a/pkg/server/session_manager.go
+++ b/pkg/server/session_manager.go
@@ -1479,6 +1479,7 @@ func (sm *SessionManager) runtimeForSession(ctx context.Context, sess *session.S
 		Models:             loadResult.Models,
 		Providers:          loadResult.Providers,
 		ModelsGateway:      rc.ModelsGateway,
+		EncryptedConfig:    loadResult.EncryptedConfig,
 		EnvProvider:        rc.EnvProvider(),
 		ProviderRegistry:   loadResult.ProviderRegistry,
 		AgentDefaultModels: loadResult.AgentDefaultModels,

--- a/pkg/teamloader/teamloader.go
+++ b/pkg/teamloader/teamloader.go
@@ -209,6 +209,12 @@ type LoadResult struct {
 	// referenced by several agents is one shared pot.
 	Budgets      map[string]latest.BudgetConfig
 	AgentBudgets map[string][]string
+
+	// EncryptedConfig is the encrypted agent config in effect for this load:
+	// either the explicit --encrypted-config / env value, or the one captured
+	// from the X-Cagent-Encrypted-Config response header when the agent YAML
+	// was fetched from a trusted Docker URL. Empty when neither applies.
+	EncryptedConfig string
 }
 
 // Load loads an agent team from the given source
@@ -264,6 +270,18 @@ func LoadWithConfig(ctx context.Context, agentSource config.Source, runConfig *c
 	cfg, err := config.Load(ctx, agentSource, config.WithFlavors(runConfig.Flavors...))
 	if err != nil {
 		return nil, err
+	}
+
+	// When the agent YAML was fetched from a trusted Docker URL that returned
+	// the encrypted config in a response header, adopt it so it is forwarded to
+	// the Docker models gateway on model requests. An explicit --encrypted-config
+	// (or its env var) always wins.
+	if runConfig.EncryptedConfig == "" {
+		if ecs, ok := agentSource.(config.EncryptedConfigSource); ok {
+			if enc := ecs.EncryptedConfig(); enc != "" {
+				runConfig.EncryptedConfig = enc
+			}
+		}
 	}
 	if cfg != nil {
 		span.SetAttributes(
@@ -617,6 +635,7 @@ func LoadWithConfig(ctx context.Context, agentSource config.Source, runConfig *c
 		Budget:             cfg.Budget,
 		Budgets:            cfg.Budgets,
 		AgentBudgets:       agentBudgets,
+		EncryptedConfig:    runConfig.EncryptedConfig,
 	}, nil
 }
 
@@ -659,6 +678,7 @@ func getModelsForAgent(ctx context.Context, cfg *latest.Config, a *latest.AgentC
 
 		opts := []options.Opt{
 			options.WithGateway(runConfig.ModelsGateway),
+			options.WithEncryptedConfig(runConfig.EncryptedConfig),
 			options.WithStructuredOutput(a.StructuredOutput),
 			options.WithProviders(cfg.Providers),
 		}
@@ -725,6 +745,7 @@ func getFallbackModelsForAgent(ctx context.Context, cfg *latest.Config, a *lates
 
 		opts := []options.Opt{
 			options.WithGateway(runConfig.ModelsGateway),
+			options.WithEncryptedConfig(runConfig.EncryptedConfig),
 			options.WithStructuredOutput(a.StructuredOutput),
 			options.WithProviders(cfg.Providers),
 		}
@@ -791,6 +812,7 @@ func getTitleModelForAgent(ctx context.Context, cfg *latest.Config, a *latest.Ag
 
 	opts := []options.Opt{
 		options.WithGateway(runConfig.ModelsGateway),
+		options.WithEncryptedConfig(runConfig.EncryptedConfig),
 		options.WithStructuredOutput(a.StructuredOutput),
 		options.WithProviders(cfg.Providers),
 	}
@@ -845,6 +867,7 @@ func getCompactionModelForAgent(ctx context.Context, cfg *latest.Config, a *late
 
 	opts := []options.Opt{
 		options.WithGateway(runConfig.ModelsGateway),
+		options.WithEncryptedConfig(runConfig.EncryptedConfig),
 		options.WithStructuredOutput(a.StructuredOutput),
 		options.WithProviders(cfg.Providers),
 	}

--- a/pkg/teamloader/teamloader_test.go
+++ b/pkg/teamloader/teamloader_test.go
@@ -1668,3 +1668,56 @@ func TestLoadWithConfig_WithWorkingDirIsConcurrencySafe(t *testing.T) {
 	assert.Equal(t, callerDir, runConfig.WorkingDir,
 		"the shared RuntimeConfig must never be mutated")
 }
+
+// encConfigSource is a config.Source that also implements
+// config.EncryptedConfigSource, standing in for a trusted Docker URL that
+// returned the X-Cagent-Encrypted-Config response header.
+type encConfigSource struct {
+	name string
+	data []byte
+	enc  string
+}
+
+func (s encConfigSource) Name() string                         { return s.name }
+func (s encConfigSource) ParentDir() string                    { return "" }
+func (s encConfigSource) Read(context.Context) ([]byte, error) { return s.data, nil }
+func (s encConfigSource) EncryptedConfig() string              { return s.enc }
+
+// TestLoadCapturesEncryptedConfigFromSource verifies the loader adopts the
+// encrypted config discovered by the source (e.g. a Docker URL response header)
+// into the load result, so it can be forwarded to the Docker models gateway.
+func TestLoadCapturesEncryptedConfigFromSource(t *testing.T) {
+	t.Setenv("OPENAI_API_KEY", "dummy")
+
+	data := []byte(`agents:
+  root:
+    model: openai/gpt-4o
+    instruction: test
+`)
+	src := encConfigSource{name: "agent.yaml", data: data, enc: "ENCRYPTED-FROM-HEADER"}
+
+	result, err := LoadWithConfig(t.Context(), src, &config.RuntimeConfig{}, withTestProviderRegistry()...)
+	require.NoError(t, err)
+	assert.Equal(t, "ENCRYPTED-FROM-HEADER", result.EncryptedConfig)
+}
+
+// TestLoadExplicitEncryptedConfigWins verifies an explicit
+// --encrypted-config / env value takes precedence over a value the source
+// discovered.
+func TestLoadExplicitEncryptedConfigWins(t *testing.T) {
+	t.Setenv("OPENAI_API_KEY", "dummy")
+
+	data := []byte(`agents:
+  root:
+    model: openai/gpt-4o
+    instruction: test
+`)
+	src := encConfigSource{name: "agent.yaml", data: data, enc: "FROM-HEADER"}
+
+	rc := &config.RuntimeConfig{}
+	rc.EncryptedConfig = "FROM-FLAG"
+
+	result, err := LoadWithConfig(t.Context(), src, rc, withTestProviderRegistry()...)
+	require.NoError(t, err)
+	assert.Equal(t, "FROM-FLAG", result.EncryptedConfig)
+}


### PR DESCRIPTION
Builds on \`share push --key --encrypt\` (#4148, pkg/protect): recover the encrypted agent YAML at run time and forward it to a trusted Docker models gateway on every request, so the gateway can verify the running system prompt against the signed config.

## What it does
- **Discover** the encrypted config from a trusted Docker source: \`urlSource\` captures the \`X-Cagent-Encrypted-Config\` response header on a 200 (gated on \`IsTrustedDockerURL\`, the same trust check as the Docker JWT), holds it via an atomic pointer, and exposes it through the new \`config.EncryptedConfigSource\` interface. teamloader adopts it into \`RuntimeConfig.EncryptedConfig\` when no explicit value was set and surfaces it on \`LoadResult\`.
- **Persist & self-heal across cached (304) fetches**: the header is stored in a \`.enc\` sidecar next to the cached YAML, so a later revalidation that returns a 304 (carrying only \`X-Cagent-Encrypted-Config-Digest\`, not the full blob) recovers the value from disk and verifies it against the digest. If the cached config is missing or its digest no longer matches, force a full reload (drop \`If-None-Match\`, send \`Cache-Control/Pragma: no-cache\`). If that forced reload *still* returns a 304 with an unmatched digest (a misbehaving server/intermediary), we do not loop or fail the whole config load — the YAML is valid and cached — but we clear the in-memory encrypted config and warn, so nothing stale or mismatched is ever forwarded to the gateway (the proxy-side check fails open on a missing header).
- **Forward** it to the gateway: \`options.WithEncryptedConfig\` threads the value through \`ModelSwitcherConfig\` and, crucially, through every model built in teamloader (main, fallback, title, and compaction models) into \`GatewayHTTPOptions\`, which injects the \`X-Cagent-Encrypted-Config\` header on trusted Docker gateways only (untrusted gateways are skipped, logged at debug).
- **httpclient** gains the shared \`EncryptedConfigHeader\` and \`EncryptedConfigDigestHeader\` constants.
- **share push/pull**: allow the protection key inline via the \`DOCKER_AGENT_ENCRYPT_KEY\` environment variable, not just a \`--key\` file, for CI and scripted/ephemeral secrets. The \`--key\` flag still takes precedence.

## Tests
Covered in \`pkg/config\` (capture, no-capture, 304 recovery, self-heal on missing cache, self-heal on digest mismatch, forced-reload-still-304 guard) and \`pkg/teamloader\` (adoption + explicit precedence). Verified end-to-end against the docker/gordon proxy: the request is forwarded, decrypted, and \`encrypted_prompt_verified=true\` in traces.

Pairs with the proxy-side PR in docker/gordon.
