### PR TITLE
feat(debug): add --json flag to debug toolsets and skills

### DIFF
--- a/cmd/root/debug.go
+++ b/cmd/root/debug.go
@@ -2,6 +2,7 @@ package root
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"log/slog"
 
@@ -22,7 +23,25 @@ import (
 
 type debugFlags struct {
 	modelOverrides []string
+	jsonOutput     bool
 	runConfig      config.RuntimeConfig
+}
+
+type agentToolsInfo struct {
+	Agent string       `json:"agent"`
+	Tools []tools.Tool `json:"tools"`
+}
+
+type agentSkillsInfo struct {
+	Agent  string      `json:"agent"`
+	Skills []skillInfo `json:"skills"`
+}
+
+type skillInfo struct {
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	Forked      bool   `json:"forked"`
+	Path        string `json:"path,omitempty"`
 }
 
 func newDebugCmd() *cobra.Command {
@@ -40,18 +59,22 @@ func newDebugCmd() *cobra.Command {
 		Args:  cobra.ExactArgs(1),
 		RunE:  flags.runDebugConfigCommand,
 	})
-	cmd.AddCommand(&cobra.Command{
+	toolsetsCmd := &cobra.Command{
 		Use:   "toolsets <agent-file>|<registry-ref>",
 		Short: "Debug the toolsets of an agent",
 		Args:  cobra.ExactArgs(1),
 		RunE:  flags.runDebugToolsetsCommand,
-	})
-	cmd.AddCommand(&cobra.Command{
+	}
+	toolsetsCmd.Flags().BoolVar(&flags.jsonOutput, "json", false, "Output in JSON format")
+	cmd.AddCommand(toolsetsCmd)
+	skillsCmd := &cobra.Command{
 		Use:   "skills <agent-file>|<registry-ref>",
 		Short: "Debug the skills of an agent",
 		Args:  cobra.ExactArgs(1),
 		RunE:  flags.runDebugSkillsCommand,
-	})
+	}
+	skillsCmd.Flags().BoolVar(&flags.jsonOutput, "json", false, "Output in JSON format")
+	cmd.AddCommand(skillsCmd)
 	titleCmd := &cobra.Command{
 		Use:   "title <agent-file>|<registry-ref> <question>",
 		Short: "Generate a session title from a question",
@@ -119,8 +142,7 @@ func (f *debugFlags) runDebugToolsetsCommand(cmd *cobra.Command, args []string) 
 	}
 	defer stopToolSets(ctx, t)
 
-	out := cli.NewPrinter(cmd.OutOrStdout())
-
+	var infos []agentToolsInfo
 	for _, name := range t.AgentNames() {
 		agent, err := t.Agent(name)
 		if err != nil {
@@ -134,13 +156,27 @@ func (f *debugFlags) runDebugToolsetsCommand(cmd *cobra.Command, args []string) 
 			continue
 		}
 
-		if len(agentTools) == 0 {
-			out.Printf("No tools for %s\n", agent.Name())
+		if agentTools == nil {
+			agentTools = []tools.Tool{}
+		}
+		infos = append(infos, agentToolsInfo{Agent: agent.Name(), Tools: agentTools})
+	}
+
+	if f.jsonOutput {
+		enc := json.NewEncoder(cmd.OutOrStdout())
+		enc.SetIndent("", "  ")
+		return enc.Encode(infos)
+	}
+
+	out := cli.NewPrinter(cmd.OutOrStdout())
+	for _, info := range infos {
+		if len(info.Tools) == 0 {
+			out.Printf("No tools for %s\n", info.Agent)
 			continue
 		}
 
-		out.Printf("%d tool(s) for %s:\n", len(agentTools), agent.Name())
-		for _, tool := range agentTools {
+		out.Printf("%d tool(s) for %s:\n", len(info.Tools), info.Agent)
+		for _, tool := range info.Tools {
 			out.Println(" +", tool.Name, "-", tool.Description)
 		}
 	}
@@ -162,8 +198,7 @@ func (f *debugFlags) runDebugSkillsCommand(cmd *cobra.Command, args []string) (c
 	}
 	defer stopToolSets(ctx, t)
 
-	out := cli.NewPrinter(cmd.OutOrStdout())
-
+	var infos []agentSkillsInfo
 	for _, name := range t.AgentNames() {
 		agent, err := t.Agent(name)
 		if err != nil {
@@ -171,24 +206,42 @@ func (f *debugFlags) runDebugSkillsCommand(cmd *cobra.Command, args []string) (c
 			continue
 		}
 
-		var skillsToolset *skillstool.ToolSet
+		info := agentSkillsInfo{Agent: agent.Name(), Skills: []skillInfo{}}
 		for _, ts := range agent.ToolSets() {
-			if st, ok := tools.As[*skillstool.ToolSet](ts); ok {
-				skillsToolset = st
-				break
+			st, ok := tools.As[*skillstool.ToolSet](ts)
+			if !ok {
+				continue
 			}
+			for _, skill := range st.Skills() {
+				info.Skills = append(info.Skills, skillInfo{
+					Name:        skill.Name,
+					Description: skill.Description,
+					Forked:      skill.IsFork(),
+					Path:        skill.FilePath,
+				})
+			}
+			break
 		}
+		infos = append(infos, info)
+	}
 
-		if skillsToolset == nil || len(skillsToolset.Skills()) == 0 {
-			out.Printf("No skills for %s\n", agent.Name())
+	if f.jsonOutput {
+		enc := json.NewEncoder(cmd.OutOrStdout())
+		enc.SetIndent("", "  ")
+		return enc.Encode(infos)
+	}
+
+	out := cli.NewPrinter(cmd.OutOrStdout())
+	for _, info := range infos {
+		if len(info.Skills) == 0 {
+			out.Printf("No skills for %s\n", info.Agent)
 			continue
 		}
 
-		loadedSkills := skillsToolset.Skills()
-		out.Printf("%d skill(s) for %s:\n", len(loadedSkills), agent.Name())
-		for _, skill := range loadedSkills {
+		out.Printf("%d skill(s) for %s:\n", len(info.Skills), info.Agent)
+		for _, skill := range info.Skills {
 			marker := ""
-			if skill.IsFork() {
+			if skill.Forked {
 				marker = " [forked]"
 			}
 			out.Println(" +", skill.Name+marker, "-", skill.Description)

--- a/cmd/root/debug.go
+++ b/cmd/root/debug.go
@@ -23,13 +23,24 @@ import (
 
 type debugFlags struct {
 	modelOverrides []string
-	jsonOutput     bool
+	toolsetsJSON   bool
+	skillsJSON     bool
 	runConfig      config.RuntimeConfig
 }
 
+// Explicit DTOs keep the JSON contract stable and independent of internal types.
 type agentToolsInfo struct {
-	Agent string       `json:"agent"`
-	Tools []tools.Tool `json:"tools"`
+	Agent string     `json:"agent"`
+	Tools []toolInfo `json:"tools"`
+}
+
+type toolInfo struct {
+	Name         string                `json:"name"`
+	Category     string                `json:"category"`
+	Description  string                `json:"description"`
+	Parameters   any                   `json:"parameters"`
+	Annotations  tools.ToolAnnotations `json:"annotations"`
+	OutputSchema any                   `json:"outputSchema"`
 }
 
 type agentSkillsInfo struct {
@@ -65,7 +76,7 @@ func newDebugCmd() *cobra.Command {
 		Args:  cobra.ExactArgs(1),
 		RunE:  flags.runDebugToolsetsCommand,
 	}
-	toolsetsCmd.Flags().BoolVar(&flags.jsonOutput, "json", false, "Output in JSON format")
+	toolsetsCmd.Flags().BoolVar(&flags.toolsetsJSON, "json", false, "Output in JSON format")
 	cmd.AddCommand(toolsetsCmd)
 	skillsCmd := &cobra.Command{
 		Use:   "skills <agent-file>|<registry-ref>",
@@ -73,7 +84,7 @@ func newDebugCmd() *cobra.Command {
 		Args:  cobra.ExactArgs(1),
 		RunE:  flags.runDebugSkillsCommand,
 	}
-	skillsCmd.Flags().BoolVar(&flags.jsonOutput, "json", false, "Output in JSON format")
+	skillsCmd.Flags().BoolVar(&flags.skillsJSON, "json", false, "Output in JSON format")
 	cmd.AddCommand(skillsCmd)
 	titleCmd := &cobra.Command{
 		Use:   "title <agent-file>|<registry-ref> <question>",
@@ -142,7 +153,9 @@ func (f *debugFlags) runDebugToolsetsCommand(cmd *cobra.Command, args []string) 
 	}
 	defer stopToolSets(ctx, t)
 
+	out := cli.NewPrinter(cmd.OutOrStdout())
 	var infos []agentToolsInfo
+
 	for _, name := range t.AgentNames() {
 		agent, err := t.Agent(name)
 		if err != nil {
@@ -156,32 +169,42 @@ func (f *debugFlags) runDebugToolsetsCommand(cmd *cobra.Command, args []string) 
 			continue
 		}
 
-		if agentTools == nil {
-			agentTools = []tools.Tool{}
+		info := agentToolsInfo{Agent: agent.Name(), Tools: make([]toolInfo, 0, len(agentTools))}
+		for _, tool := range agentTools {
+			info.Tools = append(info.Tools, toolInfo{
+				Name:         tool.Name,
+				Category:     tool.Category,
+				Description:  tool.Description,
+				Parameters:   tool.Parameters,
+				Annotations:  tool.Annotations,
+				OutputSchema: tool.OutputSchema,
+			})
 		}
-		infos = append(infos, agentToolsInfo{Agent: agent.Name(), Tools: agentTools})
-	}
 
-	if f.jsonOutput {
-		enc := json.NewEncoder(cmd.OutOrStdout())
-		enc.SetIndent("", "  ")
-		return enc.Encode(infos)
-	}
-
-	out := cli.NewPrinter(cmd.OutOrStdout())
-	for _, info := range infos {
-		if len(info.Tools) == 0 {
-			out.Printf("No tools for %s\n", info.Agent)
+		// Text mode streams per agent so slow toolsets don't hold back earlier results.
+		if f.toolsetsJSON {
+			infos = append(infos, info)
 			continue
 		}
-
-		out.Printf("%d tool(s) for %s:\n", len(info.Tools), info.Agent)
-		for _, tool := range info.Tools {
-			out.Println(" +", tool.Name, "-", tool.Description)
-		}
+		printAgentTools(out, info)
 	}
 
+	if f.toolsetsJSON {
+		return encodeJSON(cmd, infos)
+	}
 	return nil
+}
+
+func printAgentTools(out *cli.Printer, info agentToolsInfo) {
+	if len(info.Tools) == 0 {
+		out.Printf("No tools for %s\n", info.Agent)
+		return
+	}
+
+	out.Printf("%d tool(s) for %s:\n", len(info.Tools), info.Agent)
+	for _, tool := range info.Tools {
+		out.Println(" +", tool.Name, "-", tool.Description)
+	}
 }
 
 func (f *debugFlags) runDebugSkillsCommand(cmd *cobra.Command, args []string) (commandErr error) {
@@ -198,7 +221,9 @@ func (f *debugFlags) runDebugSkillsCommand(cmd *cobra.Command, args []string) (c
 	}
 	defer stopToolSets(ctx, t)
 
+	out := cli.NewPrinter(cmd.OutOrStdout())
 	var infos []agentSkillsInfo
+
 	for _, name := range t.AgentNames() {
 		agent, err := t.Agent(name)
 		if err != nil {
@@ -207,6 +232,7 @@ func (f *debugFlags) runDebugSkillsCommand(cmd *cobra.Command, args []string) (c
 		}
 
 		info := agentSkillsInfo{Agent: agent.Name(), Skills: []skillInfo{}}
+		// The loader creates at most one skills toolset per agent.
 		for _, ts := range agent.ToolSets() {
 			st, ok := tools.As[*skillstool.ToolSet](ts)
 			if !ok {
@@ -222,33 +248,40 @@ func (f *debugFlags) runDebugSkillsCommand(cmd *cobra.Command, args []string) (c
 			}
 			break
 		}
-		infos = append(infos, info)
-	}
 
-	if f.jsonOutput {
-		enc := json.NewEncoder(cmd.OutOrStdout())
-		enc.SetIndent("", "  ")
-		return enc.Encode(infos)
-	}
-
-	out := cli.NewPrinter(cmd.OutOrStdout())
-	for _, info := range infos {
-		if len(info.Skills) == 0 {
-			out.Printf("No skills for %s\n", info.Agent)
+		if f.skillsJSON {
+			infos = append(infos, info)
 			continue
 		}
-
-		out.Printf("%d skill(s) for %s:\n", len(info.Skills), info.Agent)
-		for _, skill := range info.Skills {
-			marker := ""
-			if skill.Forked {
-				marker = " [forked]"
-			}
-			out.Println(" +", skill.Name+marker, "-", skill.Description)
-		}
+		printAgentSkills(out, info)
 	}
 
+	if f.skillsJSON {
+		return encodeJSON(cmd, infos)
+	}
 	return nil
+}
+
+func printAgentSkills(out *cli.Printer, info agentSkillsInfo) {
+	if len(info.Skills) == 0 {
+		out.Printf("No skills for %s\n", info.Agent)
+		return
+	}
+
+	out.Printf("%d skill(s) for %s:\n", len(info.Skills), info.Agent)
+	for _, skill := range info.Skills {
+		marker := ""
+		if skill.Forked {
+			marker = " [forked]"
+		}
+		out.Println(" +", skill.Name+marker, "-", skill.Description)
+	}
+}
+
+func encodeJSON(cmd *cobra.Command, v any) error {
+	enc := json.NewEncoder(cmd.OutOrStdout())
+	enc.SetIndent("", "  ")
+	return enc.Encode(v)
 }
 
 func (f *debugFlags) runDebugTitleCommand(cmd *cobra.Command, args []string) (commandErr error) {

--- a/cmd/root/debug_test.go
+++ b/cmd/root/debug_test.go
@@ -36,3 +36,26 @@ func TestDebug_VisibleInAdvancedGroup(t *testing.T) {
 	assert.False(t, cmd.Hidden)
 	assert.Equal(t, "advanced", cmd.GroupID)
 }
+
+// Non-regression: `toolsets --json` and `skills --json` must not share flag
+// storage, otherwise running one with --json on a reused command tree makes
+// the other emit JSON too.
+func TestDebug_JSONFlagsAreIndependent(t *testing.T) {
+	t.Parallel()
+
+	cmd := newDebugCmd()
+	toolsetsCmd, _, err := cmd.Find([]string{"toolsets"})
+	require.NoError(t, err)
+	skillsCmd, _, err := cmd.Find([]string{"skills"})
+	require.NoError(t, err)
+
+	require.NoError(t, toolsetsCmd.Flags().Set("json", "true"))
+
+	toolsetsJSON, err := toolsetsCmd.Flags().GetBool("json")
+	require.NoError(t, err)
+	skillsJSON, err := skillsCmd.Flags().GetBool("json")
+	require.NoError(t, err)
+
+	assert.True(t, toolsetsJSON)
+	assert.False(t, skillsJSON)
+}

--- a/docs/features/cli/index.md
+++ b/docs/features/cli/index.md
@@ -735,8 +735,8 @@ $ docker agent debug <subcommand> [flags]
 | Subcommand | Description |
 | ---------- | ----------- |
 | `config <agent-file>` | Print the fully-resolved, canonical form of an agent's configuration (defaults applied, references resolved). |
-| `toolsets <agent-file>` | List every toolset each agent in the config exposes, with each tool's name and description. |
-| `skills <agent-file>` | List the skills discovered for each agent, marking forked skills. |
+| `toolsets <agent-file>` | List every toolset each agent in the config exposes, with each tool's name and description. Add `--json` for machine-readable output including each tool's parameters, annotations, and output schema. |
+| `skills <agent-file>` | List the skills discovered for each agent, marking forked skills. Add `--json` for machine-readable output including each skill's source path. |
 | `title <agent-file> <question>` | Generate a session title for `<question>` using the same title-generation path the TUI uses (including any configured `title_model`), without starting a session. See [Session Titles](../sessions/index.md#session-titles). |
 | `auth` | Print parsed Docker authentication info from the token in use (source, subject, issuer, expiry, username/email). Add `--json` for machine-readable output. |
 | `oauth list` | List stored MCP OAuth tokens (resource, scope, expiry, redacted access token). Add `--json` for machine-readable output. |
@@ -747,7 +747,9 @@ $ docker agent debug <subcommand> [flags]
 # Examples
 $ docker agent debug config agent.yaml
 $ docker agent debug toolsets agent.yaml
+$ docker agent debug toolsets agent.yaml --json
 $ docker agent debug skills agent.yaml
+$ docker agent debug skills agent.yaml --json
 $ docker agent debug title agent.yaml "How do I configure a fallback model?"
 $ docker agent debug auth --json
 $ docker agent debug oauth list

--- a/docs/features/cli/index.md
+++ b/docs/features/cli/index.md
@@ -736,7 +736,7 @@ $ docker agent debug <subcommand> [flags]
 | ---------- | ----------- |
 | `config <agent-file>` | Print the fully-resolved, canonical form of an agent's configuration (defaults applied, references resolved). |
 | `toolsets <agent-file>` | List every toolset each agent in the config exposes, with each tool's name and description. Add `--json` for machine-readable output including each tool's parameters, annotations, and output schema. |
-| `skills <agent-file>` | List the skills discovered for each agent, marking forked skills. Add `--json` for machine-readable output including each skill's source path. |
+| `skills <agent-file>` | List the skills discovered for each agent, marking forked skills. Add `--json` for machine-readable output; each skill includes a `path` field when it is backed by a file (omitted for inline skills). |
 | `title <agent-file> <question>` | Generate a session title for `<question>` using the same title-generation path the TUI uses (including any configured `title_model`), without starting a session. See [Session Titles](../sessions/index.md#session-titles). |
 | `auth` | Print parsed Docker authentication info from the token in use (source, subject, issuer, expiry, username/email). Add `--json` for machine-readable output. |
 | `oauth list` | List stored MCP OAuth tokens (resource, scope, expiry, redacted access token). Add `--json` for machine-readable output. |

--- a/e2e/debug_test.go
+++ b/e2e/debug_test.go
@@ -1,10 +1,12 @@
 package e2e_test
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/docker/docker-agent/pkg/skills"
@@ -26,12 +28,104 @@ func TestDebug_Toolsets_Todo(t *testing.T) {
 	require.Equal(t, "2 tool(s) for root:\n + create_todo - Create a new todo item with a description\n + list_todos - List all current todos with their status\n", output)
 }
 
+func TestDebug_Toolsets_JSON_None(t *testing.T) {
+	t.Parallel()
+
+	output := runCLI(t, "debug", "toolsets", "--json", "testdata/no_tools.yaml")
+
+	var got []struct {
+		Agent string            `json:"agent"`
+		Tools []json.RawMessage `json:"tools"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(output), &got))
+	require.Len(t, got, 1)
+	assert.Equal(t, "root", got[0].Agent)
+	assert.NotNil(t, got[0].Tools, "tools must be [] not null")
+	assert.Empty(t, got[0].Tools)
+}
+
+func TestDebug_Toolsets_JSON_Todo(t *testing.T) {
+	t.Parallel()
+
+	output := runCLI(t, "debug", "toolsets", "--json", "testdata/todo_tools.yaml")
+
+	var got []struct {
+		Agent string `json:"agent"`
+		Tools []struct {
+			Name        string          `json:"name"`
+			Description string          `json:"description"`
+			Parameters  json.RawMessage `json:"parameters"`
+		} `json:"tools"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(output), &got))
+	require.Len(t, got, 1)
+	assert.Equal(t, "root", got[0].Agent)
+	require.Len(t, got[0].Tools, 2)
+	assert.Equal(t, "create_todo", got[0].Tools[0].Name)
+	assert.Equal(t, "Create a new todo item with a description", got[0].Tools[0].Description)
+	assert.NotEmpty(t, got[0].Tools[0].Parameters)
+	assert.Equal(t, "list_todos", got[0].Tools[1].Name)
+	assert.Equal(t, "List all current todos with their status", got[0].Tools[1].Description)
+}
+
 func TestDebug_Skills_None(t *testing.T) {
 	t.Parallel()
 
 	output := runCLI(t, "debug", "skills", "testdata/no_tools.yaml")
 
 	require.Equal(t, "No skills for root\n", output)
+}
+
+func TestDebug_Skills_JSON_None(t *testing.T) {
+	t.Parallel()
+
+	output := runCLI(t, "debug", "skills", "--json", "testdata/no_tools.yaml")
+
+	var got []struct {
+		Agent  string            `json:"agent"`
+		Skills []json.RawMessage `json:"skills"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(output), &got))
+	require.Len(t, got, 1)
+	assert.Equal(t, "root", got[0].Agent)
+	assert.NotNil(t, got[0].Skills, "skills must be [] not null")
+	assert.Empty(t, got[0].Skills)
+}
+
+func TestDebug_Skills_JSON_Local(t *testing.T) {
+	kit := t.TempDir()
+	writeSkill(t, filepath.Join(kit, skills.KitSkillsSubdir, "plain"),
+		"---\nname: plain\ndescription: A plain skill\n---\nbody\n")
+	writeSkill(t, filepath.Join(kit, skills.KitSkillsSubdir, "forky"),
+		"---\nname: forky\ndescription: A forked skill\ncontext: fork\n---\nbody\n")
+
+	t.Setenv(skills.KitDirEnv, kit)
+
+	output := runCLI(t, "debug", "skills", "--json", "testdata/skills_local.yaml")
+
+	var got []struct {
+		Agent  string `json:"agent"`
+		Skills []struct {
+			Name        string `json:"name"`
+			Description string `json:"description"`
+			Forked      bool   `json:"forked"`
+			Path        string `json:"path"`
+		} `json:"skills"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(output), &got))
+	require.Len(t, got, 1)
+	assert.Equal(t, "root", got[0].Agent)
+	require.Len(t, got[0].Skills, 2)
+
+	assert.Equal(t, "forky", got[0].Skills[0].Name)
+	assert.Equal(t, "A forked skill", got[0].Skills[0].Description)
+	assert.True(t, got[0].Skills[0].Forked)
+	assert.Equal(t, filepath.Join(kit, skills.KitSkillsSubdir, "forky", "SKILL.md"), got[0].Skills[0].Path)
+
+	assert.Equal(t, "plain", got[0].Skills[1].Name)
+	assert.Equal(t, "A plain skill", got[0].Skills[1].Description)
+	assert.False(t, got[0].Skills[1].Forked)
+	assert.Equal(t, filepath.Join(kit, skills.KitSkillsSubdir, "plain", "SKILL.md"), got[0].Skills[1].Path)
 }
 
 // TestDebug_Skills_Local stages two skills (one regular, one forked) in an

--- a/e2e/debug_test.go
+++ b/e2e/debug_test.go
@@ -2,8 +2,10 @@ package e2e_test
 
 import (
 	"encoding/json"
+	"maps"
 	"os"
 	"path/filepath"
+	"slices"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -50,22 +52,24 @@ func TestDebug_Toolsets_JSON_Todo(t *testing.T) {
 	output := runCLI(t, "debug", "toolsets", "--json", "testdata/todo_tools.yaml")
 
 	var got []struct {
-		Agent string `json:"agent"`
-		Tools []struct {
-			Name        string          `json:"name"`
-			Description string          `json:"description"`
-			Parameters  json.RawMessage `json:"parameters"`
-		} `json:"tools"`
+		Agent string                       `json:"agent"`
+		Tools []map[string]json.RawMessage `json:"tools"`
 	}
 	require.NoError(t, json.Unmarshal([]byte(output), &got))
 	require.Len(t, got, 1)
 	assert.Equal(t, "root", got[0].Agent)
 	require.Len(t, got[0].Tools, 2)
-	assert.Equal(t, "create_todo", got[0].Tools[0].Name)
-	assert.Equal(t, "Create a new todo item with a description", got[0].Tools[0].Description)
-	assert.NotEmpty(t, got[0].Tools[0].Parameters)
-	assert.Equal(t, "list_todos", got[0].Tools[1].Name)
-	assert.Equal(t, "List all current todos with their status", got[0].Tools[1].Description)
+
+	wantKeys := []string{"annotations", "category", "description", "name", "outputSchema", "parameters"}
+	for _, tool := range got[0].Tools {
+		assert.ElementsMatch(t, wantKeys, slices.Collect(maps.Keys(tool)))
+	}
+	assert.JSONEq(t, `"create_todo"`, string(got[0].Tools[0]["name"]))
+	assert.JSONEq(t, `"Create a new todo item with a description"`, string(got[0].Tools[0]["description"]))
+	assert.JSONEq(t, `"todo"`, string(got[0].Tools[0]["category"]))
+	assert.NotEqual(t, "null", string(got[0].Tools[0]["parameters"]))
+	assert.JSONEq(t, `"list_todos"`, string(got[0].Tools[1]["name"]))
+	assert.JSONEq(t, `"List all current todos with their status"`, string(got[0].Tools[1]["description"]))
 }
 
 func TestDebug_Skills_None(t *testing.T) {


### PR DESCRIPTION
The `debug toolsets` and `debug skills` subcommands have no machine-readable output path, making them awkward to consume from scripts or other tooling. Every peer subcommand (`debug auth`, `debug oauth list`, `doctor`) already accepts a `--json` flag, so this adds the same capability to the two remaining debug commands.

`debug toolsets --json` emits a JSON array of objects with `agent` and `tools` fields, where each tool entry carries `name`, `category`, `description`, `parameters`, `annotations`, and `outputSchema`. The shape is defined by an explicit `toolInfo` DTO rather than serialising `tools.Tool` directly, keeping the JSON contract stable and free of internal fields. `debug skills --json` emits a JSON array with `agent` and `skills` fields; each skill has `name`, `description`, and `forked`, with `path` included only for file-backed skills. Empty lists serialise as `[]` rather than `null`.

```json
// docker agent debug toolsets --json agent.yaml
[{"agent":"my-agent","tools":[{"name":"bash","category":"shell","description":"Run a bash command","parameters":{"type":"object","properties":{"command":{"type":"string"}}},"annotations":null,"outputSchema":null}]}]
```

```json
// docker agent debug skills --json agent.yaml
[{"agent":"my-agent","skills":[{"name":"commit","description":"Commit local changes","forked":true}]}]
```

Text output is unchanged and still streams per agent. The two `--json` flags live on separate cobra commands with separate fields so they cannot share state when the cobra tree is reused — a unit test (`TestDebug_JSONFlagsAreIndependent`) verifies this. E2E tests cover both subcommands for empty and populated cases, including an assertion on the exact set of JSON keys returned by `toolsets --json`.