### PR TITLE
feat(share): accept inline key or file:// path for --key

### DIFF
--- a/cmd/root/pull.go
+++ b/cmd/root/pull.go
@@ -10,14 +10,13 @@ import (
 
 	"github.com/docker/docker-agent/pkg/cli"
 	"github.com/docker/docker-agent/pkg/content"
-	"github.com/docker/docker-agent/pkg/protect"
 	"github.com/docker/docker-agent/pkg/remote"
 	"github.com/docker/docker-agent/pkg/telemetry"
 )
 
 type pullFlags struct {
-	force   bool
-	keyFile string
+	force bool
+	key   string
 }
 
 func newPullCmd() *cobra.Command {
@@ -31,15 +30,16 @@ func newPullCmd() *cobra.Command {
 With --key, the pulled agent YAML is verified against the protection recorded
 by 'share push --key': a signature is checked with the same secret or the
 matching public key; an encrypted copy (push --encrypt) is decrypted with the
-same secret or the matching private key and compared to the YAML. With an
-asymmetric key the artifact must carry a signature. The pull fails if the
-artifact is unprotected or the check does not pass.`,
+same secret or the matching private key and compared to the YAML. The key is
+given inline, or as a path prefixed with file:// (e.g. --key file://~/.ssh/id_ed25519.pub).
+With an asymmetric key the artifact must carry a signature. The pull fails if
+the artifact is unprotected or the check does not pass.`,
 		Args: cobra.ExactArgs(1),
 		RunE: flags.runPullCommand,
 	}
 
 	cmd.PersistentFlags().BoolVar(&flags.force, "force", false, "Force pull even if the configuration already exists locally")
-	cmd.Flags().StringVar(&flags.keyFile, "key", "", "Path to a key file (PEM/OpenSSH) or symmetric secret used to verify the agent (or set "+envEncryptKey+" with the secret inline)")
+	cmd.Flags().StringVar(&flags.key, "key", "", "Key used to verify the agent: PEM/OpenSSH key or symmetric secret, inline or as file://<path> (or set "+envEncryptKey+")")
 
 	return cmd
 }
