### PR TITLE
feat(debug): accept positional flavors on `debug config`

### DIFF
--- a/cmd/root/debug.go
+++ b/cmd/root/debug.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"slices"
 
 	"github.com/goccy/go-yaml"
 	"github.com/spf13/cobra"
@@ -65,10 +66,13 @@ func newDebugCmd() *cobra.Command {
 	}
 
 	cmd.AddCommand(&cobra.Command{
-		Use:   "config <agent-file>|<registry-ref>",
+		Use:   "config <agent-file>|<registry-ref> [flavor...]",
 		Short: "Print the canonical form of an agent's configuration file",
-		Args:  cobra.ExactArgs(1),
-		RunE:  flags.runDebugConfigCommand,
+		Long: "Print the canonical form of an agent's configuration file.\n\n" +
+			"When flavors are given (positionally or with --flavor), they are applied in order and the\n" +
+			"resolved config is printed without its 'flavors' section, since the patches are already baked in.",
+		Args: cobra.MinimumNArgs(1),
+		RunE: flags.runDebugConfigCommand,
 	})
 	toolsetsCmd := &cobra.Command{
 		Use:   "toolsets <agent-file>|<registry-ref>",
@@ -131,9 +135,16 @@ func (f *debugFlags) runDebugConfigCommand(cmd *cobra.Command, args []string) (c
 		return err
 	}
 
-	cfg, err := config.Load(cmd.Context(), agentSource, config.WithFlavors(f.runConfig.Flavors...))
+	flavors := append(slices.Clone(f.runConfig.Flavors), args[1:]...)
+	cfg, err := config.Load(cmd.Context(), agentSource, config.WithFlavors(flavors...))
 	if err != nil {
 		return err
+	}
+
+	// Once resolved, re-applying a flavor to the output would double-apply
+	// `+`/`-` patches, so the section is dropped.
+	if len(flavors) > 0 {
+		cfg.Flavors = nil
 	}
 
 	return yaml.NewEncoder(cmd.OutOrStdout()).Encode(cfg)

--- a/cmd/root/debug_test.go
+++ b/cmd/root/debug_test.go
@@ -2,10 +2,16 @@ package root
 
 import (
 	"bytes"
+	"os"
+	"path/filepath"
 	"testing"
 
+	"github.com/goccy/go-yaml"
+	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/docker/docker-agent/pkg/config/latest"
 )
 
 // Non-regression for docker/docker-agent#3803: the debug command must be
@@ -58,4 +64,87 @@ func TestDebug_JSONFlagsAreIndependent(t *testing.T) {
 
 	assert.True(t, toolsetsJSON)
 	assert.False(t, skillsJSON)
+}
+
+const flavoredConfig = `
+agents:
+  root:
+    model: claude
+    instruction: Be helpful.
+    toolsets:
+      - type: think
+models:
+  claude:
+    provider: anthropic
+    model: claude-sonnet-5
+flavors:
+  cheap:
+    models:
+      claude:
+        model: claude-3-5-haiku-latest
+  with-shell:
+    agents:
+      root:
+        toolsets+:
+          - type: shell
+`
+
+func runDebugConfig(t *testing.T, flags *debugFlags, args ...string) latest.Config {
+	t.Helper()
+
+	path := filepath.Join(t.TempDir(), "agent.yaml")
+	require.NoError(t, os.WriteFile(path, []byte(flavoredConfig), 0o600))
+
+	var out bytes.Buffer
+	cmd := &cobra.Command{}
+	cmd.SetOut(&out)
+	cmd.SetContext(t.Context())
+
+	require.NoError(t, flags.runDebugConfigCommand(cmd, append([]string{path}, args...)))
+
+	var cfg latest.Config
+	require.NoError(t, yaml.Unmarshal(out.Bytes(), &cfg))
+	return cfg
+}
+
+func TestDebugConfig_NoFlavorsKeepsSection(t *testing.T) {
+	t.Parallel()
+
+	cfg := runDebugConfig(t, &debugFlags{})
+
+	assert.Equal(t, "claude-sonnet-5", cfg.Models["claude"].Model)
+	assert.Len(t, cfg.Agents[0].Toolsets, 1)
+	assert.Len(t, cfg.Flavors, 2)
+}
+
+func TestDebugConfig_PositionalFlavorsResolve(t *testing.T) {
+	t.Parallel()
+
+	cfg := runDebugConfig(t, &debugFlags{}, "cheap", "with-shell")
+
+	assert.Equal(t, "claude-3-5-haiku-latest", cfg.Models["claude"].Model)
+	require.Len(t, cfg.Agents[0].Toolsets, 2)
+	assert.Equal(t, "shell", cfg.Agents[0].Toolsets[1].Type)
+	assert.Empty(t, cfg.Flavors, "resolved config must not carry the flavors section")
+}
+
+func TestDebugConfig_FlagAndPositionalFlavorsCombine(t *testing.T) {
+	t.Parallel()
+
+	flags := &debugFlags{}
+	flags.runConfig.Flavors = []string{"cheap"}
+	cfg := runDebugConfig(t, flags, "with-shell")
+
+	assert.Equal(t, "claude-3-5-haiku-latest", cfg.Models["claude"].Model)
+	assert.Len(t, cfg.Agents[0].Toolsets, 2)
+	assert.Empty(t, cfg.Flavors)
+}
+
+func TestDebugConfig_UnknownFlavorIsIgnored(t *testing.T) {
+	t.Parallel()
+
+	cfg := runDebugConfig(t, &debugFlags{}, "nope")
+
+	assert.Equal(t, "claude-sonnet-5", cfg.Models["claude"].Model)
+	assert.Empty(t, cfg.Flavors)
 }

--- a/docs/configuration/flavors/index.md
+++ b/docs/configuration/flavors/index.md
@@ -166,12 +166,16 @@ flavors:
 
 ## Inspecting the Result
 
-`docker agent debug config` prints the config exactly as the runtime sees it,
-flavors applied:
+`docker agent debug config` prints the config exactly as the runtime sees it.
+Pass flavors after the config to print the resolved config, with the patches
+applied and the `flavors` section dropped:
 
 ```bash
-$ docker agent debug config agent.yaml --flavor cheap --flavor with-shell
+$ docker agent debug config agent.yaml cheap with-shell
 ```
+
+The repeatable `--flavor` flag works too, and combines with positional
+flavors (flag values are applied first).
 
 ## HCL
 

--- a/docs/features/cli/index.md
+++ b/docs/features/cli/index.md
@@ -734,7 +734,7 @@ $ docker agent debug <subcommand> [flags]
 
 | Subcommand | Description |
 | ---------- | ----------- |
-| `config <agent-file>` | Print the fully-resolved, canonical form of an agent's configuration (defaults applied, references resolved). |
+| `config <agent-file> [flavor...]` | Print the fully-resolved, canonical form of an agent's configuration (defaults applied, references resolved). When [flavors](../../configuration/flavors/index.md) are given they are applied in order and the `flavors` section is dropped from the output. |
 | `toolsets <agent-file>` | List every toolset each agent in the config exposes, with each tool's name and description. Add `--json` for machine-readable output including each tool's parameters, annotations, and output schema. |
 | `skills <agent-file>` | List the skills discovered for each agent, marking forked skills. Add `--json` for machine-readable output; each skill includes a `path` field when it is backed by a file (omitted for inline skills). |
 | `title <agent-file> <question>` | Generate a session title for `<question>` using the same title-generation path the TUI uses (including any configured `title_model`), without starting a session. See [Session Titles](../sessions/index.md#session-titles). |
@@ -746,6 +746,7 @@ $ docker agent debug <subcommand> [flags]
 ```bash
 # Examples
 $ docker agent debug config agent.yaml
+$ docker agent debug config agent.yaml cheap with-shell
 $ docker agent debug toolsets agent.yaml
 $ docker agent debug toolsets agent.yaml --json
 $ docker agent debug skills agent.yaml


### PR DESCRIPTION
Inspecting a resolved config — after one or more flavors have been applied — currently requires writing a small wrapper YAML or manually editing the file. This is tedious when you just want to see what `debug config` would look like with a particular flavor active.

`debug config` now accepts flavor names as positional arguments after the agent file or registry ref: `docker agent debug config examples/flavors.yaml cheap with-shell`. Any positional flavors are appended after values supplied via `--flavor`, so both forms can be combined freely. When at least one flavor is provided (by either means), the command prints the fully resolved config — patches applied and the `flavors` section omitted, since re-applying patches to an already-resolved document would produce incorrect results. Without flavors the output is unchanged.

No breaking changes; the existing `--flavor` flag and the no-flavor path both behave exactly as before.