### PR TITLE
fix(session): preserve the starred flag in AddSession

### DIFF
--- a/pkg/session/store.go
+++ b/pkg/session/store.go
@@ -626,11 +626,6 @@ func (s *SQLiteSessionStore) AddSession(ctx context.Context, session *Session) e
 		return ErrEmptyID
 	}
 
-	fields, err := sessionPersistedFieldsOf(session)
-	if err != nil {
-		return err
-	}
-
 	// Use a transaction to insert session and its items
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
@@ -638,17 +633,7 @@ func (s *SQLiteSessionStore) AddSession(ctx context.Context, session *Session) e
 	}
 	defer func() { _ = tx.Rollback() }()
 
-	_, err = tx.ExecContext(ctx,
-		`INSERT INTO sessions (
-			id, origin, tools_approved, safety_policy, input_tokens, output_tokens, title, cost, send_user_message,
-			max_iterations, working_dir, created_at, permissions, agent_model_overrides,
-			custom_models_used, thinking, parent_id, instruction_context, attributes
-		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-		session.ID, session.Origin, session.ToolsApproved, string(session.SafetyPolicy), session.InputTokens, session.OutputTokens, session.Title,
-		session.Cost, session.SendUserMessage, session.MaxIterations, session.WorkingDir,
-		session.CreatedAt.Format(time.RFC3339), fields.PermissionsJSON, fields.AgentModelOverridesJSON,
-		fields.CustomModelsUsedJSON, false, fields.ParentID, fields.InstructionContextJSON, fields.AttributesJSON)
-	if err != nil {
+	if err := s.addSessionTx(ctx, tx, session); err != nil {
 		return err
 	}
 

--- a/pkg/session/store_test.go
+++ b/pkg/session/store_test.go
@@ -1220,3 +1220,17 @@ func TestAddSessionTerminationRoundTrip(t *testing.T) {
 	// Termination markers are not conversation messages.
 	assert.Len(t, retrieved.GetAllMessages(), 2)
 }
+
+func TestAddSession_PreservesStarred(t *testing.T) {
+	store, err := newSQLiteStoreForTest(t, filepath.Join(t.TempDir(), "sessions.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, store.Close()) })
+
+	sess := New(WithID("starred-session"))
+	sess.Starred = true
+	require.NoError(t, store.AddSession(t.Context(), sess))
+
+	loaded, err := store.GetSession(t.Context(), "starred-session")
+	require.NoError(t, err)
+	assert.True(t, loaded.Starred)
+}


### PR DESCRIPTION
### What

`SQLiteSessionStore.AddSession` built its own `INSERT INTO sessions (...)` that omitted
the `starred` column, so the flag was silently dropped on insert. `UpdateSession`,
`addSessionTx` and `PersistCompaction` all set it.

The user-visible effect is on fork: `copySessionMetadata` copies `Starred` to the new
session, and `ForkSession` persists it through `AddSession` — so **forking a starred
session produces an unstarred fork**. Reachable from `POST /api/sessions/:id/fork` and
from the TUI fork path. The in-memory store keeps the flag, so the two backends disagree.

### Why this shape

`AddSession`'s INSERT was otherwise byte-for-byte identical to `addSessionTx`, which
already inserts `starred` correctly. Rather than adding the missing column to a second
list that can drift again, `AddSession` now calls `addSessionTx`. Net -1 line.

This is not a regression: the column list has been missing `starred` since the starring
feature was added in `875b4dd6` (Jan 2026), and it survived both `345b8aeed`
(`refactor(session): collapse duplicated session marshalling/SQL`) and `93b1673b1`
(`refactor(session): scan SQL columns into native Go types`) untouched.

### Test

`TestAddSession_PreservesStarred` fails on `main` (`Should be true`) and passes with the
change. `./pkg/session/...`, `./pkg/server/...`, `./pkg/acp/...`, `./pkg/evaluation/...`
and `./pkg/tui/...` all pass; `go vet` is clean.

### Context

Noticed while mapping the session schema for #4181 (pluggable persistent session stores).
Happy to fold this into that work instead if you would rather keep it together.
