### PR TITLE
refactor(config): remove deprecated safer shell flag from v15

### DIFF
--- a/agent-schema.json
+++ b/agent-schema.json
@@ -2378,10 +2378,6 @@
           "type": "boolean",
           "description": "Opt in to background-job recall for the background_jobs toolset (only valid for type 'background_jobs'). When enabled, run_background_job exposes a recall boolean parameter. If the agent sets recall=true for a background job, the runtime injects a steering message with a short completion sentence and the job output when the job finishes. Default false."
         },
-        "safer": {
-          "type": "boolean",
-          "description": "Deprecated and ignored (only valid for type 'shell'). The runtime now classifies every shell command natively (safe / destructive / unknown) and gates it through the session's safety mode (strict / balanced / restricted / autonomous), so the opt-in is meaningless. Kept so existing YAMLs with safer: true still parse."
-        },
         "url": {
           "type": "string",
           "description": "URL for the a2a, openapi or open_url tool",

--- a/docs/tools/shell/index.md
+++ b/docs/tools/shell/index.md
@@ -43,7 +43,6 @@ toolsets:
 | Property       | Type    | Description                                                                                          |
 | -------------- | ------- | --------------------------------------------------------------------------------------------------- |
 | `env`          | object  | Environment variables to set for all shell commands                                                 |
-| `safer`        | boolean | Deprecated and ignored — shell commands are always classified now (see [Command classification](#command-classification)). Kept so existing YAMLs still parse. |
 | `sudo_askpass` | boolean | Opt in to prompting for a `sudo` password (see [Sudo support](#sudo-support)). Default `false`.     |
 
 ### Custom Environment Variables
@@ -68,7 +67,7 @@ The session's [safety mode](../../configuration/permissions/index.md#safety-mode
 
 Compound shell (`a && b`, `a; b`, `a | b`) is never matched against the safe allowlist; any destructive segment falls through to ask. The full taxonomy lives in [`pkg/safety/safety_patterns.json`](https://github.com/docker/docker-agent/blob/main/pkg/safety/safety_patterns.json).
 
-See [`examples/safety_modes.yaml`](https://github.com/docker/docker-agent/blob/main/examples/safety_modes.yaml) for a full example. The legacy `safer: true` toolset flag is deprecated and ignored.
+See [`examples/safety_modes.yaml`](https://github.com/docker/docker-agent/blob/main/examples/safety_modes.yaml) for a full example. The legacy `safer: true` toolset flag was removed in config version 15 (it is still accepted, and ignored, by older config versions).
 
 ### Sudo support
 

--- a/pkg/config/latest/types.go
+++ b/pkg/config/latest/types.go
@@ -1698,12 +1698,6 @@ type Toolset struct {
 	// finishes.
 	Recall *bool `json:"recall,omitempty" yaml:"recall,omitempty"`
 
-	// Deprecated: ignored. The runtime now classifies every shell
-	// command natively (pkg/safety) and gates it through the session's
-	// safety mode, so the opt-in is meaningless. Kept so existing
-	// YAMLs with `safer: true` still parse under strict decoding.
-	Safer *bool `json:"safer,omitempty" yaml:"safer,omitempty"`
-
 	// For the `rag` tool
 	RAGConfig *RAGConfig `json:"rag_config,omitempty" yaml:"rag_config,omitempty"`
 

--- a/pkg/config/latest/validate.go
+++ b/pkg/config/latest/validate.go
@@ -319,9 +319,6 @@ func (t *Toolset) validate() error {
 	if t.Recall != nil && t.Type != "background_jobs" {
 		return errors.New("recall can only be used with type 'background_jobs'")
 	}
-	if t.Safer != nil && t.Type != "shell" {
-		return errors.New("safer can only be used with type 'shell'")
-	}
 	if len(t.AllowedDomains) > 0 && len(t.BlockedDomains) > 0 {
 		return errors.New("allowed_domains and blocked_domains are mutually exclusive")
 	}

--- a/pkg/config/latest/validate_test.go
+++ b/pkg/config/latest/validate_test.go
@@ -196,7 +196,6 @@ func TestToolsetValidateAttributeTypeMismatch(t *testing.T) {
 		{name: "allow_private_ips on wrong type", toolset: Toolset{Type: "shell", AllowPrivateIPs: new(true)}, wantErr: "allow_private_ips can only be used with type 'fetch', 'api', 'openapi', 'a2a' or remote MCP toolsets"},
 		{name: "sudo_askpass on non-shell", toolset: Toolset{Type: "fetch", SudoAskpass: new(true)}, wantErr: "sudo_askpass can only be used with type 'shell'"},
 		{name: "recall on non-background_jobs", toolset: Toolset{Type: "shell", Recall: new(true)}, wantErr: "recall can only be used with type 'background_jobs'"},
-		{name: "safer on non-shell", toolset: Toolset{Type: "fetch", Safer: new(true)}, wantErr: "safer can only be used with type 'shell'"},
 		{name: "allowed and blocked domains", toolset: Toolset{Type: "fetch", AllowedDomains: []string{"a.example.com"}, BlockedDomains: []string{"b.example.com"}}, wantErr: "allowed_domains and blocked_domains are mutually exclusive"},
 		{name: "invalid allowed_domains pattern", toolset: Toolset{Type: "fetch", AllowedDomains: []string{"foo.*"}}, wantErr: `allowed_domains[0] "foo.*" is invalid`},
 		{name: "invalid blocked_domains pattern", toolset: Toolset{Type: "fetch", BlockedDomains: []string{"10.0.0.0/33"}}, wantErr: `blocked_domains[0] "10.0.0.0/33" is invalid: not a valid CIDR`},
@@ -306,7 +305,7 @@ func TestToolsetValidateValidToolsets(t *testing.T) {
 		name    string
 		toolset Toolset
 	}{
-		{name: "shell", toolset: Toolset{Type: "shell", Env: map[string]string{"A": "b"}, SudoAskpass: new(true), Safer: new(true)}},
+		{name: "shell", toolset: Toolset{Type: "shell", Env: map[string]string{"A": "b"}, SudoAskpass: new(true)}},
 		{name: "background_jobs", toolset: Toolset{Type: "background_jobs", Env: map[string]string{"A": "b"}, Recall: new(true)}},
 		{name: "memory with path", toolset: Toolset{Type: "memory", Path: "/tmp/memory.db"}},
 		{name: "memory without path", toolset: Toolset{Type: "memory"}},


### PR DESCRIPTION
The `safer` boolean on the `shell` toolset has been deprecated and ignored for some time: once the runtime started classifying every shell command natively via `pkg/safety` and gating execution through the session's safety mode, the flag became redundant. This PR removes it from `pkg/config/latest` (config version 15), which is the only version still open to modification.

Frozen versions v11–v14 are untouched and continue to accept (and silently ignore) the field. For the upgrade path, a `version: "14"` YAML with `safer: true` still loads correctly — the v14→v15 migration via `types.CloneThroughJSON` drops the unknown field. A `version: "15"` YAML with `safer: true` is correctly rejected under strict decoding with an `unknown field "safer"` error.

The change drops `Toolset.Safer` and its validation check from `pkg/config/latest`, removes the matching test cases, removes the `safer` property from `agent-schema.json`, and updates `docs/tools/shell/index.md` to drop the option row and note the removal.