### PR TITLE
docs: auto-update for merged PRs (2026-09-05)

### DIFF
--- a/docs/configuration/overview/index.md
+++ b/docs/configuration/overview/index.md
@@ -19,7 +19,7 @@ A Docker Agent config has these main sections:
 
 ```bash
 # 1. Version — configuration schema version (optional but recommended)
-version: 15
+version: 16
 
 # 2. Metadata — optional agent metadata for distribution
 metadata:
@@ -298,10 +298,10 @@ For YAML editor autocompletion and validation, use the [Docker Agent JSON Schema
 
 ## Config Versioning
 
-Docker Agent configs are versioned. The current version is `15`. Add the version at the top of your config:
+Docker Agent configs are versioned. The current version is `16`. Add the version at the top of your config:
 
 ```yaml
-version: 15
+version: 16
 
 agents:
   root:


### PR DESCRIPTION
Keeps `/docs` in sync with code merged into `main` in the last 36 hours.

## Changes

- **docs/configuration/overview/index.md**: bumped the documented config schema version from `15` to `16` (both the "Config Versioning" section's "current version" statement and the version-field example), reflecting that config version 15 was frozen and version 16 is now latest.
  - Source: docker/docker-agent#4170

## Review notes

Every other PR merged in the last 36 hours whose code changes touched user-facing behavior already carried its own doc updates in the same PR (e.g. #4173, #4172, #4169, #4168, #4166, #4151, #4150, #4149, #4145). Those were reviewed for accuracy and completeness against their source diffs and found up to date — no further changes needed. Internal/bugfix-only PRs (#4171, #4167 changelog-only; #4165, #4163, #4161, #4159, #4158, #4157, #4155, #4154, #4153, #4152, #4147) do not change any currently-documented behavior, so `/docs` was left untouched for those.