### PR TITLE
fix(openai): recognise the gpt-6 family (Responses API, reasoning effort, token field)

### DIFF
--- a/pkg/model/provider/openai/chat_tools_reasoning_test.go
+++ b/pkg/model/provider/openai/chat_tools_reasoning_test.go
@@ -1,0 +1,195 @@
+package openai
+
+import (
+	"encoding/json"
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/docker/docker-agent/pkg/chat"
+	"github.com/docker/docker-agent/pkg/concurrent"
+	"github.com/docker/docker-agent/pkg/config/latest"
+	"github.com/docker/docker-agent/pkg/environment"
+	"github.com/docker/docker-agent/pkg/model/provider/options"
+	"github.com/docker/docker-agent/pkg/tools"
+)
+
+// toolsForReasoningTest returns a minimal single-tool request, enough to
+// exercise the tools-present branch of the Chat Completions reasoning-effort
+// gate without pulling in schema-conversion edge cases.
+func toolsForReasoningTest() []tools.Tool {
+	return []tools.Tool{
+		{
+			Name:        "get_time",
+			Description: "get the time",
+			Parameters: map[string]any{
+				"type":       "object",
+				"properties": map[string]any{},
+			},
+		},
+	}
+}
+
+// chatCompletionsReasoningEffortField drives a Chat Completions request for
+// model with tools against a mock server, forcing Chat Completions via
+// api_type, and returns the raw request body plus whether it carried the
+// reasoning_effort key at all (as opposed to the field being present but
+// empty).
+func chatCompletionsReasoningEffortField(t *testing.T, model string, toolList []tools.Tool) map[string]any {
+	t.Helper()
+
+	server, body := captureRequestBody(t)
+	cfg := &latest.ModelConfig{
+		Provider:       "openai",
+		Model:          model,
+		BaseURL:        server.URL,
+		TokenKey:       "MY_TOKEN",
+		ThinkingBudget: &latest.ThinkingBudget{Effort: "high"},
+		// Force Chat Completions even for a model that would otherwise
+		// auto-select the Responses API.
+		ProviderOpts: map[string]any{"api_type": "openai_chatcompletions"},
+	}
+	env := environment.NewMapEnvProvider(map[string]string{"MY_TOKEN": "secret"})
+
+	client, err := NewClient(t.Context(), cfg, env)
+	require.NoError(t, err)
+
+	stream, err := client.CreateChatCompletionStream(t.Context(), []chat.Message{{Role: chat.MessageRoleUser, Content: "hi"}}, toolList)
+	require.NoError(t, err)
+	defer stream.Close()
+	drainReasoningTestStream(t, stream)
+
+	var req map[string]any
+	require.NoError(t, json.Unmarshal(body(), &req))
+	return req
+}
+
+// chatCompletionsRequest drives a Chat Completions request for model with
+// tools against a mock server, forcing Chat Completions via api_type, using
+// the given request options (e.g. options.WithNoThinking()), with no
+// thinking_budget configured. Returns the raw request body.
+func chatCompletionsRequest(t *testing.T, model string, toolList []tools.Tool, opts ...options.Opt) map[string]any {
+	t.Helper()
+
+	server, body := captureRequestBody(t)
+	cfg := &latest.ModelConfig{
+		Provider: "openai",
+		Model:    model,
+		BaseURL:  server.URL,
+		TokenKey: "MY_TOKEN",
+		// Force Chat Completions even for a model that would otherwise
+		// auto-select the Responses API.
+		ProviderOpts: map[string]any{"api_type": "openai_chatcompletions"},
+	}
+	env := environment.NewMapEnvProvider(map[string]string{"MY_TOKEN": "secret"})
+
+	client, err := NewClient(t.Context(), cfg, env, opts...)
+	require.NoError(t, err)
+
+	stream, err := client.CreateChatCompletionStream(t.Context(), []chat.Message{{Role: chat.MessageRoleUser, Content: "hi"}}, toolList)
+	require.NoError(t, err)
+	defer stream.Close()
+	drainReasoningTestStream(t, stream)
+
+	var req map[string]any
+	require.NoError(t, json.Unmarshal(body(), &req))
+	return req
+}
+
+// TestChatCompletions_DropsReasoningEffortWithTools is the regression test
+// for docker/docker-agent#4162: gpt-5.4+ (and every gpt-5.6+/gpt-6+
+// generation, see [modelinfo.OpenAIRejectsToolsWithReasoningEffort])
+// rejects an explicit reasoning_effort alongside function tools on Chat
+// Completions (verified live against api.openai.com). Forcing such a model
+// onto Chat Completions (api_type override) with tools and a
+// thinking_budget must drop the field rather than send a value guaranteed
+// to 400, and must warn once so the drop is diagnosable.
+func TestChatCompletions_DropsReasoningEffortWithTools(t *testing.T) {
+	// Not parallel: it swaps the process-global default logger.
+	var buf concurrent.Buffer
+	prevLogger := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn})))
+	t.Cleanup(func() { slog.SetDefault(prevLogger) })
+
+	req := chatCompletionsReasoningEffortField(t, "gpt-6-astra", toolsForReasoningTest())
+	assert.NotContains(t, req, "reasoning_effort", "reasoning_effort must be dropped when tools force a model rejecting it onto Chat Completions")
+
+	logs := buf.String()
+	assert.Contains(t, logs, "dropping reasoning_effort")
+	assert.Contains(t, logs, "gpt-6-astra")
+}
+
+// TestChatCompletions_DropsReasoningEffortWithTools_GPT54Boundary exercises
+// the exact minor-version boundary where OpenAI started rejecting an
+// explicit reasoning_effort with tools (gpt-5.4), one generation before the
+// gpt-5.6/gpt-6 "no combination works" case.
+func TestChatCompletions_DropsReasoningEffortWithTools_GPT54Boundary(t *testing.T) {
+	t.Parallel()
+
+	req := chatCompletionsReasoningEffortField(t, "gpt-5.4", toolsForReasoningTest())
+	assert.NotContains(t, req, "reasoning_effort")
+	require.Contains(t, req, "tools")
+}
+
+// TestChatCompletions_KeepsReasoningEffortWithoutTools is the control case:
+// with no tools in the request, the existing thinking_budget behavior is
+// unaffected by the new tools-present gate.
+func TestChatCompletions_KeepsReasoningEffortWithoutTools(t *testing.T) {
+	t.Parallel()
+
+	req := chatCompletionsReasoningEffortField(t, "gpt-6-astra", nil)
+	assert.Equal(t, "high", req["reasoning_effort"])
+}
+
+// TestChatCompletions_KeepsReasoningEffortWithTools_BelowGPT54 covers the
+// OpenAI generations below the gpt-5.4 boundary (bare gpt-5, and the
+// o-series, which is not a "gpt-" id at all): live-verified, these still
+// accept an explicit reasoning_effort together with tools on Chat
+// Completions, so the new gate must not fire for them and change existing
+// behavior.
+func TestChatCompletions_KeepsReasoningEffortWithTools_BelowGPT54(t *testing.T) {
+	t.Parallel()
+
+	for _, model := range []string{"gpt-5", "gpt-5.2", "o3-mini"} {
+		t.Run(model, func(t *testing.T) {
+			t.Parallel()
+			req := chatCompletionsReasoningEffortField(t, model, toolsForReasoningTest())
+			assert.Equal(t, "high", req["reasoning_effort"], "gate must not fire below the gpt-5.4 boundary")
+		})
+	}
+}
+
+// TestChatCompletions_NoWarnWhenNothingWasGoingToBeSent covers the ordering
+// gap flagged in review: when tools force a rejecting model onto Chat
+// Completions but no thinking_budget is configured and NoThinking() is not
+// set, there was never a reasoning_effort about to be sent, so nothing was
+// "dropped" — the WARN must not fire (it would be misleading, and would
+// repeat on every turn of a long tool-using conversation).
+func TestChatCompletions_NoWarnWhenNothingWasGoingToBeSent(t *testing.T) {
+	// Not parallel: it swaps the process-global default logger.
+	var buf concurrent.Buffer
+	prevLogger := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn})))
+	t.Cleanup(func() { slog.SetDefault(prevLogger) })
+
+	req := chatCompletionsRequest(t, "gpt-6-astra", toolsForReasoningTest())
+	assert.NotContains(t, req, "reasoning_effort")
+	assert.Empty(t, buf.String(), "nothing was going to be sent, so there is nothing to warn about")
+}
+
+// TestChatCompletions_DropsReasoningEffortWithTools_OverridesNoThinking
+// exercises the branch ordering explicitly: the tools+reject case must take
+// priority over NoThinking() too, not just over an explicit ThinkingBudget.
+func TestChatCompletions_DropsReasoningEffortWithTools_OverridesNoThinking(t *testing.T) {
+	// Not parallel: it swaps the process-global default logger.
+	var buf concurrent.Buffer
+	prevLogger := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn})))
+	t.Cleanup(func() { slog.SetDefault(prevLogger) })
+
+	req := chatCompletionsRequest(t, "gpt-6-astra", toolsForReasoningTest(), options.WithNoThinking())
+	assert.NotContains(t, req, "reasoning_effort", "the tools+reject gate must win over NoThinking(), not just over an explicit ThinkingBudget")
+	assert.Contains(t, buf.String(), "dropping reasoning_effort", "NoThinking() was about to send an effort, so the drop must be reported")
+}