@@ -55,22 +55,14 @@ func (f *pullFlags) runPullCommand(cmd *cobra.Command, args []string) (commandEr
 	registryRef := args[0]
 	slog.DebugContext(ctx, "Starting pull", "registry_ref", registryRef)
 
-	var key *protect.Key
-	if f.keyFile != "" {
-		var err error
-		if key, err = protect.LoadKey(f.keyFile); err != nil {
-			return err
-		}
-	} else if secret := os.Getenv(envEncryptKey); secret != "" {
-		var err error
-		if key, err = protect.ParseKey([]byte(secret)); err != nil {
-			return err
-		}
+	key, err := resolveKey(f.key)
+	if err != nil {
+		return err
 	}
 
 	out.Println("Pulling agent", registryRef)
 
-	_, err := remote.Pull(ctx, registryRef, f.force)
+	_, err = remote.Pull(ctx, registryRef, f.force)
 	if err != nil {
 		return fmt.Errorf("failed to pull artifact: %w", err)
 	}

--- a/cmd/root/push.go
+++ b/cmd/root/push.go
@@ -17,7 +17,7 @@ import (
 )
 
 type pushFlags struct {
-	keyFile string
+	key     string
 	encrypt bool
 }
 
@@ -30,10 +30,11 @@ func newPushCmd() *cobra.Command {
 		Long: `Push an agent configuration file to an OCI registry.
 
 With --key, the agent YAML is protected and the proof is stored as manifest
-annotations; the YAML itself is always pushed in clear. The key kind is
-detected from the file: PEM or OpenSSH keys (Ed25519, ECDSA, RSA) are
-asymmetric, anything else is a raw symmetric secret of at least 16 bytes
-(e.g. 'openssl rand -hex 32 > agent.key') that must not contain PEM or
+annotations; the YAML itself is always pushed in clear. The key is given
+inline, or as a path prefixed with file:// (e.g. --key file://~/.ssh/id_ed25519).
+The key kind is detected from its contents: PEM or OpenSSH keys (Ed25519,
+ECDSA, RSA) are asymmetric, anything else is a raw symmetric secret of at
+least 16 bytes (e.g. 'openssl rand -hex 32') that must not contain PEM or
 OpenSSH key markers.
 
   Default (sign):  a signature (private key) or MAC (secret) is recorded.
@@ -49,33 +50,32 @@ OpenSSH key markers.
 		RunE: flags.runPushCommand,
 	}
 
-	cmd.Flags().StringVar(&flags.keyFile, "key", "", "Path to a key file (PEM/OpenSSH) or symmetric secret used to protect the agent (or set "+envEncryptKey+" with the secret inline)")
+	cmd.Flags().StringVar(&flags.key, "key", "", "Key used to protect the agent: PEM/OpenSSH key or symmetric secret, inline or as file://<path> (or set "+envEncryptKey+")")
 	cmd.Flags().BoolVar(&flags.encrypt, "encrypt", false, "Also embed an encrypted copy of the agent in the annotations (requires --key)")
 
 	return cmd
 }
 
-// envEncryptKey is an alternative to --key for callers that prefer not to write
-// the secret to a file: its value is used as the symmetric secret directly
-// (never a file path). The --key flag takes precedence when both are set.
+// envEncryptKey is an alternative to --key. Its value is resolved the same way
+// (inline key, or file://<path>). The --key flag takes precedence when both
+// are set.
 const envEncryptKey = "DOCKER_AGENT_ENCRYPT_KEY"
 
-// resolveKey loads the protection key from the --key flag (a file path) or,
-// when the flag is empty, from the [envEncryptKey] environment variable (an
-// inline symmetric secret). It returns a nil key and nil error when neither is
-// set, so callers can treat "no key" as "no protection".
-func (f *pushFlags) resolveKey() (*protect.Key, error) {
-	if f.keyFile != "" {
-		return protect.LoadKey(f.keyFile)
+// resolveKey loads the protection key from the --key value or, when empty,
+// from [envEncryptKey]. Returns a nil key and nil error when neither is set,
+// so callers can treat "no key" as "no protection".
+func resolveKey(flag string) (*protect.Key, error) {
+	if flag == "" {
+		flag = os.Getenv(envEncryptKey)
 	}
-	if secret := os.Getenv(envEncryptKey); secret != "" {
-		return protect.ParseKey([]byte(secret))
+	if flag == "" {
+		return nil, nil
 	}
-	return nil, nil
+	return protect.ResolveKey(flag)
 }
 
 func (f *pushFlags) protection() (oci.PackageOption, error) {
-	key, err := f.resolveKey()
+	key, err := resolveKey(f.key)
 	if err != nil {
 		return nil, err
 	}
@@ -90,7 +90,8 @@ func (f *pushFlags) protection() (oci.PackageOption, error) {
 		mode = protect.ModeEncrypt
 	}
 	if err := key.Supports(mode); err != nil {
-		return nil, fmt.Errorf("%s: %w", f.keyFile, err)
+		// Never echo the key value: it may be an inline secret.
+		return nil, fmt.Errorf("%s: %w", key.Describe(), err)
 	}
 	return oci.WithProtection(key, mode), nil
 }

--- a/cmd/root/push_test.go
+++ b/cmd/root/push_test.go
@@ -19,7 +19,7 @@ func writeKey(t *testing.T, name string, data []byte) string {
 	t.Helper()
 	path := filepath.Join(t.TempDir(), name)
 	require.NoError(t, os.WriteFile(path, data, 0o600))
-	return path
+	return protect.FilePrefix + path
 }
 
 func TestPushFlags_Protection(t *testing.T) {
@@ -34,7 +34,8 @@ func TestPushFlags_Protection(t *testing.T) {
 
 	secret := writeKey(t, "secret", []byte("a symmetric secret long enough\n"))
 	short := writeKey(t, "short", []byte("short"))
-	edPrivFile := writeKey(t, "ed25519", pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: privDER}))
+	edPrivPEM := pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: privDER})
+	edPrivFile := writeKey(t, "ed25519", edPrivPEM)
 	edPubFile := writeKey(t, "ed25519.pub", pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: pubDER}))
 
 	tests := []struct {
@@ -46,13 +47,16 @@ func TestPushFlags_Protection(t *testing.T) {
 	}{
 		{name: "no key", flags: pushFlags{}},
 		{name: "encrypt without key", flags: pushFlags{encrypt: true}, errMsg: "--encrypt requires --key"},
-		{name: "missing key file", flags: pushFlags{keyFile: filepath.Join(t.TempDir(), "nope")}, errMsg: "reading key file"},
-		{name: "short secret", flags: pushFlags{keyFile: short}, wantErr: protect.ErrSecretTooShort},
-		{name: "secret sign", flags: pushFlags{keyFile: secret}, wantOpt: true},
-		{name: "secret encrypt", flags: pushFlags{keyFile: secret, encrypt: true}, wantOpt: true},
-		{name: "ed25519 sign", flags: pushFlags{keyFile: edPrivFile}, wantOpt: true},
-		{name: "ed25519 cannot encrypt", flags: pushFlags{keyFile: edPrivFile, encrypt: true}, wantErr: protect.ErrCannotEncrypt},
-		{name: "public key cannot sign", flags: pushFlags{keyFile: edPubFile}, wantErr: protect.ErrCannotSign},
+		{name: "missing key file", flags: pushFlags{key: protect.FilePrefix + filepath.Join(t.TempDir(), "nope")}, errMsg: "reading key file"},
+		{name: "short secret", flags: pushFlags{key: short}, wantErr: protect.ErrSecretTooShort},
+		{name: "secret sign", flags: pushFlags{key: secret}, wantOpt: true},
+		{name: "secret encrypt", flags: pushFlags{key: secret, encrypt: true}, wantOpt: true},
+		{name: "inline secret", flags: pushFlags{key: "an inline secret long enough"}, wantOpt: true},
+		{name: "inline short secret", flags: pushFlags{key: "short"}, wantErr: protect.ErrSecretTooShort},
+		{name: "inline pem key", flags: pushFlags{key: string(edPrivPEM)}, wantOpt: true},
+		{name: "ed25519 sign", flags: pushFlags{key: edPrivFile}, wantOpt: true},
+		{name: "ed25519 cannot encrypt", flags: pushFlags{key: edPrivFile, encrypt: true}, wantErr: protect.ErrCannotEncrypt},
+		{name: "public key cannot sign", flags: pushFlags{key: edPubFile}, wantErr: protect.ErrCannotSign},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/cmd/root/push_test.go
+++ b/cmd/root/push_test.go
@@ -22,6 +22,46 @@ func writeKey(t *testing.T, name string, data []byte) string {
 	return protect.FilePrefix + path
 }
 
+func TestResolveKey_Env(t *testing.T) {
+	secretFile := writeKey(t, "secret", []byte("a symmetric secret long enough"))
+
+	t.Run("unset", func(t *testing.T) {
+		t.Setenv(envEncryptKey, "")
+		key, err := resolveKey("")
+		require.NoError(t, err)
+		assert.Nil(t, key)
+	})
+
+	t.Run("inline env", func(t *testing.T) {
+		t.Setenv(envEncryptKey, "an env secret that is long enough")
+		key, err := resolveKey("")
+		require.NoError(t, err)
+		assert.True(t, key.Symmetric())
+	})
+
+	t.Run("file env", func(t *testing.T) {
+		t.Setenv(envEncryptKey, secretFile)
+		key, err := resolveKey("")
+		require.NoError(t, err)
+		assert.True(t, key.Symmetric())
+	})
+
+	t.Run("flag wins over env", func(t *testing.T) {
+		t.Setenv(envEncryptKey, "an env secret that is long enough")
+		fromFlag, err := resolveKey("a flag secret that is long enough")
+		require.NoError(t, err)
+		fromEnv, err := protect.ParseKey([]byte("an env secret that is long enough"))
+		require.NoError(t, err)
+		assert.NotEqual(t, fromEnv.Identity(), fromFlag.Identity())
+	})
+
+	t.Run("invalid env", func(t *testing.T) {
+		t.Setenv(envEncryptKey, "short")
+		_, err := resolveKey("")
+		require.ErrorIs(t, err, protect.ErrSecretTooShort)
+	})
+}
+
 func TestPushFlags_Protection(t *testing.T) {
 	t.Parallel()
 

--- a/docs/concepts/distribution/index.md
+++ b/docs/concepts/distribution/index.md
@@ -39,31 +39,36 @@ $ docker agent share pull myorg/agent:tag
 
 ## Signing and Encrypting Agents
 
-`share push --key <file>` protects the agent so that pullers holding the matching key can check it was published by you and has not been altered. The YAML is **always pushed in clear**; only the proof goes into the OCI manifest annotations. `share pull --key <file>` performs the check and refuses the artifact if it fails.
+`share push --key <key>` protects the agent so that pullers holding the matching key can check it was published by you and has not been altered. The YAML is **always pushed in clear**; only the proof goes into the OCI manifest annotations. `share pull --key <key>` performs the check and refuses the artifact if it fails.
+
+The key is given inline, or as a path prefixed with `file://`. `DOCKER_AGENT_ENCRYPT_KEY` accepts the same forms and is used when `--key` is not set.
 
 ```bash
 # Asymmetric: sign with a private key, verify with the public key
-$ docker agent share push ./agent.yaml myorg/agent:v1 --key ~/.ssh/id_ed25519
-$ docker agent share pull myorg/agent:v1 --key ~/.ssh/id_ed25519.pub
+$ docker agent share push ./agent.yaml myorg/agent:v1 --key file://~/.ssh/id_ed25519
+$ docker agent share pull myorg/agent:v1 --key file://~/.ssh/id_ed25519.pub
 
 # Symmetric: same secret on both sides
 $ openssl rand -hex 32 > agent.key
-$ docker agent share push ./agent.yaml myorg/agent:v1 --key agent.key
-$ docker agent share pull myorg/agent:v1 --key agent.key
+$ docker agent share push ./agent.yaml myorg/agent:v1 --key file://agent.key
+$ docker agent share pull myorg/agent:v1 --key file://agent.key
+
+# Symmetric, inline
+$ docker agent share push ./agent.yaml myorg/agent:v1 --key "$(openssl rand -hex 32)"
 ```
 
 ### Key formats
 
-The key kind is detected from the file contents:
+The key kind is detected from its contents:
 
-| File contents                                              | Kind       | Sign | Verify | `--encrypt` |
+| Key contents                                               | Kind       | Sign | Verify | `--encrypt` |
 | ---------------------------------------------------------- | ---------- | ---- | ------ | ----------- |
 | PEM / OpenSSH **Ed25519** private key                      | asymmetric | ✓    | ✓      | ✗           |
 | PEM / OpenSSH **ECDSA** or **RSA** private key             | asymmetric | ✓    | ✓      | ✓           |
 | PEM / OpenSSH public key (`.pub`)                          | asymmetric | ✗    | ✓      | ✗           |
 | Anything else: a raw **secret** of at least 16 bytes       | symmetric  | ✓    | ✓      | ✓           |
 
-Passphrase-protected keys are not supported. Anything containing a PEM boundary (`-----BEGIN`) or an OpenSSH key-type marker (`ssh-`, `ecdsa-sha2-`, `sk-ssh-`, `sk-ecdsa-`) anywhere is treated as a key file and rejected if it does not parse — a broken public key is never silently used as a secret. Symmetric secrets can be guessed offline against the public YAML, so use random material (`openssl rand -hex 32`), not a password.
+Passphrase-protected keys are not supported. Anything containing a PEM boundary (`-----BEGIN`) or an OpenSSH key-type marker (`ssh-`, `ecdsa-sha2-`, `sk-ssh-`, `sk-ecdsa-`) anywhere is treated as a key and rejected if it does not parse — a broken public key is never silently used as a secret. Symmetric secrets can be guessed offline against the public YAML, so use random material (`openssl rand -hex 32`), not a password.
 
 ### Modes
 

--- a/docs/concepts/distribution/index.md
+++ b/docs/concepts/distribution/index.md
@@ -41,7 +41,7 @@ $ docker agent share pull myorg/agent:tag
 
 `share push --key <key>` protects the agent so that pullers holding the matching key can check it was published by you and has not been altered. The YAML is **always pushed in clear**; only the proof goes into the OCI manifest annotations. `share pull --key <key>` performs the check and refuses the artifact if it fails.
 
-The key is given inline, or as a path prefixed with `file://`. `DOCKER_AGENT_ENCRYPT_KEY` accepts the same forms and is used when `--key` is not set.
+The key is given inline, or as a path prefixed with `file://` (a plain prefix, not a URL: `file://./agent.key`, `file:///etc/agent.key`, `file://~/.ssh/id_ed25519` and `file://C:\keys\agent.key` all work; there is no percent-decoding). Inline material that itself starts with `file://` cannot be passed inline — use the file form instead. `DOCKER_AGENT_ENCRYPT_KEY` accepts the same forms and is used when `--key` is not set.
 
 ```bash
 # Asymmetric: sign with a private key, verify with the public key

--- a/docs/features/cli/index.md
+++ b/docs/features/cli/index.md
@@ -452,15 +452,15 @@ $ docker agent share pull docker.io/username/my-agent:latest
 $ docker agent share pull docker.io/username/my-agent:latest --force
 
 # Sign on push, verify on pull
-$ docker agent share push ./agent.yaml docker.io/username/my-agent:latest --key ~/.ssh/id_ed25519
-$ docker agent share pull docker.io/username/my-agent:latest --key ~/.ssh/id_ed25519.pub
+$ docker agent share push ./agent.yaml docker.io/username/my-agent:latest --key file://~/.ssh/id_ed25519
+$ docker agent share pull docker.io/username/my-agent:latest --key file://~/.ssh/id_ed25519.pub
 ```
 
-| Flag        | Applies to | Description                                                                          |
-| ----------- | ---------- | ------------------------------------------------------------------------------------ |
-| `--force`   | `pull`     | Force pull even if the configuration already exists locally                          |
-| `--key`     | both       | Key file used to sign/encrypt the agent on push, or verify it on pull                |
-| `--encrypt` | `push`     | Also embed an encrypted copy of the agent in the manifest annotations (needs `--key`) |
+| Flag        | Applies to | Description                                                                                       |
+| ----------- | ---------- | ------------------------------------------------------------------------------------------------- |
+| `--force`   | `pull`     | Force pull even if the configuration already exists locally                                       |
+| `--key`     | both       | Key (inline, or `file://<path>`) used to sign/encrypt the agent on push, or verify it on pull     |
+| `--encrypt` | `push`     | Also embed an encrypted copy of the agent in the manifest annotations (needs `--key`)             |
 
 See [Signing and encrypting agents](../../concepts/distribution/index.md#signing-and-encrypting-agents) for key formats and the security model.
 

--- a/pkg/protect/key.go
+++ b/pkg/protect/key.go
@@ -42,6 +42,8 @@ import (
 	"strings"
 
 	"golang.org/x/crypto/ssh"
+
+	pathx "github.com/docker/docker-agent/pkg/path"
 )
 
 // MinSecretLen is the minimum accepted length of a symmetric secret. The
@@ -59,6 +61,23 @@ type Key struct {
 	priv crypto.PrivateKey
 	// pub is always set for asymmetric keys.
 	pub crypto.PublicKey
+}
+
+// FilePrefix marks a ResolveKey value as a path to a key file.
+const FilePrefix = "file://"
+
+// ResolveKey parses a key given on the command line: a value prefixed with
+// FilePrefix names a key file (a leading ~ is expanded, since shells do not
+// expand it mid-word), anything else is the key material itself.
+func ResolveKey(value string) (*Key, error) {
+	if path, ok := strings.CutPrefix(value, FilePrefix); ok {
+		expanded, err := pathx.ExpandHomeDir(path)
+		if err != nil {
+			return nil, fmt.Errorf("resolving key file %s: %w", path, err)
+		}
+		return LoadKey(expanded)
+	}
+	return ParseKey([]byte(value))
 }
 
 // LoadKey reads and parses a key file. See ParseKey.

--- a/pkg/protect/key.go
+++ b/pkg/protect/key.go
@@ -63,7 +63,8 @@ type Key struct {
 	pub crypto.PublicKey
 }
 
-// FilePrefix marks a ResolveKey value as a path to a key file.
+// FilePrefix marks a ResolveKey value as a path to a key file. It is a
+// literal prefix, not a URL scheme: no percent-decoding or authority parsing.
 const FilePrefix = "file://"
 
 // ResolveKey parses a key given on the command line: a value prefixed with

--- a/pkg/protect/protect_test.go
+++ b/pkg/protect/protect_test.go
@@ -547,3 +547,27 @@ func TestLoadKey(t *testing.T) {
 	_, err = LoadKey(filepath.Join(t.TempDir(), "missing"))
 	require.Error(t, err)
 }
+
+func TestResolveKey(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	path := filepath.Join(home, "key")
+	require.NoError(t, os.WriteFile(path, []byte(secret), 0o600))
+
+	fromFile, err := ResolveKey(FilePrefix + path)
+	require.NoError(t, err)
+	inline, err := ResolveKey(secret)
+	require.NoError(t, err)
+	assert.Equal(t, fromFile.Identity(), inline.Identity())
+
+	fromHome, err := ResolveKey(FilePrefix + "~/key")
+	require.NoError(t, err)
+	assert.Equal(t, fromFile.Identity(), fromHome.Identity())
+
+	// A bare path is key material, not a file reference.
+	_, err = ResolveKey(path)
+	require.NoError(t, err)
+
+	_, err = ResolveKey(FilePrefix + filepath.Join(t.TempDir(), "missing"))
+	require.ErrorContains(t, err, "reading key file")
+}


### PR DESCRIPTION
Previously, `--key` on `docker agent share push` and `docker agent share pull` expected a file path to the key material. This was awkward to use inline (e.g. with a freshly generated secret) and inconsistent with how env-var secrets are typically handled.

`--key` now accepts either the key material directly (e.g. `--key "$(openssl rand -hex 32)"`) or a path prefixed with `file://` (e.g. `--key file://~/.ssh/id_ed25519`). A leading `~` after `file://` is expanded because shells do not expand it mid-word. `DOCKER_AGENT_ENCRYPT_KEY` is resolved with the same logic when no flag is given. The resolution is centralised in a new `protect.ResolveKey` helper; push and pull now share a single `resolveKey` call in `cmd/root/push.go` instead of duplicating the logic. The `Supports` error message now shows `key.Describe()` so an inline secret is never echoed back to the user.

*Breaking change:* bare file paths are no longer accepted as `--key` values. A bare path is now treated as inline key material and will typically fail validation as a too-short or malformed secret. Callers must prefix file paths with `file://`.