### PR TITLE
feat(rag): decouple indexing from caller timeout via indexing_timeout config (#4073)

### DIFF
--- a/agent-schema.json
+++ b/agent-schema.json
@@ -2869,6 +2869,10 @@
           "description": "Whether to respect VCS ignore files (e.g., .gitignore) when collecting documents for indexing. When true (default), files matching ignore patterns will be excluded. Can be overridden per-strategy.",
           "default": true
         },
+        "indexing_timeout": {
+          "type": "string",
+          "description": "Cap on a single indexing run started by this RAG source, detached from the much shorter 30s toolset-start wait budget: indexing keeps running in the background past that budget and the tool appears once it is ready, resuming from per-file progress on a later start. Go duration format (e.g. '30m', '2h'). Default '30m' when omitted; '0s' means no bound."
+        },
         "strategies": {
           "type": "array",
           "description": "Array of retrieval strategy configurations. Each strategy can have different parameters based on its type.",

--- a/docs/tools/rag/index.md
+++ b/docs/tools/rag/index.md
@@ -235,6 +235,59 @@ The gate is a lightweight wall-clock check — it creates no background threads 
 timers. A Stop command or agent shutdown takes effect immediately regardless of
 how much of the backoff window remains.
 
+### Long indexing runs
+
+Starting any toolset — RAG included — is bounded by a 30-second *wait* budget
+(`tools.DefaultStartTimeout`): if a toolset's `Start` has not returned within
+30s, the caller stops waiting and the turn proceeds without that toolset's
+tools, exactly as it would for a wedged MCP server. This budget exists to
+detect toolsets that never come up; it is not a deadline on indexing itself.
+
+A large knowledge base can legitimately take much longer than 30s to index.
+Rather than abort in-flight indexing at the 30s mark — which used to discard
+any embeddings not yet committed for the file being processed — the RAG
+toolset detaches indexing from the caller's wait budget the same way it
+already detaches its file watcher. When the 30s budget expires:
+
+- The current turn proceeds without the RAG tool (the existing "taking too
+  long to start" warning and TUI progress events still apply).
+- Indexing keeps running in the background.
+- Files that finish indexing are persisted atomically per file (a file is
+  always either fully indexed or untouched — see #4073/#4158), so progress
+  is never lost to this budget.
+- A later turn's `Start` call picks the toolset up: if indexing has finished,
+  the tool is available immediately; if it is still running, that turn also
+  proceeds without the tool.
+
+This is a **visible behavior change**: knowledge bases that used to finish
+indexing (and thus offer the tool) on the very first turn, within the old
+30-second window, now do so on whichever turn happens to land after indexing
+completes. If indexing takes under 30s, nothing changes.
+
+`indexing_timeout` bounds indexing itself, independent of the 30s wait
+budget — it exists only so a hung provider connection cannot pin a knowledge
+base's indexing lock forever:
+
+```yaml
+rag:
+  codebase:
+    indexing_timeout: 2h # Go duration; "0s" = unbounded; default 30m
+    docs: [./knowledge-base]
+    strategies:
+      - type: chunked-embeddings
+        embedding_model: openai/text-embedding-3-small
+```
+
+- Default: `30m` when omitted.
+- `0s` means no bound. A negative value is rejected at config validation time.
+- Expiry is a plain timeout, not a provider error: it does **not** arm the
+  backoff gate described above, and the next turn's `Start` resumes indexing
+  immediately rather than waiting out a cooldown. Files already persisted are
+  kept; unfinished files are re-indexed on resume.
+- A 429/408/5xx from the provider *during* a detached indexing run is
+  unaffected by any of this — it still aborts the run and arms the backoff
+  gate exactly as described above.
+
 ### Operational impact
 
 **Before**: a rate-limited knowledge base was re-indexed on every agent turn —
@@ -302,13 +355,14 @@ Look for log tags: `[RAG Manager]`, `[Chunked-Embeddings Strategy]`, `[BM25 Stra
 
 ### Top-Level RAG Fields
 
-| Field         | Type     | Default | Description                                                    |
-| ------------- | -------- | ------- | -------------------------------------------------------------- |
-| `docs`        | []string | —       | Document paths/directories (shared across strategies)          |
-| `description` | string   | —       | Human-readable description of this RAG source                  |
-| `respect_vcs` | boolean  | `true`  | Respect `.gitignore` files when indexing documents             |
-| `strategies`  | []object | —       | Array of retrieval strategy configurations                     |
-| `results`     | object   | —       | Post-processing: fusion, reranking, deduplication, final limit |
+| Field              | Type     | Default | Description                                                                                                                                    |
+| ------------------ | -------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| `docs`             | []string | —       | Document paths/directories (shared across strategies)                                                                                          |
+| `description`      | string   | —       | Human-readable description of this RAG source                                                                                                  |
+| `respect_vcs`      | boolean  | `true`  | Respect `.gitignore` files when indexing documents                                                                                             |
+| `indexing_timeout` | string   | `30m`   | Cap on a single indexing run, detached from the 30s toolset-start wait budget; `0s` = unbounded. See [Long indexing runs](#long-indexing-runs) |
+| `strategies`       | []object | —       | Array of retrieval strategy configurations                                                                                                     |
+| `results`          | object   | —       | Post-processing: fusion, reranking, deduplication, final limit                                                                                 |
 
 ### Chunked-Embeddings Strategy
 

--- a/examples/rag/semantic_embeddings.yaml
+++ b/examples/rag/semantic_embeddings.yaml
@@ -25,6 +25,11 @@ rag:
   codebase:
     tool:
       description: Search the codebase for relevant code snippets by semantic meaning
+    # Large knowledge bases can take a while to index. indexing_timeout bounds
+    # that single indexing run, detached from the much shorter (30s) toolset-
+    # start wait budget: the agent proceeds without this tool on early turns
+    # and it appears once indexing finishes. "0s" means no bound; default 30m.
+    indexing_timeout: 2h
     docs:
       - ../../pkg/**/*.go
       - ../../cmd/**/*.go

--- a/pkg/config/latest/rag_test.go
+++ b/pkg/config/latest/rag_test.go
@@ -1,0 +1,174 @@
+package latest
+
+import (
+	"testing"
+	"time"
+
+	"github.com/goccy/go-yaml"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRAGConfig_GetIndexingTimeout(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		cfg  *RAGConfig
+		want time.Duration
+	}{
+		{name: "omitted defaults to 30m", cfg: &RAGConfig{}, want: 30 * time.Minute},
+		{name: "explicit 0s is unbounded", cfg: &RAGConfig{IndexingTimeout: &Duration{Duration: 0}}, want: 0},
+		{name: "explicit value", cfg: &RAGConfig{IndexingTimeout: &Duration{Duration: 2 * time.Hour}}, want: 2 * time.Hour},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, tt.cfg.GetIndexingTimeout())
+		})
+	}
+}
+
+func TestRAGConfig_Validate_IndexingTimeout(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		cfg     *RAGConfig
+		wantErr string
+	}{
+		{name: "nil is valid (default applies)", cfg: &RAGConfig{}},
+		{name: "explicit zero is valid (unbounded)", cfg: &RAGConfig{IndexingTimeout: &Duration{Duration: 0}}},
+		{name: "positive is valid", cfg: &RAGConfig{IndexingTimeout: &Duration{Duration: 2 * time.Hour}}},
+		{
+			name:    "negative is rejected",
+			cfg:     &RAGConfig{IndexingTimeout: &Duration{Duration: -time.Second}},
+			wantErr: "indexing_timeout must not be negative",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := tt.cfg.validate()
+			if tt.wantErr == "" {
+				require.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.wantErr)
+		})
+	}
+}
+
+// TestConfigValidate_RAGTopLevelIndexingTimeout pins that a top-level "rag:"
+// definition is validated even though it skips Toolset.validate() during
+// YAML unmarshaling (see RAGToolset.UnmarshalYAML) — Config.Validate() must
+// check it directly.
+func TestConfigValidate_RAGTopLevelIndexingTimeout(t *testing.T) {
+	t.Parallel()
+
+	cfg := &Config{
+		RAG: map[string]RAGToolset{
+			"docs": {Toolset: Toolset{Type: "rag", RAGConfig: &RAGConfig{
+				IndexingTimeout: &Duration{Duration: -time.Second},
+			}}},
+		},
+	}
+
+	err := cfg.Validate()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "rag.docs")
+	assert.Contains(t, err.Error(), "indexing_timeout must not be negative")
+}
+
+// TestRAGToolset_MarshalYAML_IndexingTimeout pins the flattening added
+// alongside respect_vcs: an explicit "0s" (unbounded) must round-trip
+// distinctly from an omitted field (which defaults to 30m via
+// GetIndexingTimeout), so RAGConfig.IndexingTimeout.String() is used
+// directly rather than Duration.MarshalYAML (which renders zero as "").
+func TestRAGToolset_MarshalYAML_IndexingTimeout(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name            string
+		indexingTimeout *Duration
+		wantYAML        string // substring expected in the marshaled output
+		wantAbsent      bool
+	}{
+		{name: "omitted", indexingTimeout: nil, wantAbsent: true},
+		{name: "explicit zero (unbounded)", indexingTimeout: &Duration{Duration: 0}, wantYAML: "indexing_timeout: 0s"},
+		{name: "explicit value", indexingTimeout: &Duration{Duration: 2 * time.Hour}, wantYAML: "indexing_timeout: 2h0m0s"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			toolset := RAGToolset{Toolset: Toolset{
+				Type:      "rag",
+				RAGConfig: &RAGConfig{IndexingTimeout: tt.indexingTimeout},
+			}}
+
+			out, err := toolset.MarshalYAML()
+			require.NoError(t, err)
+
+			data, err := yaml.Marshal(out)
+			require.NoError(t, err)
+
+			if tt.wantAbsent {
+				assert.NotContains(t, string(data), "indexing_timeout")
+				return
+			}
+			assert.Contains(t, string(data), tt.wantYAML)
+		})
+	}
+}
+
+// TestRAGToolset_UnmarshalYAML_IndexingTimeout pins the top-level "rag:"
+// spelling (flattened alongside docs/strategies), mirroring the inline
+// "rag_config:" spelling exercised elsewhere.
+func TestRAGToolset_UnmarshalYAML_IndexingTimeout(t *testing.T) {
+	t.Parallel()
+
+	input := []byte(`tool:
+  description: test
+indexing_timeout: 2h
+docs: [./docs]
+strategies:
+  - type: bm25
+`)
+
+	var toolset RAGToolset
+	require.NoError(t, yaml.Unmarshal(input, &toolset))
+
+	require.NotNil(t, toolset.RAGConfig)
+	require.NotNil(t, toolset.RAGConfig.IndexingTimeout)
+	assert.Equal(t, 2*time.Hour, toolset.RAGConfig.IndexingTimeout.Duration)
+	assert.Equal(t, 2*time.Hour, toolset.RAGConfig.GetIndexingTimeout())
+}
+
+// TestRAGConfig_UnmarshalYAML_InlineIndexingTimeout mirrors the above for
+// the "rag_config:" inline spelling used directly on an agent's toolset.
+func TestRAGConfig_UnmarshalYAML_InlineIndexingTimeout(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		yaml string
+		want time.Duration
+	}{
+		{name: "omitted defaults to 30m", yaml: `tool: {}`, want: 30 * time.Minute},
+		{name: "explicit 0s is unbounded", yaml: "tool: {}\nindexing_timeout: 0s\n", want: 0},
+		{name: "explicit value", yaml: "tool: {}\nindexing_timeout: 2h\n", want: 2 * time.Hour},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var cfg RAGConfig
+			require.NoError(t, yaml.Unmarshal([]byte(tt.yaml), &cfg))
+			assert.Equal(t, tt.want, cfg.GetIndexingTimeout())
+		})
+	}
+}

--- a/pkg/config/latest/types.go
+++ b/pkg/config/latest/types.go
@@ -249,6 +249,9 @@ func (r RAGToolset) MarshalYAML() (any, error) {
 		if cfg.RespectVCS != nil {
 			result["respect_vcs"] = *cfg.RespectVCS
 		}
+		if cfg.IndexingTimeout != nil {
+			result["indexing_timeout"] = cfg.IndexingTimeout.String()
+		}
 		if len(cfg.Strategies) > 0 {
 			result["strategies"] = cfg.Strategies
 		}
@@ -2124,6 +2127,12 @@ type RAGConfig struct {
 	RespectVCS *bool               `json:"respect_vcs,omitempty"` // Whether to respect VCS ignore files like .gitignore (default: true)
 	Strategies []RAGStrategyConfig `json:"strategies,omitempty"`  // Array of strategy configurations
 	Results    RAGResultsConfig    `json:"results"`
+	// IndexingTimeout bounds a single Initialize run started by the toolset's
+	// Start, detached from the caller's own (much shorter) start-wait budget.
+	// nil means the default (30m); an explicit "0s" means no bound. Completed
+	// files are persisted per file, so an expired run resumes where it left
+	// off on the next start.
+	IndexingTimeout *Duration `json:"indexing_timeout,omitempty"`
 }
 
 // GetRespectVCS returns whether VCS ignore files should be respected, defaulting to true
@@ -2132,6 +2141,18 @@ func (c *RAGConfig) GetRespectVCS() bool {
 		return true
 	}
 	return *c.RespectVCS
+}
+
+// defaultRAGIndexingTimeout is used when IndexingTimeout is unset.
+const defaultRAGIndexingTimeout = 30 * time.Minute
+
+// GetIndexingTimeout returns the configured indexing timeout, defaulting to
+// defaultRAGIndexingTimeout when unset. An explicit "0s" means no bound.
+func (c *RAGConfig) GetIndexingTimeout() time.Duration {
+	if c.IndexingTimeout == nil {
+		return defaultRAGIndexingTimeout
+	}
+	return c.IndexingTimeout.Duration
 }
 
 // RAGStrategyConfig represents a single retrieval strategy configuration

--- a/pkg/config/latest/validate.go
+++ b/pkg/config/latest/validate.go
@@ -65,6 +65,18 @@ func (t *Config) Validate() error {
 		}
 	}
 
+	// Top-level "rag" definitions skip Toolset.validate() during YAML
+	// unmarshaling (see RAGToolset.UnmarshalYAML), so their RAGConfig is
+	// validated here instead.
+	for name, def := range t.RAG {
+		if def.RAGConfig == nil {
+			continue
+		}
+		if err := def.RAGConfig.validate(); err != nil {
+			return fmt.Errorf("rag.%s: %w", name, err)
+		}
+	}
+
 	for i := range t.Agents {
 		agent := &t.Agents[i]
 
@@ -451,10 +463,24 @@ func (t *Toolset) validate() error {
 		if t.Ref == "" && t.RAGConfig == nil {
 			return errors.New("rag toolset requires either ref or rag_config")
 		}
+		if t.RAGConfig != nil {
+			if err := t.RAGConfig.validate(); err != nil {
+				return err
+			}
+		}
 	case "background_agents":
 		// no additional validation needed
 	}
 
+	return nil
+}
+
+// validate rejects an invalid RAGConfig. Currently only IndexingTimeout is
+// checked; a negative value would make context.WithTimeout fire immediately.
+func (c *RAGConfig) validate() error {
+	if c.IndexingTimeout != nil && c.IndexingTimeout.Duration < 0 {
+		return errors.New("indexing_timeout must not be negative")
+	}
 	return nil
 }
 

--- a/pkg/config/latest/validate_test.go
+++ b/pkg/config/latest/validate_test.go
@@ -247,6 +247,7 @@ func TestToolsetValidateTypeRequirements(t *testing.T) {
 		{name: "open_url without url", toolset: Toolset{Type: "open_url"}, wantErr: "open_url toolset requires a url to be set"},
 		{name: "model_picker without models", toolset: Toolset{Type: "model_picker"}, wantErr: "model_picker toolset requires at least one model in the 'models' list"},
 		{name: "rag without ref or config", toolset: Toolset{Type: "rag"}, wantErr: "rag toolset requires either ref or rag_config"},
+		{name: "rag inline config with negative indexing_timeout", toolset: Toolset{Type: "rag", RAGConfig: &RAGConfig{IndexingTimeout: &Duration{Duration: -time.Second}}}, wantErr: "indexing_timeout must not be negative"},
 	}
 
 	for _, tt := range tests {

--- a/pkg/tools/builtin/rag/rag.go
+++ b/pkg/tools/builtin/rag/rag.go
@@ -9,6 +9,7 @@ import (
 	"log/slog"
 	"slices"
 	"sync"
+	"time"
 
 	"github.com/docker/docker-agent/pkg/config"
 	"github.com/docker/docker-agent/pkg/config/latest"
@@ -39,7 +40,7 @@ func CreateToolSet(ctx context.Context, toolset latest.Toolset, parentDir string
 	}
 
 	toolName := cmp.Or(mgr.ToolName(), ragName)
-	return New(mgr, toolName), nil
+	return New(mgr, toolName, WithIndexingTimeout(toolset.RAGConfig.GetIndexingTimeout())), nil
 }
 
 // EventCallback is called to forward RAG manager events during initialization.
@@ -52,6 +53,10 @@ type ToolSet struct {
 	eventCallback EventCallback
 	cancelWatcher context.CancelFunc
 	wg            sync.WaitGroup
+	// indexingTimeout bounds a single Initialize call. Zero means unbounded.
+	// Resolved once by the caller (config.RAGConfig.GetIndexingTimeout()); the
+	// zero value here is a plain Go zero, not "apply the default".
+	indexingTimeout time.Duration
 }
 
 // Verify interface compliance.
@@ -61,12 +66,28 @@ var (
 	_ tools.Startable    = (*ToolSet)(nil)
 )
 
+// Option configures optional ToolSet behavior.
+type Option func(*ToolSet)
+
+// WithIndexingTimeout bounds a single Initialize call started by Start,
+// independent of the caller's own (much shorter) start-wait budget. Zero
+// (the default) means unbounded.
+func WithIndexingTimeout(d time.Duration) Option {
+	return func(t *ToolSet) {
+		t.indexingTimeout = d
+	}
+}
+
 // New creates a new RAG toolset for a single RAG manager.
-func New(manager *rag.Manager, toolName string) *ToolSet {
-	return &ToolSet{
+func New(manager *rag.Manager, toolName string, opts ...Option) *ToolSet {
+	t := &ToolSet{
 		manager:  manager,
 		toolName: toolName,
 	}
+	for _, opt := range opts {
+		opt(t)
+	}
+	return t
 }
 
 // Name returns the tool name for this RAG source.
@@ -82,16 +103,23 @@ func (t *ToolSet) SetEventCallback(cb EventCallback) {
 
 // Start initializes the RAG manager (indexes documents) and starts a
 // file watcher for incremental updates.
+//
+// Indexing is detached from the caller's cancellation, just like the file
+// watcher: Start may run under a short-lived startup-probe context (the
+// wait budget documented on tools.DefaultStartTimeout / TryStartWithTimeout),
+// and a caller giving up on that budget must not abort in-flight work —
+// TryStartWithTimeout already promises that an abandoned Start keeps running
+// and is picked up by a later call once it completes. Indexing is instead
+// bounded only by indexingTimeout (see WithIndexingTimeout; zero means
+// unbounded) and by Stop.
 func (t *ToolSet) Start(ctx context.Context) error {
 	if t.manager == nil {
 		return nil
 	}
 
-	// The watcher and event forwarder are long-lived and owned by Stop() via
-	// cancelWatcher: detach them from the caller's cancellation — Start may
-	// run under a short-lived startup-probe context — while keeping its values
-	// (logging, tracing). Initialize below still uses the caller's ctx so a
-	// canceled startup aborts indexing.
+	// The watcher, event forwarder and indexing are all long-lived and owned
+	// by Stop() via cancelWatcher: detach them from the caller's cancellation
+	// while keeping its values (logging, tracing).
 	watchCtx, cancel := context.WithCancel(context.WithoutCancel(ctx))
 	t.cancelWatcher = cancel
 
@@ -102,9 +130,24 @@ func (t *ToolSet) Start(ctx context.Context) error {
 		})
 	}
 
-	if err := t.manager.Initialize(ctx); err != nil {
+	// initCtx bounds a single Initialize run: derived from the detached
+	// watchCtx (so Stop still cancels it), plus indexingTimeout when set.
+	initCtx := watchCtx
+	if t.indexingTimeout > 0 {
+		var initCancel context.CancelFunc
+		initCtx, initCancel = context.WithTimeout(watchCtx, t.indexingTimeout)
+		defer initCancel()
+	}
+
+	if err := t.manager.Initialize(initCtx); err != nil {
 		cancel()
 		t.wg.Wait()
+		if errors.Is(initCtx.Err(), context.DeadlineExceeded) {
+			slog.WarnContext(ctx, "RAG indexing exceeded indexing_timeout; progress is saved and resumes on the next start",
+				"tool", t.toolName, "indexing_timeout", t.indexingTimeout)
+			return fmt.Errorf("RAG manager %q: indexing exceeded indexing_timeout (%s); progress is saved and resumes on the next start: %w",
+				t.toolName, t.indexingTimeout, err)
+		}
 		return fmt.Errorf("failed to initialize RAG manager %q: %w", t.toolName, err)
 	}
 

--- a/pkg/tools/builtin/rag/rag_backoff_test.go
+++ b/pkg/tools/builtin/rag/rag_backoff_test.go
@@ -137,3 +137,97 @@ func TestRAGStartableBackoff_PlainErrorNoGate(t *testing.T) {
 			"plain error must not gate subsequent TryStart calls (attempt %d)", i)
 	}
 }
+
+// blockingStatusErrStrategy blocks in Initialize until release is closed,
+// then fails with a *modelerrors.StatusError. It lets tests abandon a
+// TryStartWithTimeout call (simulating the caller's expired wait budget)
+// while indexing is still in flight, matching #4073's detachment contract.
+type blockingStatusErrStrategy struct {
+	mockStrategy
+
+	release    chan struct{}
+	statusCode int
+	calls      atomic.Int32
+}
+
+func (s *blockingStatusErrStrategy) Initialize(_ context.Context, _ []string, _ strategy.ChunkingConfig) error {
+	s.calls.Add(1)
+	<-s.release
+	return &modelerrors.StatusError{
+		StatusCode: s.statusCode,
+		Err:        fmt.Errorf("HTTP %d error from provider", s.statusCode),
+	}
+}
+
+// TestRAGStartableBackoff_DetachedStatusErrorStillEngagesGate proves the
+// #4073/#4062 interaction called out in D3: a StatusError returned by
+// indexing that outlived the caller's wait budget (and so ran to completion
+// in the background, detached per #4073) still arms the backoff gate exactly
+// as an immediate failure would.
+func TestRAGStartableBackoff_DetachedStatusErrorStillEngagesGate(t *testing.T) {
+	t.Parallel()
+
+	blocking := &blockingStatusErrStrategy{release: make(chan struct{}), statusCode: 429}
+	toolset := buildRAGToolSet(t, blocking)
+
+	// Frozen clock: window = base + 0% jitter = exactly base. We advance the
+	// clock manually to control expiry, exactly as the sibling test above.
+	now := time.Unix(1_000_000, 0)
+	s := tools.NewStartable(toolset,
+		tools.WithStartRetryJitter(func(d time.Duration) time.Duration { return d }), // identity
+		tools.WithStartRetryClock(func() time.Time { return now }),
+	)
+
+	// The caller gives up well before indexing (still blocked on release)
+	// returns. Per TryStartWithTimeout's documented contract, the attempt is
+	// abandoned — not stopped — and keeps running under the single-flight lock.
+	started, err := s.TryStartWithTimeout(t.Context(), 10*time.Millisecond)
+	assert.False(t, started)
+	require.ErrorIs(t, err, context.DeadlineExceeded, "the caller's wait budget must expire while indexing is still in flight")
+	assert.Equal(t, int32(1), blocking.calls.Load())
+
+	// Let the detached indexing finish; it fails with a 429 minutes "later"
+	// from the caller's point of view, and must still arm the gate.
+	close(blocking.release)
+	require.Eventually(t, func() bool {
+		_, err := s.TryStart(t.Context())
+		return err != nil
+	}, time.Second, time.Millisecond, "the detached failure must eventually arm the backoff gate")
+	assert.Equal(t, int32(1), blocking.calls.Load(),
+		"the gate must suppress a retry within the window — no second Initialize call")
+
+	// Advance clock past the base window; the gate must release.
+	now = now.Add(6 * time.Minute)
+	_, err = s.TryStart(t.Context())
+	require.Error(t, err, "still failing — expected error")
+	assert.Equal(t, int32(2), blocking.calls.Load(),
+		"Initialize must be called again once the backoff window expires")
+}
+
+// TestRAGStartableBackoff_IndexingTimeoutDeadlineDoesNotEngageGate proves the
+// other half of the #4073/#4062 invariant: indexing_timeout expiring is a
+// plain context.DeadlineExceeded, not a provider failure, and must NOT arm
+// the backoff gate — the next TryStart re-invokes Initialize immediately.
+func TestRAGStartableBackoff_IndexingTimeoutDeadlineDoesNotEngageGate(t *testing.T) {
+	t.Parallel()
+
+	blocking := &blockingIndexStrategy{
+		release: make(chan struct{}), // never closed: only the indexing_timeout ends Initialize
+		ctxCh:   make(chan context.Context, 1),
+	}
+	toolset := newTestRAGToolSet(t, blocking, WithIndexingTimeout(30*time.Millisecond))
+	s := tools.NewStartable(toolset)
+
+	_, err := s.TryStart(t.Context())
+	require.Error(t, err)
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, int32(1), blocking.calls.Load())
+
+	// No backoff armed: the very next TryStart must re-invoke Initialize
+	// immediately, with no wait and no retained gate error.
+	_, err = s.TryStart(t.Context())
+	require.Error(t, err)
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, int32(2), blocking.calls.Load(),
+		"an indexing_timeout deadline must not arm the backoff gate")
+}

--- a/pkg/tools/builtin/rag/rag_indexing_timeout_test.go
+++ b/pkg/tools/builtin/rag/rag_indexing_timeout_test.go
@@ -1,0 +1,215 @@
+package rag
+
+// Regression tests for #4073: RAG indexing must be decoupled from the
+// caller's tools.DefaultStartTimeout wait budget and bounded only by the
+// new indexing_timeout (WithIndexingTimeout) and Stop.
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"testing/synctest"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/docker/docker-agent/pkg/rag"
+	"github.com/docker/docker-agent/pkg/rag/strategy"
+	"github.com/docker/docker-agent/pkg/tools"
+)
+
+// blockingIndexStrategy blocks in Initialize until either release is closed
+// (success) or the supplied ctx is done (the caller's cancellation/timeout).
+// It captures the ctx it was called with on ctxCh so tests can assert on its
+// lifetime without racing the goroutine that invokes Initialize.
+type blockingIndexStrategy struct {
+	mockStrategy
+
+	release chan struct{}
+	ctxCh   chan context.Context
+	calls   atomic.Int32
+}
+
+func (s *blockingIndexStrategy) Initialize(ctx context.Context, _ []string, _ strategy.ChunkingConfig) error {
+	s.calls.Add(1)
+	select {
+	case s.ctxCh <- ctx:
+	default:
+	}
+	select {
+	case <-s.release:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func newTestRAGToolSet(t *testing.T, impl strategy.Strategy, opts ...Option) *ToolSet {
+	t.Helper()
+	cfg := rag.Config{
+		StrategyConfigs: []strategy.Config{
+			{Name: "test-strategy", Strategy: impl},
+		},
+	}
+	mgr, err := rag.New(t.Context(), "test-rag", cfg, nil)
+	require.NoError(t, err)
+	return New(mgr, "test-rag", opts...)
+}
+
+// TestRAGIndexingTimeout_WaitBudgetDoesNotCancelIndexing proves the core
+// #4073 fix: when tools.DefaultStartTimeout-style wait budget expires,
+// indexing (Initialize) keeps running on a context that is NOT canceled by
+// that budget, and a later attempt picks up the completed result without
+// calling Initialize again.
+func TestRAGIndexingTimeout_WaitBudgetDoesNotCancelIndexing(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		strategyMock := &blockingIndexStrategy{
+			release: make(chan struct{}),
+			ctxCh:   make(chan context.Context, 1),
+		}
+		// indexingTimeout left at its zero value (unbounded): only the
+		// caller's wait budget below should ever be observed expiring.
+		toolset := newTestRAGToolSet(t, strategyMock)
+		s := tools.NewStartable(toolset)
+
+		started, err := s.TryStartWithTimeout(t.Context(), time.Second)
+		assert.False(t, started)
+		require.ErrorIs(t, err, context.DeadlineExceeded, "the caller's wait budget must expire")
+
+		var capturedCtx context.Context
+		select {
+		case capturedCtx = <-strategyMock.ctxCh:
+		default:
+			t.Fatal("Initialize was never called")
+		}
+		require.NoError(t, capturedCtx.Err(), "indexing's context must survive the caller's expired wait budget")
+
+		// Let indexing finish; the abandoned background attempt still holds
+		// the single-flight lock and settles once Initialize returns.
+		close(strategyMock.release)
+		synctest.Wait()
+
+		started, err = s.TryStart(t.Context())
+		require.NoError(t, err)
+		assert.True(t, started, "a later TryStart must pick up the completed background start")
+		assert.Equal(t, int32(1), strategyMock.calls.Load(), "Initialize must not be called a second time")
+	})
+}
+
+// TestRAGIndexingTimeout_Applied proves that a positive indexing_timeout
+// bounds Initialize itself (independent of any caller wait budget) and that
+// the resulting Start error is context.DeadlineExceeded.
+func TestRAGIndexingTimeout_Applied(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		strategyMock := &blockingIndexStrategy{
+			release: make(chan struct{}),
+			ctxCh:   make(chan context.Context, 1),
+		}
+		toolset := newTestRAGToolSet(t, strategyMock, WithIndexingTimeout(5*time.Second))
+
+		err := toolset.Start(t.Context())
+		require.Error(t, err)
+		require.ErrorIs(t, err, context.DeadlineExceeded)
+		assert.Equal(t, int32(1), strategyMock.calls.Load())
+	})
+}
+
+// TestRAGIndexingTimeout_ContextDeadline covers indexing_timeout resolution
+// at the ToolSet level: the context handed to Initialize carries a deadline
+// only when a positive indexing_timeout was configured.
+func TestRAGIndexingTimeout_ContextDeadline(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		timeout      time.Duration
+		wantDeadline bool
+	}{
+		{name: "unbounded (zero value, e.g. omitted config)", timeout: 0, wantDeadline: false},
+		{name: "bounded", timeout: 5 * time.Minute, wantDeadline: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctxCh := make(chan context.Context, 1)
+			strategyMock := &ctxCapturingStrategy{ctxCh: ctxCh}
+
+			var opts []Option
+			if tt.timeout != 0 {
+				opts = append(opts, WithIndexingTimeout(tt.timeout))
+			}
+			toolset := newTestRAGToolSet(t, strategyMock, opts...)
+
+			require.NoError(t, toolset.Start(t.Context()))
+			defer func() { require.NoError(t, toolset.Stop(t.Context())) }()
+
+			var capturedCtx context.Context
+			select {
+			case capturedCtx = <-ctxCh:
+			default:
+				t.Fatal("Initialize was never called")
+			}
+			_, hasDeadline := capturedCtx.Deadline()
+			assert.Equal(t, tt.wantDeadline, hasDeadline)
+		})
+	}
+}
+
+// ctxCapturingStrategy returns immediately from Initialize after handing the
+// ctx it received to the test, for synchronous deadline assertions.
+type ctxCapturingStrategy struct {
+	mockStrategy
+
+	ctxCh chan context.Context
+}
+
+func (s *ctxCapturingStrategy) Initialize(ctx context.Context, _ []string, _ strategy.ChunkingConfig) error {
+	select {
+	case s.ctxCh <- ctx:
+	default:
+	}
+	return nil
+}
+
+// closeCountingStrategy counts Close calls so Stop's exactly-once contract
+// can be asserted after a detached Start completes.
+type closeCountingStrategy struct {
+	mockStrategy
+
+	closes atomic.Int32
+}
+
+func (s *closeCountingStrategy) Close() error {
+	s.closes.Add(1)
+	return nil
+}
+
+// TestRAGIndexingTimeout_StopAfterDetachedStartClosesOnce proves Stop's
+// wg/cancelWatcher accounting is unaffected by decoupling indexing from the
+// caller's ctx: a completed detached Start still closes the manager exactly
+// once and Stop does not deadlock.
+func TestRAGIndexingTimeout_StopAfterDetachedStartClosesOnce(t *testing.T) {
+	t.Parallel()
+
+	strategyMock := &closeCountingStrategy{}
+	toolset := newTestRAGToolSet(t, strategyMock, WithIndexingTimeout(0))
+
+	require.NoError(t, toolset.Start(t.Context()))
+
+	done := make(chan struct{})
+	go func() {
+		_ = toolset.Stop(t.Context())
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Stop deadlocked after a detached Start completed")
+	}
+
+	assert.Equal(t, int32(1), strategyMock.closes.Load())
+}

--- a/pkg/tools/startable.go
+++ b/pkg/tools/startable.go
@@ -432,6 +432,12 @@ func (s *StartableToolSet) TryStart(ctx context.Context) (started bool, err erro
 // startup probe so both give up on a wedged toolset after the same grace
 // period; it is deliberately generous because a cold start can legitimately
 // include an image pull.
+//
+// This is a *wait* budget, not a bound on the start itself: a toolset whose
+// Start legitimately outlives it (e.g. RAG indexing a large knowledge base,
+// bounded by its own indexing_timeout) is expected to keep running past this
+// deadline by design — see TryStartWithTimeout below for the abandon-and-
+// resume contract that makes that safe.
 const DefaultStartTimeout = 30 * time.Second
 
 // TryStartWithTimeout runs TryStart bounded by timeout (DefaultStartTimeout


### PR DESCRIPTION
Part of #4073 (T2+T3), depends on #4158 (merged — atomic per-file persistence, T1).

## Problem

`tools.DefaultStartTimeout` (30s) is a shared wait budget for detecting wedged toolsets of *any* type (#4001). `rag.ToolSet.Start` honoured the caller's cancellation for `manager.Initialize`, so when a large knowledge base's indexing outlived the 30s budget, in-flight embedding work (and, pre-#4158, correctness) was discarded and the next turn re-started from scratch.

## Fix

Extend the detachment pattern already used for the RAG file watcher (`context.WithoutCancel`) to `manager.Initialize`. Indexing now runs on a context derived from the detached watcher context, bounded only by:
- a new `indexing_timeout` config on `RAGConfig` (default `30m`, `0s` = unbounded), and
- the toolset's own `Stop`.

`tools.DefaultStartTimeout`'s value and the #4062 backoff logic are **unchanged** — only a clarifying doc comment was added. Raising the shared constant would regress wedged-toolset detection for every toolset type; the fix belongs in RAG's own `Start`.

**#4062 invariant preserved (regression-tested):** a detached 429/408/5xx from the model provider during indexing still arms the backoff gate; an `indexing_timeout` expiry is `context.DeadlineExceeded` (non-retryable) and never arms it, so the next turn resumes immediately.

## Behavior change

Large-KB first turn(s) now proceed **without** the RAG tool (same UX as any wedged toolset today) instead of blocking up to 30s. Files finished before the budget expires are persisted (per #4158); the tool appears once indexing completes on a later turn.

## Changes

- `pkg/config/latest/{types,validate}.go`: `RAGConfig.IndexingTimeout *Duration` + `GetIndexingTimeout()`; negative values rejected, including for top-level `rag:` blocks (which bypass `Toolset.validate()` during unmarshal).
- `agent-schema.json`, `examples/rag/semantic_embeddings.yaml`, `docs/tools/rag/index.md`: schema/example/docs for `indexing_timeout`.
- `pkg/tools/builtin/rag/rag.go`: `WithIndexingTimeout` option; `Start` builds `initCtx` from the detached watcher context.
- `pkg/tools/startable.go`: doc-only clarification on `DefaultStartTimeout`.
- Tests: `pkg/tools/builtin/rag/rag_indexing_timeout_test.go` (new), `rag_backoff_test.go` (extended), `pkg/config/latest/rag_test.go` (new).

## Testing

`task lint` and `task test` (incl. `-race` on the rag package) pass clean.