--- a/pkg/model/provider/openai/client.go
+++ b/pkg/model/provider/openai/client.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"sync"
 
 	"github.com/openai/openai-go/v3"
 	"github.com/openai/openai-go/v3/option"
@@ -44,6 +45,11 @@ type Client struct {
 	// wsPool is initialized in NewClient when transport=websocket is configured.
 	// It maintains a persistent WebSocket connection across requests.
 	wsPool *wsPool
+
+	// warnThinkingBudgetIgnoredOnce dedupes the "thinking_budget has no
+	// effect on this model" diagnostic (see [Client.warnThinkingBudgetIgnored])
+	// so a long-lived client warns at most once instead of on every request.
+	warnThinkingBudgetIgnoredOnce sync.Once
 }
 
 // NewClient creates a new OpenAI client from the provided configuration
@@ -478,32 +484,55 @@ func (c *Client) CreateChatCompletionStream(
 	// noThinkingMinOutputTokens so residual hidden reasoning can't starve
 	// visible output. The nil-guard is intentional: when MaxTokens is unset
 	// the caller has imposed no cap, so there is nothing to floor.
-	if modelinfo.UsesReasoningEffort(c.ModelConfig.Model) {
-		if c.ModelOptions.NoThinking() {
-			reasoningEffort := "low"
-			if sendsRealNoneEffort(&c.ModelConfig, c.ModelOptions.OpenAIVendor()) {
-				reasoningEffort = "none"
-			}
-			params.ReasoningEffort = shared.ReasoningEffort(reasoningEffort)
-			// Hidden reasoning tokens count against the output budget even
-			// with low effort. Enforce a floor so visible text isn't starved.
-			if c.ModelConfig.MaxTokens != nil && *c.ModelConfig.MaxTokens < noThinkingMinOutputTokens {
-				if !modelinfo.SupportsResponsesAPI(c.ModelConfig.Model) {
-					params.MaxTokens = openai.Int(noThinkingMinOutputTokens)
-				} else {
-					params.MaxCompletionTokens = openai.Int(noThinkingMinOutputTokens)
-				}
-			}
-			slog.DebugContext(ctx, "OpenAI request using reasoning effort (NoThinking)", "reasoning_effort", reasoningEffort)
-		} else if c.ModelConfig.ThinkingBudget != nil {
-			effortStr, err := openAIReasoningEffort(c.ModelConfig.ThinkingBudget)
-			if err != nil {
-				slog.ErrorContext(ctx, "OpenAI request using thinking_budget failed", "error", err)
-				return nil, err
-			}
-			params.ReasoningEffort = shared.ReasoningEffort(effortStr)
-			slog.DebugContext(ctx, "OpenAI request using thinking_budget", "reasoning_effort", effortStr)
+	switch {
+	case !modelinfo.UsesReasoningEffort(c.ModelConfig.Model):
+		if c.ModelConfig.ThinkingBudget != nil && !c.ModelConfig.ThinkingBudget.IsDisabled() {
+			c.warnThinkingBudgetIgnored(ctx)
 		}
+	case len(requestTools) > 0 && modelinfo.OpenAIRejectsToolsWithReasoningEffort(c.ModelConfig.Model):
+		// See modelinfo.OpenAIRejectsToolsWithReasoningEffort: gpt-5.4+
+		// (and every gpt-5.6+/gpt-6+ generation) reject an explicit
+		// reasoning_effort alongside function tools on Chat Completions;
+		// the API's own error points at /v1/responses. Reaching this path
+		// at all means the caller forced Chat Completions for a model
+		// that would otherwise auto-select the Responses API (an explicit
+		// api_type or custom-provider override). Dropping the field lets
+		// gpt-5.4/gpt-5.5 succeed with their implicit default effort;
+		// gpt-5.6+/gpt-6+ still 400 on tools with ANY reasoning_effort
+		// there (OpenAI has no combination that works on Chat Completions
+		// for those), but the request degrades instead of silently
+		// sending a value the caller can't see is the cause. Only warn
+		// when a value was actually about to be sent (NoThinking or an
+		// explicit ThinkingBudget); otherwise there is nothing dropped to
+		// report, and warning anyway would be misleading and would repeat
+		// on every turn of a long tool-using conversation.
+		if c.ModelOptions.NoThinking() || c.ModelConfig.ThinkingBudget != nil {
+			slog.WarnContext(ctx, "OpenAI: dropping reasoning_effort for a tools request forced onto Chat Completions; use api_type: openai_responses for tool calling on this model", "model", c.ModelConfig.Model)
+		}
+	case c.ModelOptions.NoThinking():
+		reasoningEffort := "low"
+		if sendsRealNoneEffort(&c.ModelConfig, c.ModelOptions.OpenAIVendor()) {
+			reasoningEffort = "none"
+		}
+		params.ReasoningEffort = shared.ReasoningEffort(reasoningEffort)
+		// Hidden reasoning tokens count against the output budget even
+		// with low effort. Enforce a floor so visible text isn't starved.
+		if c.ModelConfig.MaxTokens != nil && *c.ModelConfig.MaxTokens < noThinkingMinOutputTokens {
+			if !modelinfo.SupportsResponsesAPI(c.ModelConfig.Model) {
+				params.MaxTokens = openai.Int(noThinkingMinOutputTokens)
+			} else {
+				params.MaxCompletionTokens = openai.Int(noThinkingMinOutputTokens)
+			}
+		}
+		slog.DebugContext(ctx, "OpenAI request using reasoning effort (NoThinking)", "reasoning_effort", reasoningEffort)
+	case c.ModelConfig.ThinkingBudget != nil:
+		effortStr, err := openAIReasoningEffort(c.ModelConfig.ThinkingBudget)
+		if err != nil {
+			slog.ErrorContext(ctx, "OpenAI request using thinking_budget failed", "error", err)
+			return nil, err
+		}
+		params.ReasoningEffort = shared.ReasoningEffort(effortStr)
+		slog.DebugContext(ctx, "OpenAI request using thinking_budget", "reasoning_effort", effortStr)
 	}
 
 	// Apply structured output configuration
@@ -542,6 +571,17 @@ func (c *Client) CreateChatCompletionStream(
 
 	slog.DebugContext(ctx, "OpenAI chat completion stream created successfully", "model", c.ModelConfig.Model)
 	return newStreamAdapter(stream, trackUsage), nil
+}
+
+// warnThinkingBudgetIgnored logs, once per client, that a configured and
+// enabled thinking_budget has no effect because this model does not accept
+// a reasoning-effort parameter at all (docker-agent#4162: previously
+// silent — the setting was accepted by config validation but dropped
+// without a trace here).
+func (c *Client) warnThinkingBudgetIgnored(ctx context.Context) {
+	c.warnThinkingBudgetIgnoredOnce.Do(func() {
+		slog.WarnContext(ctx, "OpenAI: thinking_budget is configured but this model does not support a reasoning effort parameter; the setting has no effect", "model", c.ModelConfig.Model)
+	})
 }
 
 func (c *Client) supportsDeferredTools() bool {
@@ -740,6 +780,8 @@ func (c *Client) CreateResponseStream(
 				slog.DebugContext(ctx, "OpenAI responses request using thinking_budget", "reasoning_effort", effortStr)
 			}
 		}
+	} else if c.ModelConfig.ThinkingBudget != nil && !c.ModelConfig.ThinkingBudget.IsDisabled() {
+		c.warnThinkingBudgetIgnored(ctx)
 	}
 
 	// Apply structured output configuration

--- a/pkg/model/provider/openai/thinking_budget_ignored_test.go
+++ b/pkg/model/provider/openai/thinking_budget_ignored_test.go
@@ -1,0 +1,119 @@
+package openai
+
+import (
+	"log/slog"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/docker/docker-agent/pkg/chat"
+	"github.com/docker/docker-agent/pkg/concurrent"
+	"github.com/docker/docker-agent/pkg/config/latest"
+	"github.com/docker/docker-agent/pkg/environment"
+)
+
+// TestChatCompletions_WarnsOnceWhenThinkingBudgetIgnored is the regression
+// test for docker/docker-agent#4162: configuring thinking_budget on a model
+// that does not accept a reasoning-effort parameter used to be silently
+// dropped. It must now warn, and only once per client even across several
+// requests.
+func TestChatCompletions_WarnsOnceWhenThinkingBudgetIgnored(t *testing.T) {
+	// Not parallel: it swaps the process-global default logger.
+	var buf concurrent.Buffer
+	prevLogger := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn})))
+	t.Cleanup(func() { slog.SetDefault(prevLogger) })
+
+	server, _ := captureRequestBody(t)
+	cfg := &latest.ModelConfig{
+		Provider: "openai",
+		// gpt-4o does not accept reasoning_effort at all.
+		Model:          "gpt-4o",
+		BaseURL:        server.URL,
+		TokenKey:       "MY_TOKEN",
+		ThinkingBudget: &latest.ThinkingBudget{Effort: "high"},
+	}
+	env := environment.NewMapEnvProvider(map[string]string{"MY_TOKEN": "secret"})
+
+	client, err := NewClient(t.Context(), cfg, env)
+	require.NoError(t, err)
+
+	for range 2 {
+		stream, err := client.CreateChatCompletionStream(t.Context(), []chat.Message{{Role: chat.MessageRoleUser, Content: "hi"}}, nil)
+		require.NoError(t, err)
+		drainReasoningTestStream(t, stream)
+		stream.Close()
+	}
+
+	logs := buf.String()
+	assert.Contains(t, logs, "thinking_budget is configured but this model does not support")
+	assert.Contains(t, logs, "gpt-4o")
+	assert.Equal(t, 1, strings.Count(logs, "does not support a reasoning effort parameter"), "the warning must fire at most once per client")
+}
+
+// TestResponsesAPI_WarnsOnceWhenThinkingBudgetIgnored is the Responses-API
+// sibling: gpt-4.1 auto-selects the Responses API but does not accept a
+// reasoning-effort parameter either.
+func TestResponsesAPI_WarnsOnceWhenThinkingBudgetIgnored(t *testing.T) {
+	// Not parallel: it swaps the process-global default logger.
+	var buf concurrent.Buffer
+	prevLogger := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn})))
+	t.Cleanup(func() { slog.SetDefault(prevLogger) })
+
+	server, _ := captureResponsesRequestBody(t)
+	cfg := &latest.ModelConfig{
+		Provider:       "openai",
+		Model:          "gpt-4.1",
+		BaseURL:        server.URL,
+		TokenKey:       "MY_TOKEN",
+		ThinkingBudget: &latest.ThinkingBudget{Effort: "high"},
+		ProviderOpts:   map[string]any{"api_type": "openai_responses"},
+	}
+	env := environment.NewMapEnvProvider(map[string]string{"MY_TOKEN": "secret"})
+
+	client, err := NewClient(t.Context(), cfg, env)
+	require.NoError(t, err)
+
+	stream, err := client.CreateResponseStream(t.Context(), []chat.Message{{Role: chat.MessageRoleUser, Content: "hi"}}, nil)
+	require.NoError(t, err)
+	drainReasoningTestStream(t, stream)
+	stream.Close()
+
+	logs := buf.String()
+	assert.Contains(t, logs, "thinking_budget is configured but this model does not support")
+	assert.Contains(t, logs, "gpt-4.1")
+}
+
+// TestChatCompletions_NoWarnWhenThinkingBudgetDisabled ensures a disabled
+// thinking_budget (thinking_budget: none/0) never triggers the ignored-budget
+// warning: there is no configured effort to report as dropped.
+func TestChatCompletions_NoWarnWhenThinkingBudgetDisabled(t *testing.T) {
+	// Not parallel: it swaps the process-global default logger.
+	var buf concurrent.Buffer
+	prevLogger := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn})))
+	t.Cleanup(func() { slog.SetDefault(prevLogger) })
+
+	server, _ := captureRequestBody(t)
+	cfg := &latest.ModelConfig{
+		Provider:       "openai",
+		Model:          "gpt-4o",
+		BaseURL:        server.URL,
+		TokenKey:       "MY_TOKEN",
+		ThinkingBudget: &latest.ThinkingBudget{Effort: "none"},
+	}
+	env := environment.NewMapEnvProvider(map[string]string{"MY_TOKEN": "secret"})
+
+	client, err := NewClient(t.Context(), cfg, env)
+	require.NoError(t, err)
+
+	stream, err := client.CreateChatCompletionStream(t.Context(), []chat.Message{{Role: chat.MessageRoleUser, Content: "hi"}}, nil)
+	require.NoError(t, err)
+	drainReasoningTestStream(t, stream)
+	stream.Close()
+
+	assert.NotContains(t, buf.String(), "thinking_budget is configured")
+}

--- a/pkg/modelinfo/modelinfo.go
+++ b/pkg/modelinfo/modelinfo.go
@@ -46,8 +46,10 @@ import (
 // the Responses API rather than the legacy Chat Completions API.
 //
 // The Responses API is the forward path for newer OpenAI models: gpt-4.1,
-// the o-series (o1/o3/o4), gpt-5 and Codex variants. Older models stay on
-// Chat Completions for compatibility.
+// the o-series (o1/o3/o4), gpt-5 and later generations (gpt-6+, matched via
+// [gptGeneration] so a naming convention rather than a per-id list picks up
+// new generations), and Codex variants. Older models stay on Chat
+// Completions for compatibility.
 func SupportsResponsesAPI(modelID string) bool {
 	m := normalizeOpenAI(modelID)
 	switch {
@@ -55,6 +57,9 @@ func SupportsResponsesAPI(modelID string) bool {
 		strings.HasPrefix(m, "gpt-5"),
 		strings.HasPrefix(m, "codex"),
 		strings.Contains(m, "-codex"):
+		return true
+	}
+	if maj, _, ok := gptGeneration(m); ok && maj >= 6 {
 		return true
 	}
 	return isOSeries(m)
@@ -66,7 +71,14 @@ func SupportsDeferredTools(provider, modelID string) bool {
 	provider = strings.ToLower(strings.TrimSpace(provider))
 	switch provider {
 	case "openai", "chatgpt":
-		switch normalizeOpenAI(modelID) {
+		m := normalizeOpenAI(modelID)
+		// gpt-6 is the next generation of the gpt-5.6 trio, which already
+		// supports deferred tool loading; every future generation inherits
+		// the capability without a per-id allow-list entry.
+		if maj, _, ok := gptGeneration(m); ok && maj >= 6 {
+			return true
+		}
+		switch m {
 		case "gpt-5.4", "gpt-5.4-mini", "gpt-5.5", "gpt-5.6-luna", "gpt-5.6-sol", "gpt-5.6-terra":
 			return true
 		case "gpt-5.4-pro":
@@ -92,12 +104,16 @@ func SupportsDeferredTools(provider, modelID string) bool {
 // UsesReasoningEffort reports whether an OpenAI model accepts the
 // `reasoning.effort` API parameter.
 //
-// All reasoning-capable OpenAI models do, except the gpt-5-chat variants
-// which are non-reasoning chat models at the API level.
+// All reasoning-capable OpenAI models do (gpt-5, gpt-6+, the o-series),
+// except the gpt-5-chat variants which are non-reasoning chat models at the
+// API level.
 func UsesReasoningEffort(modelID string) bool {
 	m := normalizeOpenAI(modelID)
 	if strings.HasPrefix(m, "gpt-5-chat") {
 		return false
+	}
+	if maj, _, ok := gptGeneration(m); ok && maj >= 6 {
+		return true
 	}
 	return isOSeries(m) || strings.HasPrefix(m, "gpt-5")
 }
@@ -230,6 +246,62 @@ func claudeOpusSonnetVersion(m string) (major, minor int, ok bool) {
 		return maj, minor, true
 	}
 	return 0, 0, false
+}
+
+// gptGeneration extracts the major and minor version of a normalized OpenAI
+// GPT model id of the form "gpt-<major>[.<minor>][-suffix]", such as
+// "gpt-6-astra", "gpt-6.1-foo", or "gpt-5.6-terra". A bare major with no dot
+// ("gpt-6") yields minor 0. It reports ok=false for anything that isn't a
+// GPT-5-or-later id: pre-gpt-5 families ("gpt-4.1"), non-GPT ids, and
+// malformed/date-shaped runs (a major or minor wider than two digits, or a
+// suffix glued on without a '-' boundary, e.g. "gpt-5.20260709" or
+// "gpt-6foo").
+//
+// This is the family-agnostic sibling of [gptFiveMinor] in
+// thinking_levels.go: callers that need to compare across GPT generations
+// ("is this gpt-5.6 or later, including gpt-6+") use [atLeastGPT] built on
+// top of this, while gptFiveMinor stays the narrower gpt-5.x-only gate whose
+// callers and tests predate the gpt-6 family and must keep rejecting a bare
+// "gpt-5" (no minor) exactly as before.
+func gptGeneration(modelID string) (major, minor int, ok bool) {
+	m := normalizeOpenAI(modelID)
+	rest, found := strings.CutPrefix(m, "gpt-")
+	if !found {
+		return 0, 0, false
+	}
+	maj, w := leadingInt(rest)
+	if w == 0 || w > 2 || maj < 5 {
+		return 0, 0, false
+	}
+	rest = rest[w:]
+	switch {
+	case rest == "", rest[0] == '-':
+		return maj, 0, true
+	case rest[0] != '.':
+		return 0, 0, false
+	}
+	min, mw := leadingInt(rest[1:])
+	if mw == 0 || mw > 2 {
+		return 0, 0, false
+	}
+	if tail := rest[1+mw:]; tail != "" && tail[0] != '-' {
+		return 0, 0, false
+	}
+	return maj, min, true
+}
+
+// atLeastGPT reports whether modelID names an OpenAI GPT model at or above
+// the given generation (major, minor), e.g. atLeastGPT(id, 5, 6) is the
+// gpt-5.6-or-later threshold shared by several capability checks. It uses
+// [gptGeneration], so every later GPT generation (gpt-6, gpt-7, ...)
+// automatically satisfies any gpt-5.x-or-later threshold without a code
+// change; ok=false (non-GPT-5+ ids) reports false.
+func atLeastGPT(modelID string, major, minor int) bool {
+	maj, min, ok := gptGeneration(modelID)
+	if !ok {
+		return false
+	}
+	return maj > major || (maj == major && min >= minor)
 }
 
 // UsesThinkingLevel reports whether a Google Gemini model uses level-based

--- a/pkg/modelinfo/modelinfo.go
+++ b/pkg/modelinfo/modelinfo.go
@@ -106,7 +106,9 @@ func SupportsDeferredTools(provider, modelID string) bool {
 //
 // All reasoning-capable OpenAI models do (gpt-5, gpt-6+, the o-series),
 // except the gpt-5-chat variants which are non-reasoning chat models at the
-// API level.
+// API level. This exclusion is NOT (yet) generation-agnostic: a future
+// "gpt-6-chat"-style non-reasoning id would need its own prefix check added
+// here, since the maj >= 6 branch below returns true unconditionally.
 func UsesReasoningEffort(modelID string) bool {
 	m := normalizeOpenAI(modelID)
 	if strings.HasPrefix(m, "gpt-5-chat") {
@@ -280,14 +282,14 @@ func gptGeneration(modelID string) (major, minor int, ok bool) {
 	case rest[0] != '.':
 		return 0, 0, false
 	}
-	min, mw := leadingInt(rest[1:])
+	mn, mw := leadingInt(rest[1:])
 	if mw == 0 || mw > 2 {
 		return 0, 0, false
 	}
 	if tail := rest[1+mw:]; tail != "" && tail[0] != '-' {
 		return 0, 0, false
 	}
-	return maj, min, true
+	return maj, mn, true
 }
 
 // atLeastGPT reports whether modelID names an OpenAI GPT model at or above
@@ -297,11 +299,11 @@ func gptGeneration(modelID string) (major, minor int, ok bool) {
 // automatically satisfies any gpt-5.x-or-later threshold without a code
 // change; ok=false (non-GPT-5+ ids) reports false.
 func atLeastGPT(modelID string, major, minor int) bool {
-	maj, min, ok := gptGeneration(modelID)
+	maj, mn, ok := gptGeneration(modelID)
 	if !ok {
 		return false
 	}
-	return maj > major || (maj == major && min >= minor)
+	return maj > major || (maj == major && mn >= minor)
 }
 
 // UsesThinkingLevel reports whether a Google Gemini model uses level-based

--- a/pkg/modelinfo/modelinfo_test.go
+++ b/pkg/modelinfo/modelinfo_test.go
@@ -9,6 +9,78 @@ import (
 	"github.com/docker/docker-agent/pkg/modelsdev"
 )
 
+// TestGPTGeneration exercises gptGeneration's parsing of "gpt-<major>[.<minor>]"
+// ids across generations (gpt-5.x and gpt-6+), including the syntactic
+// boundary rules it shares with gptFiveMinor: a malformed or date-shaped
+// digit run must not parse as a real minor version.
+func TestGPTGeneration(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		model     string
+		wantMajor int
+		wantMinor int
+		wantOK    bool
+	}{
+		{"gpt-6-astra", 6, 0, true},
+		{"gpt-6.1-foo", 6, 1, true},
+		{"gpt-6", 6, 0, true},
+		{"openai/gpt-6-astra", 6, 0, true},
+		{"gpt-5.6-terra", 5, 6, true},
+		{"gpt-5.6", 5, 6, true},
+		{"gpt-5", 5, 0, true},
+		{"GPT-6-ASTRA", 6, 0, true},
+		{"gpt-7.2", 7, 2, true},
+
+		// Malformed / date-shaped / pre-gpt-5.
+		{"gpt-5.20260709", 0, 0, false},
+		{"gpt-6foo", 0, 0, false},
+		{"gpt-4.1", 0, 0, false},
+		{"gpt-5.6.1", 0, 0, false},
+		{"gpt-5.", 0, 0, false},
+		{"o3", 0, 0, false},
+		{"", 0, 0, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.model, func(t *testing.T) {
+			t.Parallel()
+			major, minor, ok := gptGeneration(tc.model)
+			require.Equal(t, tc.wantOK, ok, "ok mismatch")
+			if tc.wantOK {
+				assert.Equal(t, tc.wantMajor, major, "major mismatch")
+				assert.Equal(t, tc.wantMinor, minor, "minor mismatch")
+			}
+		})
+	}
+}
+
+// TestAtLeastGPT exercises the "is this GPT id at or above generation X.Y"
+// helper that every gpt-5.6-or-later threshold in this package is built on.
+func TestAtLeastGPT(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		model        string
+		major, minor int
+		want         bool
+	}{
+		{"gpt-5.6-terra", 5, 6, true},
+		{"gpt-5.5", 5, 6, false},
+		{"gpt-6-astra", 5, 6, true},
+		{"gpt-6-astra", 6, 0, true},
+		{"gpt-7", 5, 6, true},
+		{"gpt-4.1", 5, 6, false},
+		{"claude-sonnet-4-5", 5, 6, false},
+		{"", 5, 6, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.model, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.want, atLeastGPT(tc.model, tc.major, tc.minor))
+		})
+	}
+}
+
 func TestSupportsResponsesAPI(t *testing.T) {
 	t.Parallel()
 
@@ -51,6 +123,12 @@ func TestSupportsResponsesAPI(t *testing.T) {
 		{"openai/gpt-5.6-sol", true},
 		{"OPENAI/gpt-4.1", true},
 		{"openai/gpt-4o", false},
+		// gpt-6 is the next generation of gpt-5.6, matched via gptGeneration
+		// rather than a per-id list.
+		{"gpt-6-astra", true},
+		{"gpt-6.1-foo", true},
+		{"gpt-6", true},
+		{"openai/gpt-6-astra", true},
 		// Unrelated provider-style prefixes must NOT be stripped: they are
 		// the model's actual catalog path, not an OpenAI wrapper.
 		{"ai/qwen3", false},
@@ -81,6 +159,10 @@ func TestSupportsDeferredTools(t *testing.T) {
 		{"openai", "gpt-5.6-luna", true},
 		{"openai", "gpt-5.6-sol", true},
 		{"openai", "gpt-5.6-terra", true},
+		// gpt-6 is the next generation of the gpt-5.6 trio.
+		{"openai", "gpt-6-astra", true},
+		{"openai", "gpt-6.1-foo", true},
+		{"chatgpt", "gpt-6-astra", true},
 		{"chatgpt", "gpt-5.4", true},
 		{"chatgpt", "gpt-5.4-pro", false},
 		{"openai", "gpt-5.3-codex-spark", false},
@@ -135,6 +217,12 @@ func TestUsesReasoningEffort(t *testing.T) {
 		{"gpt-5-mini", true},
 		{"gpt-5-turbo", true},
 		{"GPT-5", true},
+
+		// gpt-6 is the next generation of gpt-5, matched via gptGeneration.
+		{"gpt-6-astra", true},
+		{"gpt-6.1-foo", true},
+		{"gpt-6", true},
+		{"openai/gpt-6-astra", true},
 
 		// Provider-qualified ids (gateways/aggregators) match the bare name.
 		{"openai/gpt-5-nano", true},
@@ -198,6 +286,9 @@ func TestAlwaysReasons(t *testing.T) {
 		{"gpt-4o", false},
 		{"claude-sonnet-4-5", false},
 		{"", false},
+		// gpt-6 can also produce visible output without reasoning, same as
+		// gpt-5: it is not classified as "always reasons".
+		{"gpt-6-astra", false},
 		// Gateway "openai/" qualified ids resolve the same as the bare model.
 		{"openai/o3-mini", true},
 		{"openai/gpt-4o", false},

--- a/pkg/modelinfo/thinking_levels.go
+++ b/pkg/modelinfo/thinking_levels.go
@@ -237,11 +237,39 @@ func OpenAISupportsNoneEffort(modelID string) bool {
 
 // openAIDropsMinimalEffort reports whether an OpenAI model rejects reasoning
 // effort "minimal", unlike [OpenAISupportsNoneEffort] this holds for every
-// gpt-5.6-or-later generation including gpt-6 (verified live: gpt-6-astra
-// 400s on reasoning.effort "minimal" as well as "none") — only the "none"
+// gpt-5.6-or-later generation including gpt-6. Verified live against
+// api.openai.com (2026-09): gpt-5.6/-sol/-terra AND gpt-6-astra all 400 on
+// reasoning.effort "minimal" ("Supported values are: 'none', 'low',
+// 'medium', 'high', 'xhigh', and 'max'" for the gpt-5.6 line — "none" isn't
+// in gpt-6-astra's list, see [OpenAISupportsNoneEffort]) — only the "none"
 // value itself stops being honored past gpt-5.6.
 func openAIDropsMinimalEffort(modelID string) bool {
 	return atLeastGPT(modelID, 5, 6)
+}
+
+// OpenAIRejectsToolsWithReasoningEffort reports whether an OpenAI model
+// rejects an explicit `reasoning_effort` sent alongside function tools on the
+// Chat Completions endpoint (HTTP 400: "Function tools with reasoning_effort
+// are not supported for <model> in /v1/chat/completions. To use function
+// tools, use /v1/responses or set reasoning_effort to 'none'."). Verified
+// live against api.openai.com (2026-09):
+//
+//   - gpt-5, gpt-5.1, gpt-5.2, and the o-series still accept an explicit
+//     effort together with tools on this endpoint.
+//   - gpt-5.4, gpt-5.4-mini, and gpt-5.5 reject an *explicit* effort with
+//     tools, but accept the combination when the field is omitted entirely
+//     (the model falls back to its implicit default effort).
+//   - gpt-5.6 and every later generation (including gpt-6+, via
+//     [atLeastGPT]) reject tools+reasoning on this endpoint outright, even
+//     with the field omitted; only the Responses API supports the
+//     combination for them.
+//
+// The OpenAI client uses this to drop reasoning_effort rather than send a
+// value guaranteed to 400 when a Responses-capable model is forced onto
+// Chat Completions (an explicit api_type or custom-provider override) with
+// tools in the request.
+func OpenAIRejectsToolsWithReasoningEffort(modelID string) bool {
+	return atLeastGPT(modelID, 5, 4)
 }
 
 // OpenAISupportsExplicitPromptCache reports whether an OpenAI model accepts

--- a/pkg/modelinfo/thinking_levels.go
+++ b/pkg/modelinfo/thinking_levels.go
@@ -42,8 +42,10 @@ func thinkingLevelMap(provider, modelID string) effort.LevelMap {
 		for _, top := range openAITopEfforts(modelID) {
 			m[top] = true
 		}
-		if OpenAISupportsNoneEffort(modelID) {
-			// gpt-5.6 dropped minimal from its accepted efforts.
+		if openAIDropsMinimalEffort(modelID) {
+			// gpt-5.6+ (including every later generation, e.g. gpt-6) dropped
+			// minimal from its accepted efforts; offering it would make the
+			// TUI's Shift+Tab cycle land on a value the API 400s on.
 			m[effort.Minimal] = false
 		}
 		if len(m) == 0 {
@@ -200,42 +202,56 @@ func gptFiveMinor(modelID string) (minor int, ok bool) {
 // openAITopEfforts returns the explicit-only effort tiers (xhigh and/or max)
 // an OpenAI model accepts beyond the universal minimal/low/medium/high
 // ladder. OpenAI's ladder is cumulative (unlike Anthropic's independent
-// tiers), so a single minor-version parse suffices: gpt-5.2+ adds xhigh,
-// gpt-5.6+ (Sol/Terra/Luna) adds max on top. The o-series and gpt-5/5.0/5.1
+// tiers): gpt-5.2+ adds xhigh, gpt-5.6+ adds max on top — and gpt-6 and every
+// later generation inherit the full gpt-5.6+ ladder via [atLeastGPT], so a
+// new GPT generation needs no code change here. The o-series and gpt-5/5.0/5.1
 // top out at high.
 func openAITopEfforts(modelID string) []effort.Level {
-	minor, ok := gptFiveMinor(modelID)
 	switch {
-	case !ok || minor < 2:
-		return nil
-	case minor >= 6:
+	case atLeastGPT(modelID, 5, 6):
 		return []effort.Level{effort.XHigh, effort.Max}
-	default:
+	case atLeastGPT(modelID, 5, 2):
 		return []effort.Level{effort.XHigh}
+	default:
+		return nil
 	}
 }
 
 // OpenAISupportsNoneEffort reports whether an OpenAI model accepts reasoning
 // effort "none" as a real, honored value rather than a config-level "turn
 // thinking off" sentinel. gpt-5.6 (Sol/Terra/Luna) is the first OpenAI
-// family to do so; it is also the first to drop "minimal" from its accepted
-// efforts, so callers use this predicate to gate both changes. Exported: the
-// defaults pipeline (pkg/model/provider) and the OpenAI client need the same
-// gate to decide whether "none" survives normalization and is sent on the
-// wire.
+// family to do so. Exported: the defaults pipeline (pkg/model/provider) and
+// the OpenAI client need the same gate to decide whether "none" survives
+// normalization and is sent on the wire.
+//
+// Deliberately scoped to the gpt-5.x line via [gptFiveMinor] rather than
+// [atLeastGPT]: gpt-6 (verified live against api.openai.com) rejects
+// reasoning.effort "none" with a 400 ("Supported values are: 'low',
+// 'medium', 'high', 'xhigh', and 'max'"), so this predicate must NOT widen
+// to "gpt-5.6 or later" the way [openAIDropsMinimalEffort] and
+// [openAITopEfforts] do — those two effects diverged when gpt-6 shipped.
 func OpenAISupportsNoneEffort(modelID string) bool {
 	minor, ok := gptFiveMinor(modelID)
 	return ok && minor >= 6
 }
 
+// openAIDropsMinimalEffort reports whether an OpenAI model rejects reasoning
+// effort "minimal", unlike [OpenAISupportsNoneEffort] this holds for every
+// gpt-5.6-or-later generation including gpt-6 (verified live: gpt-6-astra
+// 400s on reasoning.effort "minimal" as well as "none") — only the "none"
+// value itself stops being honored past gpt-5.6.
+func openAIDropsMinimalEffort(modelID string) bool {
+	return atLeastGPT(modelID, 5, 6)
+}
+
 // OpenAISupportsExplicitPromptCache reports whether an OpenAI model accepts
 // explicit prompt-cache breakpoints (`prompt_cache_breakpoint` content
 // markers). gpt-5.6 (Sol/Terra/Luna) is the first OpenAI family to support
-// them; older models reject the field with HTTP 400, so the OpenAI client
-// gates on this before putting breakpoints on the wire.
+// them; gpt-6 and every later generation inherit the capability via
+// [atLeastGPT]. Older models reject the field with HTTP 400, so the OpenAI
+// client gates on this before putting breakpoints on the wire.
 func OpenAISupportsExplicitPromptCache(modelID string) bool {
-	minor, ok := gptFiveMinor(modelID)
-	return ok && minor >= 6
+	return atLeastGPT(modelID, 5, 6)
 }
 
 // leadingInt parses the run of decimal digits at the start of s, returning

--- a/pkg/modelinfo/thinking_levels_test.go
+++ b/pkg/modelinfo/thinking_levels_test.go
@@ -174,6 +174,12 @@ func TestSupportedThinkingLevels(t *testing.T) {
 			want:     []effort.Level{effort.None, effort.Low, effort.Medium, effort.High, effort.XHigh, effort.Max},
 		},
 		{
+			name:     "gpt-6-astra gets the full gpt-5.6+ ladder (xhigh, max, dropped minimal) even though it rejects wire 'none'",
+			provider: "openai",
+			modelID:  "gpt-6-astra",
+			want:     []effort.Level{effort.None, effort.Low, effort.Medium, effort.High, effort.XHigh, effort.Max},
+		},
+		{
 			name:     "chatgpt provider maps to the openai scale",
 			provider: "chatgpt",
 			modelID:  "gpt-5.6",
@@ -255,6 +261,9 @@ func TestOpenAITopEfforts(t *testing.T) {
 		{"gpt-5.6-luna", []effort.Level{effort.XHigh, effort.Max}},
 		{"gpt-5.7", []effort.Level{effort.XHigh, effort.Max}},
 		{"GPT-5.6-SOL", []effort.Level{effort.XHigh, effort.Max}},
+		// gpt-6 inherits the full gpt-5.6+ ladder via atLeastGPT.
+		{"gpt-6-astra", []effort.Level{effort.XHigh, effort.Max}},
+		{"gpt-6", []effort.Level{effort.XHigh, effort.Max}},
 		// Valid hyphen-delimited snapshot form: still a real gpt-5.6 minor.
 		{"gpt-5.6-2026-07-09", []effort.Level{effort.XHigh, effort.Max}},
 		// Vercel-style "openai/" qualified id: normalize strips the qualifier.
@@ -374,6 +383,54 @@ func TestOpenAISupportsNoneEffort(t *testing.T) {
 	}
 }
 
+// TestOpenAISupportsNoneEffort_GPT6Excluded is the regression test for the
+// divergence documented on [OpenAISupportsNoneEffort]: gpt-6 accepts the
+// full gpt-5.6+ effort ladder except "none" itself (verified live against
+// api.openai.com), so this predicate must stay gpt-5.x-scoped even though
+// [openAIDropsMinimalEffort] and [openAITopEfforts] widen to "gpt-5.6 or
+// later" including gpt-6+.
+func TestOpenAISupportsNoneEffort_GPT6Excluded(t *testing.T) {
+	t.Parallel()
+
+	for _, modelID := range []string{"gpt-6-astra", "gpt-6", "gpt-6.1-foo", "gpt-7"} {
+		t.Run(modelID, func(t *testing.T) {
+			t.Parallel()
+			assert.False(t, OpenAISupportsNoneEffort(modelID))
+		})
+	}
+}
+
+// TestOpenAIDropsMinimalEffort exercises the gpt-5.6-or-later gate that,
+// unlike [OpenAISupportsNoneEffort], DOES widen to gpt-6 and later
+// generations: they all reject reasoning.effort "minimal" even though only
+// the gpt-5.x line also rejects "none".
+func TestOpenAIDropsMinimalEffort(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		modelID string
+		want    bool
+	}{
+		{"gpt-5", false},
+		{"gpt-5.2", false},
+		{"gpt-5.5", false},
+		{"gpt-5.6", true},
+		{"gpt-5.6-sol", true},
+		{"gpt-6-astra", true},
+		{"gpt-6", true},
+		{"gpt-7", true},
+		{"o3", false},
+		{"claude-opus-4-7", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.modelID, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, openAIDropsMinimalEffort(tt.modelID))
+		})
+	}
+}
+
 func TestOpenAISupportsExplicitPromptCache(t *testing.T) {
 	t.Parallel()
 
@@ -398,6 +455,9 @@ func TestOpenAISupportsExplicitPromptCache(t *testing.T) {
 		// Malformed/date-shaped minors must not be treated as gpt-5.6+.
 		{"gpt-5.6foo", false},
 		{"gpt-5.20260709", false},
+		// gpt-6 inherits explicit prompt-cache support via atLeastGPT.
+		{"gpt-6-astra", true},
+		{"gpt-6", true},
 	}
 
 	for _, tt := range tests {

--- a/pkg/modelinfo/thinking_levels_test.go
+++ b/pkg/modelinfo/thinking_levels_test.go
@@ -468,6 +468,43 @@ func TestOpenAISupportsExplicitPromptCache(t *testing.T) {
 	}
 }
 
+// TestOpenAIRejectsToolsWithReasoningEffort exercises the minor-version
+// boundary (verified live against api.openai.com) where OpenAI's Chat
+// Completions endpoint starts rejecting an explicit reasoning_effort
+// alongside function tools: below gpt-5.4 the combination works; gpt-5.4
+// and gpt-5.5 reject only an explicit effort; gpt-5.6 and every later
+// generation (including gpt-6+) reject the combination outright.
+func TestOpenAIRejectsToolsWithReasoningEffort(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		modelID string
+		want    bool
+	}{
+		{"gpt-5", false},
+		{"gpt-5.1-codex", false},
+		{"gpt-5.2", false},
+		{"o3-mini", false},
+		{"claude-opus-4-7", false},
+		{"gpt-5.4", true},
+		{"gpt-5.4-mini", true},
+		{"gpt-5.5", true},
+		{"gpt-5.6", true},
+		{"gpt-5.6-terra", true},
+		{"gpt-6-astra", true},
+		{"gpt-6", true},
+		{"gpt-7", true},
+		{"openai/gpt-5.4", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.modelID, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, OpenAIRejectsToolsWithReasoningEffort(tt.modelID))
+		})
+	}
+}
+
 func TestAnthropicTopEfforts(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
> 🤖 **Automated implementer agent** — *this comment was posted by the implementer bot from Docker Agentic Platform, not by a human developer*

Fixes #4162.

`gpt-6-astra` (and any future `gpt-6*` id) matched none of the OpenAI capability
checks in `pkg/modelinfo`, so it stayed on Chat Completions (400s on tools +
`reasoning_effort`, and on legacy `max_tokens`) and `thinking_budget` was
silently ignored.

## Fix

- Added `gptGeneration`/`atLeastGPT`, a generation-agnostic
  `gpt-<major>[.<minor>]` parser, and extended every gpt-5.6 threshold
  (`SupportsResponsesAPI`, `UsesReasoningEffort`, `SupportsDeferredTools`,
  `openAITopEfforts`, `OpenAISupportsExplicitPromptCache`) so gpt-6+ inherits
  gpt-5.6's capabilities by naming convention rather than a per-id allow-list.
  No new config surface.
- Chat Completions: when tools are present and the model rejects an explicit
  `reasoning_effort` alongside them (new `OpenAIRejectsToolsWithReasoningEffort`,
  gpt-5.4+), drop the field instead of sending a value guaranteed to 400, and
  warn once.
- Warn once per client when `thinking_budget` is configured on a model that
  doesn't accept a reasoning-effort parameter at all (previously silent).

## Deviations from the plan (all live-verified against api.openai.com, 2026-09-04)

- **`OpenAISupportsNoneEffort` stays gpt-5.x-only, not widened to gpt-6.**
  `gpt-6-astra` 400s on `reasoning.effort: none` ("Supported values are:
  'low', 'medium', 'high', 'xhigh', and 'max'"). A separate
  `openAIDropsMinimalEffort` gate (gpt-5.6+, including gpt-6+) independently
  drops `minimal` from the offered effort ladder — verified directly for
  **both** generations, not inferred: `gpt-5.6`/`-sol`/`-terra` and
  `gpt-6-astra` all 400 on `reasoning.effort: minimal` too.
- **Chat Completions + function tools + `reasoning_effort` breaks starting at
  gpt-5.4, not just gpt-5.6+**, and the failure mode differs by generation:
  - `gpt-5`, `gpt-5.1`, `gpt-5.2`: tools + an explicit effort work fine.
  - `gpt-5.4`, `gpt-5.4-mini`, `gpt-5.5`: reject an *explicit* effort with
    tools (400: "Function tools with reasoning_effort are not supported...
    use /v1/responses or set reasoning_effort to 'none'"), but succeed when
    the field is *omitted* entirely (implicit default effort). This PR drops
    the field for these generations, fixing them for the forced-Chat-Completions
    case.
  - `gpt-5.6`, `gpt-5.6-terra`/`-sol`/`-luna`, `gpt-6-astra`: reject tools +
    reasoning outright on Chat Completions, **even with the field omitted** —
    there is no request shape that works; only `/v1/responses` supports it.
    Dropping the field still avoids sending a value the caller can't see is
    the cause, and the WARN points at `api_type: openai_responses`, but the
    request still 400s with OpenAI's own descriptive error for these models —
    verified in the e2e evidence below.
- `gpt-6-astra` is absent from the live models.dev catalog (`api.json`) as of
  today, so no models.dev snapshot entry is added. **Until models.dev adds
  it**, `gpt-6-astra`'s context window falls back to the runtime default
  (affects compaction thresholds) — set `provider_opts.context_size: <n>` on
  the model explicitly in the meantime, the same workaround already used for
  gpt-5.6-luna.

## Evidence (curl probes against api.openai.com via the platform gateway)

| Request | Result |
|---|---|
| Responses `gpt-6-astra` + `effort: none` | 400 (not supported) |
| Responses `gpt-6-astra` + `effort: minimal` | 400 (not supported) |
| Responses `gpt-5.6`/`-sol`/`-terra` + `effort: minimal` | 400 (not supported) — confirms `openAIDropsMinimalEffort`'s gpt-5.6+ scope |
| Responses `gpt-6-astra` + `effort: max`/`xhigh` + tools | 200, real tool call |
| Chat Completions `gpt-6-astra` + `max_tokens` | 400 (use `max_completion_tokens`) |
| Chat Completions `gpt-5`/`gpt-5.2`/`o3-mini` + tools + explicit effort | 200 |
| Chat Completions `gpt-5.4`/`gpt-5.4-mini`/`gpt-5.5` + tools + explicit effort | 400; **omitting the field** → 200 |
| Chat Completions `gpt-5.6`/`-terra`/`gpt-6-astra` + tools, effort omitted | 400 regardless |
| Live models.dev `api.json` | no `gpt-6*` entry |

### Manual e2e (`docker-agent run --exec --debug`, built from this branch)

1. `openai/gpt-6-astra`, `max_tokens: 64000`, `thinking_budget: high`, **no
   `api_type`/`provider_opts.api_type`** (only transport headers to reach the
   gateway), one shell tool:
   ```
   Auto-selecting Responses API provider=openai model=gpt-6-astra
   OpenAI responses request using thinking_budget reasoning_effort=high
   request={"max_output_tokens":64000,...,"reasoning":{"effort":"high","summary":"detailed"},"tools":[{"name":"shell",...}]}
   ```
   → the model called `shell(cmd: "date")`, got the result, and replied
   `astra-ok`.
2. Same config with `provider_opts.api_type: openai_chatcompletions` (forced):
   ```
   Using Chat Completions API api_type=openai_chatcompletions model=gpt-6-astra
   WARN OpenAI: dropping reasoning_effort for a tools request forced onto Chat Completions; use api_type: openai_responses for tool calling on this model model=gpt-6-astra
   request={"model":"gpt-6-astra",...} // no reasoning_effort key
   ```
   → `reasoning_effort` is confirmed absent from the wire request, but the
   run still fails with OpenAI's own 400 ("Function tools with
   reasoning_effort are not supported for gpt-6-astra in
   /v1/chat/completions... use /v1/responses"), matching the documented
   limitation above (no combination works for gpt-6-astra on this endpoint).
3. `openai/gpt-4o` (no reasoning support) + `thinking_budget: high`:
   ```
   WARN OpenAI: thinking_budget is configured but this model does not support a reasoning effort parameter; the setting has no effect model=gpt-4o
   ```

## Testing

- `go build ./...`
- `go test ./...` (all pass except `pkg/rag/treesitter`, which fails in this
  sandbox with `CGO_ENABLED=0`/no `gcc` — confirmed pre-existing on `main`,
  unrelated to this change)
- `go vet ./...`
- `golangci-lint run` (v2.13.1, the version pinned in CI) — 0 issues
- `go run ./lint .` — no offenses
- `go mod tidy --diff` — empty
- New/extended table tests in `pkg/modelinfo` and new request-capture tests
  in `pkg/model/provider/openai` for the tools-drop and ignored-budget
  warnings (including the exact gpt-5.4 boundary and a below-boundary
  control group).
