### PR TITLE
fix: harden concurrent and external resource handling

### DIFF
--- a/cmd/root/pull.go
+++ b/cmd/root/pull.go
@@ -71,13 +71,17 @@ func (f *pullFlags) runPullCommand(cmd *cobra.Command, args []string) (commandEr
 	if err != nil {
 		return fmt.Errorf("failed to open content store: %w", err)
 	}
-	yamlFile, err := store.GetArtifact(registryRef)
+	storeKey, err := remote.FullyQualifiedReference(registryRef)
+	if err != nil {
+		return fmt.Errorf("failed to normalize registry reference: %w", err)
+	}
+	yamlFile, err := store.GetArtifact(storeKey)
 	if err != nil {
 		return fmt.Errorf("failed to get agent yaml: %w", err)
 	}
 
 	if key != nil {
-		metadata, err := store.GetArtifactMetadata(registryRef)
+		metadata, err := store.GetArtifactMetadata(storeKey)
 		if err != nil {
 			return fmt.Errorf("failed to get artifact metadata: %w", err)
 		}

--- a/cmd/root/push.go
+++ b/cmd/root/push.go
@@ -126,7 +126,12 @@ func (f *pushFlags) runPushCommand(cmd *cobra.Command, args []string) (commandEr
 		return fmt.Errorf("resolving agent file: %w", err)
 	}
 
-	_, err = oci.PackageFileAsOCIToStore(ctx, agentSource, tag, store, packageOpts...)
+	storeKey, err := remote.FullyQualifiedReference(tag)
+	if err != nil {
+		return fmt.Errorf("normalizing registry reference: %w", err)
+	}
+
+	_, err = oci.PackageFileAsOCIToStore(ctx, agentSource, storeKey, store, packageOpts...)
 	if err != nil {
 		return fmt.Errorf("failed to build artifact: %w", err)
 	}

--- a/docs/concepts/distribution/index.md
+++ b/docs/concepts/distribution/index.md
@@ -181,3 +181,5 @@ $ docker agent run http://127.0.0.1:8080/agent.yaml
 ```
 
 This is useful for iterating on agent configs served from a local dev server before pushing to a registry. Both `localhost` and `127.0.0.1` addresses are supported with plain `http://` URLs.
+
+Agent configurations loaded from HTTP(S) URLs or OCI artifacts are limited to 32 MiB after decompression.

--- a/examples/golibrary/renderer/main.go
+++ b/examples/golibrary/renderer/main.go
@@ -141,7 +141,7 @@ func run(ctx context.Context) error {
 
 	// Attach the in-process MCP server as a remote toolset named "github". Its
 	// "search_repositories" tool is therefore exposed as "github_search_repositories".
-	githubTools := mcptools.NewRemoteToolset("github", mcpHTTP.URL, "streamable", nil, nil)
+	githubTools := mcptools.NewRemoteToolsetWithAllowPrivateIPs("github", mcpHTTP.URL, "streamable", nil, nil, true)
 
 	llm, err := gemini.NewClient(ctx, &latest.ModelConfig{
 		Provider: "google",

--- a/examples/golibrary/renderer/main_test.go
+++ b/examples/golibrary/renderer/main_test.go
@@ -16,7 +16,7 @@ func TestEmbeddedMCPExposesPrefixedTool(t *testing.T) {
 	srv := startMCPServer()
 	defer srv.Close()
 
-	ts := tools.NewStartable(mcptools.NewRemoteToolset("github", srv.URL, "streamable", nil, nil))
+	ts := tools.NewStartable(mcptools.NewRemoteToolsetWithAllowPrivateIPs("github", srv.URL, "streamable", nil, nil, true))
 	require.NoError(t, ts.Start(ctx))
 	defer func() { _ = ts.Stop(ctx) }()
 

--- a/pkg/acp/agent.go
+++ b/pkg/acp/agent.go
@@ -48,9 +48,114 @@ type Session struct {
 	id             string
 	sess           *session.Session
 	rt             runtime.Runtime
-	cancel         context.CancelFunc
 	workingDir     string
 	additionalDirs []string
+
+	mu sync.Mutex
+
+	turns      chan struct{}
+	cancel     context.CancelFunc
+	generation uint64
+	closed     bool
+}
+
+var errSessionClosed = errors.New("ACP session closed")
+
+func (s *Session) cancelTurn() {
+	s.mu.Lock()
+	cancel := s.cancel
+	s.mu.Unlock()
+	if cancel != nil {
+		cancel()
+	}
+}
+
+func (s *Session) close() {
+	s.mu.Lock()
+	s.closed = true
+	cancel := s.cancel
+	s.mu.Unlock()
+	if cancel != nil {
+		cancel()
+	}
+}
+
+func (s *Session) startTurn(ctx context.Context) (context.Context, func(), error) {
+	if err := ctx.Err(); err != nil {
+		return nil, nil, err
+	}
+
+	turnCtx, cancel := context.WithCancel(ctx)
+	s.mu.Lock()
+	if s.closed {
+		s.mu.Unlock()
+		cancel()
+		return nil, nil, errSessionClosed
+	}
+	if err := ctx.Err(); err != nil {
+		s.mu.Unlock()
+		cancel()
+		return nil, nil, err
+	}
+	if s.turns == nil {
+		s.turns = make(chan struct{}, 1)
+		s.turns <- struct{}{}
+	}
+	turns := s.turns
+	previous := s.cancel
+	s.generation++
+	generation := s.generation
+	s.cancel = cancel
+	s.mu.Unlock()
+
+	if previous != nil {
+		previous()
+	}
+
+	select {
+	case <-turnCtx.Done():
+		s.clearTurn(generation, cancel)
+		s.mu.Lock()
+		closed := s.closed
+		s.mu.Unlock()
+		if closed {
+			return nil, nil, errSessionClosed
+		}
+		return nil, nil, turnCtx.Err()
+	case <-turns:
+	}
+
+	s.mu.Lock()
+	closed := s.closed
+	current := s.generation == generation
+	err := turnCtx.Err()
+	s.mu.Unlock()
+	if closed || !current || err != nil {
+		turns <- struct{}{}
+		s.clearTurn(generation, cancel)
+		if closed {
+			return nil, nil, errSessionClosed
+		}
+		if err != nil {
+			return nil, nil, err
+		}
+		return nil, nil, context.Canceled
+	}
+
+	finish := func() {
+		turns <- struct{}{}
+		s.clearTurn(generation, cancel)
+	}
+	return turnCtx, finish, nil
+}
+
+func (s *Session) clearTurn(generation uint64, cancel context.CancelFunc) {
+	cancel()
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.generation == generation {
+		s.cancel = nil
+	}
 }
 
 // NewAgent creates a new ACP agent.
@@ -263,8 +368,8 @@ func (a *Agent) CloseSession(_ context.Context, params acp.CloseSessionRequest) 
 	}
 	a.mu.Unlock()
 
-	if ok && acpSess != nil && acpSess.cancel != nil {
-		acpSess.cancel()
+	if ok && acpSess != nil {
+		acpSess.close()
 	}
 
 	return acp.CloseSessionResponse{}, nil
@@ -373,8 +478,8 @@ func (a *Agent) Cancel(_ context.Context, params acp.CancelNotification) error {
 	acpSess, ok := a.sessions[sid]
 	a.mu.Unlock()
 
-	if ok && acpSess != nil && acpSess.cancel != nil {
-		acpSess.cancel()
+	if ok && acpSess != nil {
+		acpSess.cancelTurn()
 	}
 
 	return nil
@@ -393,22 +498,19 @@ func (a *Agent) Prompt(ctx context.Context, params acp.PromptRequest) (acp.Promp
 		return acp.PromptResponse{}, fmt.Errorf("session %s not found", sid)
 	}
 
-	// Cancel any previous turn
-	a.mu.Lock()
-	if acpSess.cancel != nil {
-		prev := acpSess.cancel
-		a.mu.Unlock()
-		prev()
-	} else {
-		a.mu.Unlock()
+	turnCtx, finish, err := acpSess.startTurn(ctx)
+	if err != nil {
+		if errors.Is(err, errSessionClosed) {
+			return acp.PromptResponse{}, fmt.Errorf("session %s not found", sid)
+		}
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			return acp.PromptResponse{StopReason: acp.StopReasonCancelled}, nil
+		}
+		return acp.PromptResponse{}, err
 	}
+	defer finish()
 
-	turnCtx, cancel := context.WithCancel(ctx)
-	a.mu.Lock()
-	acpSess.cancel = cancel
-	a.mu.Unlock()
-
-	userMsg := a.buildUserMessage(ctx, sid, params.Prompt)
+	userMsg := a.buildUserMessage(turnCtx, sid, params.Prompt)
 	if userMsg != nil && (userMsg.Message.Content != "" || len(userMsg.Message.MultiContent) > 0) {
 		acpSess.sess.AddMessage(userMsg)
 	}
@@ -419,10 +521,6 @@ func (a *Agent) Prompt(ctx context.Context, params acp.PromptRequest) (acp.Promp
 		}
 		return acp.PromptResponse{}, err
 	}
-
-	a.mu.Lock()
-	defer a.mu.Unlock()
-	acpSess.cancel = nil
 
 	return acp.PromptResponse{StopReason: acp.StopReasonEndTurn}, nil
 }
@@ -703,6 +801,9 @@ func (a *Agent) runAgent(ctx context.Context, acpSess *Session) error {
 		}
 	}
 
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/pkg/acp/runagent_test.go
+++ b/pkg/acp/runagent_test.go
@@ -11,6 +11,7 @@ import (
 	"slices"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -18,6 +19,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/docker/docker-agent/pkg/chat"
 	"github.com/docker/docker-agent/pkg/effort"
 	"github.com/docker/docker-agent/pkg/runtime"
 	"github.com/docker/docker-agent/pkg/session"
@@ -130,6 +132,186 @@ func (f *fakeRuntime) OnBackgroundEvent(func(runtime.Event))                 {}
 func (f *fakeRuntime) OnElicitationRequest(func(runtime.Event))              {}
 func (f *fakeRuntime) Close() error                                          { return nil }
 
+type blockingPromptRuntime struct {
+	fakeRuntime
+
+	started       chan int
+	firstCanceled chan struct{}
+	releaseFirst  chan struct{}
+	calls         atomic.Int32
+	active        atomic.Int32
+	max           atomic.Int32
+}
+
+func (r *blockingPromptRuntime) RunStream(ctx context.Context, _ *session.Session) <-chan runtime.Event {
+	call := int(r.calls.Add(1))
+	current := int(r.active.Add(1))
+	for {
+		old := r.max.Load()
+		if int32(current) <= old || r.max.CompareAndSwap(old, int32(current)) {
+			break
+		}
+	}
+	r.started <- call
+	ch := make(chan runtime.Event)
+	go func() {
+		defer close(ch)
+		defer r.active.Add(-1)
+		<-ctx.Done()
+		if call == 1 && r.releaseFirst != nil {
+			close(r.firstCanceled)
+			<-r.releaseFirst
+		}
+	}()
+	return ch
+}
+
+func newPromptTestAgent(t *testing.T, rt runtime.Runtime) (*Agent, *Session, *peerResponder) {
+	t.Helper()
+	fixture := newRunAgentFixture(t, &fakeRuntime{}, &captureWriter{})
+	fixture.agent.sessions = make(map[string]*Session)
+	sess := &Session{id: testSessionID, sess: session.New(), rt: rt}
+	fixture.agent.sessions[testSessionID] = sess
+	return fixture.agent, sess, fixture.peer
+}
+
+func promptRequest(text string) acpsdk.PromptRequest {
+	return acpsdk.PromptRequest{
+		SessionId: acpsdk.SessionId(testSessionID),
+		Prompt:    []acpsdk.ContentBlock{acpsdk.TextBlock(text)},
+	}
+}
+
+func TestPromptReplacementCancelsQueuedTurnWithoutSideEffects(t *testing.T) {
+	t.Parallel()
+
+	rt := &blockingPromptRuntime{
+		started:       make(chan int, 2),
+		firstCanceled: make(chan struct{}),
+		releaseFirst:  make(chan struct{}),
+	}
+	agent, sess, peer := newPromptTestAgent(t, rt)
+	agent.clientFS.ReadTextFile = true
+	peer.readTextFile = func(req acpsdk.ReadTextFileRequest) acpsdk.ReadTextFileResponse {
+		return acpsdk.ReadTextFileResponse{Content: "resource contents"}
+	}
+
+	firstDone := promptAsync(agent, t.Context(), promptRequest("first"))
+	require.Equal(t, 1, <-rt.started)
+
+	second := promptRequest("second")
+	second.Prompt = []acpsdk.ContentBlock{{ResourceLink: &acpsdk.ContentBlockResourceLink{
+		Type: "resource_link", Name: "second.txt", Uri: "second.txt",
+	}}}
+	secondDone := promptAsync(agent, t.Context(), second)
+	<-rt.firstCanceled
+
+	thirdDone := promptAsync(agent, t.Context(), promptRequest("third"))
+	secondResult := <-secondDone
+	require.NoError(t, secondResult.err)
+	assert.Equal(t, acpsdk.StopReasonCancelled, secondResult.response.StopReason)
+
+	assert.Equal(t, int32(1), rt.calls.Load())
+	assert.Empty(t, peer.recordedReadRequests())
+	assert.Equal(t, []string{"first"}, sessionUserMessages(sess.sess))
+
+	close(rt.releaseFirst)
+	firstResult := <-firstDone
+	require.NoError(t, firstResult.err)
+	assert.Equal(t, acpsdk.StopReasonCancelled, firstResult.response.StopReason)
+	require.Equal(t, 2, <-rt.started)
+
+	require.NoError(t, agent.Cancel(t.Context(), acpsdk.CancelNotification{SessionId: testSessionID}))
+	thirdResult := <-thirdDone
+	require.NoError(t, thirdResult.err)
+	assert.Equal(t, acpsdk.StopReasonCancelled, thirdResult.response.StopReason)
+	assert.Equal(t, int32(1), rt.max.Load())
+	assert.Equal(t, []string{"first", "third"}, sessionUserMessages(sess.sess))
+}
+
+func TestPromptRejectsCanceledContextBeforeAdmission(t *testing.T) {
+	t.Parallel()
+
+	rt := &blockingPromptRuntime{started: make(chan int, 1)}
+	agent, sess, _ := newPromptTestAgent(t, rt)
+
+	firstDone := promptAsync(agent, t.Context(), promptRequest("first"))
+	<-rt.started
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+	result := <-promptAsync(agent, ctx, promptRequest("canceled"))
+	require.NoError(t, result.err)
+	assert.Equal(t, acpsdk.StopReasonCancelled, result.response.StopReason)
+	assert.Equal(t, int32(1), rt.calls.Load())
+	assert.Equal(t, []string{"first"}, sessionUserMessages(sess.sess))
+
+	select {
+	case result := <-firstDone:
+		t.Fatalf("canceled prompt superseded the active turn: %+v", result)
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	require.NoError(t, agent.Cancel(t.Context(), acpsdk.CancelNotification{SessionId: testSessionID}))
+	firstResult := <-firstDone
+	require.NoError(t, firstResult.err)
+	assert.Equal(t, acpsdk.StopReasonCancelled, firstResult.response.StopReason)
+}
+
+func TestCloseSessionCancelsActiveAndQueuedPrompts(t *testing.T) {
+	t.Parallel()
+
+	rt := &blockingPromptRuntime{
+		started:       make(chan int, 1),
+		firstCanceled: make(chan struct{}),
+		releaseFirst:  make(chan struct{}),
+	}
+	agent, sess, _ := newPromptTestAgent(t, rt)
+
+	firstDone := promptAsync(agent, t.Context(), promptRequest("first"))
+	<-rt.started
+	secondDone := promptAsync(agent, t.Context(), promptRequest("second"))
+	<-rt.firstCanceled
+
+	_, err := agent.CloseSession(t.Context(), acpsdk.CloseSessionRequest{SessionId: testSessionID})
+	require.NoError(t, err)
+	secondResult := <-secondDone
+	require.ErrorContains(t, secondResult.err, "not found")
+	assert.Empty(t, secondResult.response.StopReason)
+	assert.Equal(t, int32(1), rt.calls.Load())
+	assert.Equal(t, []string{"first"}, sessionUserMessages(sess.sess))
+
+	close(rt.releaseFirst)
+	firstResult := <-firstDone
+	require.NoError(t, firstResult.err)
+	assert.Equal(t, acpsdk.StopReasonCancelled, firstResult.response.StopReason)
+	assert.Empty(t, agent.sessions)
+}
+
+type promptResult struct {
+	response acpsdk.PromptResponse
+	err      error
+}
+
+func promptAsync(agent *Agent, ctx context.Context, req acpsdk.PromptRequest) <-chan promptResult {
+	done := make(chan promptResult, 1)
+	go func() {
+		response, err := agent.Prompt(ctx, req)
+		done <- promptResult{response: response, err: err}
+	}()
+	return done
+}
+
+func sessionUserMessages(sess *session.Session) []string {
+	var messages []string
+	for _, item := range sess.GetAllMessages() {
+		if item.Message.Role == chat.MessageRoleUser {
+			messages = append(messages, item.Message.Content)
+		}
+	}
+	return messages
+}
+
 // captureWriter is a goroutine-safe sink for the connection's outbound
 // line-delimited JSON-RPC messages. failOn, when set, is called with the
 // 1-based write index and can inject write failures.
@@ -166,20 +348,18 @@ func (w *captureWriter) lines() []string {
 }
 
 // peerResponder plays the ACP client side of the connection's outbound
-// stream. Notifications pass through to the capture writer unchanged, while
-// session/request_permission requests are decoded, recorded, and answered on
-// the peer pipe with a JSON-RPC response echoing the request ID. respond
-// picks the result the client answers with, letting tests choose the
-// permission outcome; any other request fails the test immediately instead
-// of deadlocking the sender.
+// stream. Notifications pass through to the capture writer; supported requests
+// are decoded, recorded, and answered on the peer pipe.
 type peerResponder struct {
-	t       *testing.T
-	out     io.Writer // outbound notifications, usually a captureWriter
-	peer    io.Writer // write half of the connection's inbound peer pipe
-	respond func(req acpsdk.RequestPermissionRequest) any
+	t            *testing.T
+	out          io.Writer // outbound notifications, usually a captureWriter
+	peer         io.Writer // write half of the connection's inbound peer pipe
+	respond      func(req acpsdk.RequestPermissionRequest) any
+	readTextFile func(req acpsdk.ReadTextFileRequest) acpsdk.ReadTextFileResponse
 
-	mu       sync.Mutex
-	requests []acpsdk.RequestPermissionRequest
+	mu           sync.Mutex
+	requests     []acpsdk.RequestPermissionRequest
+	readRequests []acpsdk.ReadTextFileRequest
 }
 
 // Write receives exactly one line-delimited JSON-RPC message per call: the
@@ -197,6 +377,21 @@ func (p *peerResponder) Write(b []byte) (int, error) {
 	}
 	if len(msg.ID) == 0 {
 		return p.out.Write(b)
+	}
+	if msg.Method == acpsdk.ClientMethodFsReadTextFile && p.readTextFile != nil {
+		var req acpsdk.ReadTextFileRequest
+		if err := json.Unmarshal(msg.Params, &req); err != nil {
+			p.t.Errorf("peer failed to decode %s params: %v", msg.Method, err)
+			return 0, err
+		}
+		p.mu.Lock()
+		p.readRequests = append(p.readRequests, req)
+		p.mu.Unlock()
+		if err := p.reply(msg.ID, p.readTextFile(req)); err != nil {
+			p.t.Errorf("peer failed to answer %s: %v", msg.Method, err)
+			return 0, err
+		}
+		return len(b), nil
 	}
 	if msg.Method != "session/request_permission" || p.respond == nil {
 		err := fmt.Errorf("peer cannot answer JSON-RPC request %q (id %s)", msg.Method, msg.ID)
@@ -244,6 +439,12 @@ func (p *peerResponder) recordedRequests() []acpsdk.RequestPermissionRequest {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	return slices.Clone(p.requests)
+}
+
+func (p *peerResponder) recordedReadRequests() []acpsdk.ReadTextFileRequest {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return slices.Clone(p.readRequests)
 }
 
 // permissionSelected is the JSON-RPC result for a user picking optionID.

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -554,24 +554,28 @@ func (a *App) EmitStartupInfo(ctx context.Context, events chan runtime.Event) {
 // Run one agent loop
 func (a *App) Run(ctx context.Context, cancel context.CancelFunc, message string, attachments []messages.Attachment) {
 	a.cancel = cancel
+	sess := a.session
 
 	// If this is the first message and no title exists, start local title generation
-	if a.session.TitleSnapshot() == "" && a.titleGen != nil {
+	if sess.TitleSnapshot() == "" && a.titleGen != nil {
 		a.titleGenerating.Store(true)
-		go a.generateTitle(ctx, []string{message})
+		go a.generateTitle(ctx, sess, []string{message})
 	}
 
 	go func() {
 		release := a.acquireStreamGuard()
 		defer release()
+		if ctx.Err() != nil {
+			return
+		}
 
 		if len(attachments) > 0 {
-			multiContent := a.buildUserMultiContent(ctx, message, attachments)
-			a.session.AddMessage(session.UserMessage(message, multiContent...))
+			multiContent := a.buildUserMultiContent(ctx, sess, message, attachments)
+			sess.AddMessage(session.UserMessage(message, multiContent...))
 		} else {
-			a.session.AddMessage(session.UserMessage(message))
+			sess.AddMessage(session.UserMessage(message))
 		}
-		a.forwardRunStreamEvents(ctx, a.runtime.RunStream(ctx, a.session), nil)
+		a.forwardRunStreamEvents(ctx, sess, a.runtime.RunStream(ctx, sess), nil)
 	}()
 }
 
@@ -580,7 +584,7 @@ func (a *App) Run(ctx context.Context, cancel context.CancelFunc, message string
 // and inlined text files — keeping everything in one text block ensures the
 // model sees file content together with the message, rather than as separate
 // content blocks — followed by any binary parts (images, PDFs, …).
-func (a *App) buildUserMultiContent(ctx context.Context, message string, attachments []messages.Attachment) []chat.MessagePart {
+func (a *App) buildUserMultiContent(ctx context.Context, sess *session.Session, message string, attachments []messages.Attachment) []chat.MessagePart {
 	var textBuilder strings.Builder
 	textBuilder.WriteString(message)
 
@@ -596,7 +600,7 @@ func (a *App) buildUserMultiContent(ctx context.Context, message string, attachm
 			// dangling references to directories or missing paths. The editor
 			// resolves @-mentions to absolute paths before this point.
 			if a.processFileAttachment(ctx, att, &textBuilder, &binaryParts) {
-				a.session.AddAttachedFile(att.FilePath)
+				sess.AddAttachedFile(att.FilePath)
 			}
 		case att.Content != "":
 			// Inline content attachment (e.g. pasted text).
@@ -786,7 +790,7 @@ func mustSkipMirroredElicitation(rt runtime.Runtime) bool {
 // may itself veto forwarding an event by returning false. Retry uses it to
 // suppress the pre-StreamStarted re-emitted user message; Run and
 // RunWithMessage pass nil.
-func (a *App) forwardRunStreamEvents(ctx context.Context, ch <-chan runtime.Event, filter func(event runtime.Event) (forward bool)) {
+func (a *App) forwardRunStreamEvents(ctx context.Context, sess *session.Session, ch <-chan runtime.Event, filter func(event runtime.Event) (forward bool)) {
 	skipMirroredElicitation := mustSkipMirroredElicitation(a.runtime)
 
 	// sawRootStop/sawRootError/agentName drive the #4136 fallback below: the
@@ -801,7 +805,7 @@ func (a *App) forwardRunStreamEvents(ctx context.Context, ch <-chan runtime.Even
 	)
 
 	for event := range ch {
-		isRoot := isRootSessionEvent(event, a.session.ID)
+		isRoot := isRootSessionEvent(event, sess.ID)
 		if isRoot {
 			if name := event.GetAgentName(); name != "" {
 				agentName = name
@@ -852,7 +856,7 @@ func (a *App) forwardRunStreamEvents(ctx context.Context, ch <-chan runtime.Even
 	}
 
 	if !sawRootStop {
-		a.synthesizeStreamStopped(ctx, a.session.ID, agentName, sawRootError)
+		a.synthesizeStreamStopped(ctx, sess.ID, agentName, sawRootError)
 	}
 }
 
@@ -935,13 +939,17 @@ func (a *App) processInlineAttachment(att messages.Attachment, textBuilder *stri
 // arrive after StreamStarted and are forwarded normally.
 func (a *App) Retry(ctx context.Context, cancel context.CancelFunc) {
 	a.cancel = cancel
+	sess := a.session
 
 	go func() {
 		release := a.acquireStreamGuard()
 		defer release()
+		if ctx.Err() != nil {
+			return
+		}
 
 		streamStarted := false
-		a.forwardRunStreamEvents(ctx, a.runtime.RunStream(ctx, a.session), func(event runtime.Event) bool {
+		a.forwardRunStreamEvents(ctx, sess, a.runtime.RunStream(ctx, sess), func(event runtime.Event) bool {
 			switch event.(type) {
 			case *runtime.StreamStartedEvent:
 				streamStarted = true
@@ -959,9 +967,10 @@ func (a *App) Retry(ctx context.Context, cancel context.CancelFunc) {
 // This is used for special cases like image attachments.
 func (a *App) RunWithMessage(ctx context.Context, cancel context.CancelFunc, msg *session.Message) {
 	a.cancel = cancel
+	sess := a.session
 
 	// If this is the first message and no title exists, start local title generation
-	if a.session.TitleSnapshot() == "" && a.titleGen != nil {
+	if sess.TitleSnapshot() == "" && a.titleGen != nil {
 		a.titleGenerating.Store(true)
 		// Extract text content from the message for title generation
 		userMessage := msg.Message.Content
@@ -973,15 +982,18 @@ func (a *App) RunWithMessage(ctx context.Context, cancel context.CancelFunc, msg
 				}
 			}
 		}
-		go a.generateTitle(ctx, []string{userMessage})
+		go a.generateTitle(ctx, sess, []string{userMessage})
 	}
 
 	go func() {
 		release := a.acquireStreamGuard()
 		defer release()
+		if ctx.Err() != nil {
+			return
+		}
 
-		a.session.AddMessage(msg)
-		a.forwardRunStreamEvents(ctx, a.runtime.RunStream(ctx, a.session), nil)
+		sess.AddMessage(msg)
+		a.forwardRunStreamEvents(ctx, sess, a.runtime.RunStream(ctx, sess), nil)
 	}()
 }
 
@@ -1136,7 +1148,7 @@ func (a *App) FollowUp(ctx context.Context, msg runtime.QueuedMessage) error {
 func (a *App) SteerMessage(ctx context.Context, content string, attachments []messages.Attachment) error {
 	msg := runtime.QueuedMessage{Content: content}
 	if len(attachments) > 0 {
-		msg.MultiContent = a.buildUserMultiContent(ctx, content, attachments)
+		msg.MultiContent = a.buildUserMultiContent(ctx, a.session, content, attachments)
 	}
 	return a.runtime.Steer(ctx, msg)
 }
@@ -1146,7 +1158,7 @@ func (a *App) SteerMessage(ctx context.Context, content string, attachments []me
 func (a *App) FollowUpMessage(ctx context.Context, content string, attachments []messages.Attachment) error {
 	msg := runtime.QueuedMessage{Content: content}
 	if len(attachments) > 0 {
-		msg.MultiContent = a.buildUserMultiContent(ctx, content, attachments)
+		msg.MultiContent = a.buildUserMultiContent(ctx, a.session, content, attachments)
 	}
 	return a.runtime.FollowUp(ctx, msg)
 }
@@ -1985,7 +1997,7 @@ func (a *App) IsTitleGenerating() bool {
 // generateTitle generates a title using the local title generator.
 // This method always clears the titleGenerating flag when done (success or failure).
 // It should be called in a goroutine.
-func (a *App) generateTitle(ctx context.Context, userMessages []string) {
+func (a *App) generateTitle(ctx context.Context, sess *session.Session, userMessages []string) {
 	// Always clear the flag when done, whether success or failure
 	defer a.titleGenerating.Store(false)
 
@@ -1993,18 +2005,18 @@ func (a *App) generateTitle(ctx context.Context, userMessages []string) {
 		slog.DebugContext(ctx, "No title generator available, skipping title generation")
 		// Emit empty title event so the UI clears any title-generation spinner
 		select {
-		case a.events <- runtime.SessionTitle(a.session.ID, ""):
+		case a.events <- runtime.SessionTitle(sess.ID, ""):
 		case <-ctx.Done():
 		}
 		return
 	}
 
-	title, err := a.titleGen.Generate(ctx, a.session.ID, userMessages)
+	title, err := a.titleGen.Generate(ctx, sess.ID, userMessages)
 	if err != nil {
-		slog.ErrorContext(ctx, "Failed to generate session title", "session_id", a.session.ID, "error", err)
+		slog.ErrorContext(ctx, "Failed to generate session title", "session_id", sess.ID, "error", err)
 		// Emit empty title event so the UI clears any title-generation spinner
 		select {
-		case a.events <- runtime.SessionTitle(a.session.ID, ""):
+		case a.events <- runtime.SessionTitle(sess.ID, ""):
 		case <-ctx.Done():
 		}
 		return
@@ -2013,20 +2025,20 @@ func (a *App) generateTitle(ctx context.Context, userMessages []string) {
 	if title == "" {
 		// Emit empty title event so the UI clears any title-generation spinner
 		select {
-		case a.events <- runtime.SessionTitle(a.session.ID, ""):
+		case a.events <- runtime.SessionTitle(sess.ID, ""):
 		case <-ctx.Done():
 		}
 		return
 	}
 
 	// Persist the title
-	if err := a.runtime.UpdateSessionTitle(ctx, a.session, title); err != nil {
-		slog.ErrorContext(ctx, "Failed to persist title", "session_id", a.session.ID, "error", err)
+	if err := a.runtime.UpdateSessionTitle(ctx, sess, title); err != nil {
+		slog.ErrorContext(ctx, "Failed to persist title", "session_id", sess.ID, "error", err)
 	}
 
 	// Emit the title event to update the UI
 	select {
-	case a.events <- runtime.SessionTitle(a.session.ID, title):
+	case a.events <- runtime.SessionTitle(sess.ID, title):
 	case <-ctx.Done():
 	}
 }
@@ -2055,7 +2067,7 @@ func (a *App) RegenerateSessionTitle(ctx context.Context) error {
 			}
 		}
 
-		go a.generateTitle(ctx, userMessages)
+		go a.generateTitle(ctx, a.session, userMessages)
 		return nil
 	}
 

--- a/pkg/app/session_lifecycle_test.go
+++ b/pkg/app/session_lifecycle_test.go
@@ -1,0 +1,200 @@
+package app
+
+import (
+	"context"
+	"io"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/docker/docker-agent/pkg/chat"
+	"github.com/docker/docker-agent/pkg/model/provider/base"
+	"github.com/docker/docker-agent/pkg/modelsdev"
+	"github.com/docker/docker-agent/pkg/runtime"
+	"github.com/docker/docker-agent/pkg/session"
+	"github.com/docker/docker-agent/pkg/sessiontitle"
+	"github.com/docker/docker-agent/pkg/tools"
+)
+
+type sessionCaptureRuntime struct {
+	mockRuntime
+
+	started chan *session.Session
+	release chan struct{}
+}
+
+func (r *sessionCaptureRuntime) RunStream(_ context.Context, sess *session.Session) <-chan runtime.Event {
+	ch := make(chan runtime.Event)
+	go func() {
+		defer close(ch)
+		r.started <- sess
+		<-r.release
+	}()
+	return ch
+}
+
+func TestAppRunKeepsWorkScopedToOriginalSession(t *testing.T) {
+	for _, entryPoint := range []struct {
+		name string
+		run  func(*App, context.Context, context.CancelFunc)
+	}{
+		{name: "Run", run: func(app *App, ctx context.Context, cancel context.CancelFunc) {
+			app.Run(ctx, cancel, "hello", nil)
+		}},
+		{name: "RunWithMessage", run: func(app *App, ctx context.Context, cancel context.CancelFunc) {
+			app.RunWithMessage(ctx, cancel, session.UserMessage("hello"))
+		}},
+	} {
+		t.Run(entryPoint.name, func(t *testing.T) {
+			oldSession := session.New()
+			rt := &sessionCaptureRuntime{
+				started: make(chan *session.Session, 1),
+				release: make(chan struct{}),
+			}
+			app := &App{
+				runtime: rt,
+				session: oldSession,
+				events:  make(chan tea.Msg, 4),
+			}
+			ctx, cancel := context.WithCancel(t.Context())
+			entryPoint.run(app, ctx, cancel)
+
+			require.Same(t, oldSession, <-rt.started)
+			newSession := session.New()
+			app.ReplaceSession(t.Context(), newSession)
+			close(rt.release)
+
+			event := <-app.events
+			stop, ok := event.(*runtime.StreamStoppedEvent)
+			require.True(t, ok)
+			assert.Equal(t, oldSession.ID, stop.SessionID)
+			assert.Equal(t, 1, oldSession.MessageCount())
+			assert.Zero(t, newSession.MessageCount())
+		})
+	}
+}
+
+type signalingLocker struct {
+	locked   chan struct{}
+	release  chan struct{}
+	unlocked chan struct{}
+}
+
+func (l *signalingLocker) Lock() {
+	close(l.locked)
+	<-l.release
+}
+
+func (l *signalingLocker) Unlock() {
+	close(l.unlocked)
+}
+
+func TestAppRunDropsCanceledWorkWaitingForStreamGuard(t *testing.T) {
+	for _, entryPoint := range []struct {
+		name string
+		run  func(*App, context.Context, context.CancelFunc)
+	}{
+		{name: "Run", run: func(app *App, ctx context.Context, cancel context.CancelFunc) {
+			app.Run(ctx, cancel, "hello", nil)
+		}},
+		{name: "RunWithMessage", run: func(app *App, ctx context.Context, cancel context.CancelFunc) {
+			app.RunWithMessage(ctx, cancel, session.UserMessage("hello"))
+		}},
+	} {
+		t.Run(entryPoint.name, func(t *testing.T) {
+			oldSession := session.New()
+			guard := &signalingLocker{
+				locked:   make(chan struct{}),
+				release:  make(chan struct{}),
+				unlocked: make(chan struct{}),
+			}
+			rt := &sessionCaptureRuntime{
+				started: make(chan *session.Session, 1),
+				release: make(chan struct{}),
+			}
+			app := &App{
+				ctx:         func() context.Context { return t.Context() },
+				runtime:     rt,
+				session:     oldSession,
+				events:      make(chan tea.Msg, 4),
+				streamGuard: guard,
+			}
+			ctx, cancel := context.WithCancel(t.Context())
+			entryPoint.run(app, ctx, cancel)
+			<-guard.locked
+			app.NewSession()
+			close(guard.release)
+			<-guard.unlocked
+
+			assert.Zero(t, oldSession.MessageCount())
+			assert.Zero(t, app.Session().MessageCount())
+			assert.Empty(t, rt.started)
+		})
+	}
+}
+
+type blockingTitleProvider struct {
+	started chan struct{}
+	release chan struct{}
+}
+
+func (p *blockingTitleProvider) ID() modelsdev.ID {
+	return modelsdev.NewID("test", "title")
+}
+
+func (p *blockingTitleProvider) BaseConfig() base.Config { return base.Config{} }
+
+func (p *blockingTitleProvider) CreateChatCompletionStream(context.Context, []chat.Message, []tools.Tool) (chat.MessageStream, error) {
+	close(p.started)
+	<-p.release
+	return &singleTitleStream{}, nil
+}
+
+type singleTitleStream struct {
+	done bool
+}
+
+func (s *singleTitleStream) Recv() (chat.MessageStreamResponse, error) {
+	if s.done {
+		return chat.MessageStreamResponse{}, io.EOF
+	}
+	s.done = true
+	return chat.MessageStreamResponse{
+		Choices: []chat.MessageStreamChoice{{Delta: chat.MessageDelta{Content: "Original title"}}},
+	}, nil
+}
+
+func (*singleTitleStream) Close() {}
+
+func TestGenerateTitleKeepsOriginalSession(t *testing.T) {
+	provider := &blockingTitleProvider{
+		started: make(chan struct{}),
+		release: make(chan struct{}),
+	}
+	oldSession := session.New()
+	app := &App{
+		runtime:  &mockRuntime{},
+		session:  oldSession,
+		events:   make(chan tea.Msg, 1),
+		titleGen: sessiontitle.New(provider),
+	}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		app.generateTitle(t.Context(), oldSession, []string{"hello"})
+	}()
+	<-provider.started
+	newSession := session.New()
+	app.ReplaceSession(t.Context(), newSession)
+	close(provider.release)
+	<-done
+
+	assert.Equal(t, "Original title", oldSession.TitleSnapshot())
+	assert.Empty(t, newSession.TitleSnapshot())
+	titleEvent, ok := (<-app.events).(*runtime.SessionTitleEvent)
+	require.True(t, ok)
+	assert.Equal(t, oldSession.ID, titleEvent.SessionID)
+}

--- a/pkg/config/ocisource/ocisource.go
+++ b/pkg/config/ocisource/ocisource.go
@@ -140,10 +140,9 @@ func (a ociSource) read(ctx context.Context) (data []byte, degraded bool, err er
 		return nil, false, fmt.Errorf("failed to create content store: %w", err)
 	}
 
-	// Normalize the reference so that equivalent forms (e.g.
-	// "myorg/review-pr" and "index.docker.io/myorg/review-pr:latest")
-	// resolve to the same store key that remote.Pull uses.
-	storeKey, err := remote.NormalizeReference(a.reference)
+	// Normalize the reference so equivalent shorthand forms resolve to the
+	// same registry-scoped store key that remote.Pull uses.
+	storeKey, err := remote.FullyQualifiedReference(a.reference)
 	if err != nil {
 		return nil, false, fmt.Errorf("normalizing OCI reference %s: %w", a.reference, err)
 	}

--- a/pkg/config/ocisource/ocisource_test.go
+++ b/pkg/config/ocisource/ocisource_test.go
@@ -42,19 +42,21 @@ func TestOCISource_DigestReference_ServesFromCache(t *testing.T) {
 		"io.docker.agent.version": "test",
 	}).(v1.Image)
 
-	ref := "test-digest-cache/agent:latest"
-	digest, err := store.StoreArtifact(img, ref)
+	ref := "registry.example.com/test-digest-cache/agent:latest"
+	storeKey, err := remote.FullyQualifiedReference(ref)
+	require.NoError(t, err)
+	digest, err := store.StoreArtifact(img, storeKey)
 	require.NoError(t, err)
 
 	// Build a digest reference using the stored digest.
-	digestRef := "test-digest-cache/agent@" + digest
+	digestRef := "registry.example.com/test-digest-cache/agent@" + digest
 
 	// Read via ociSource. Since the reference is pinned by digest and is
 	// present in the local store, this must succeed without any network call.
 	// We override the default store directory via an env-based approach;
 	// instead, we directly exercise the cache-hit logic by verifying the
 	// store lookup works with the normalized key.
-	storeKey, err := remote.NormalizeReference(digestRef)
+	storeKey, err = remote.FullyQualifiedReference(digestRef)
 	require.NoError(t, err)
 
 	// Verify the store can resolve the digest key directly.
@@ -69,8 +71,16 @@ func TestOCISource_DigestReference_ServesFromCache(t *testing.T) {
 
 // storeTestArtifact writes an agent YAML artifact into the default content
 // store (rooted at $HOME, which the caller must point at a temp dir) under
-// the given tag reference.
-func storeTestArtifact(t *testing.T, ref string, data []byte) string {
+// the normalized registry-scoped key for ref.
+func storeTestArtifact(t *testing.T, ref string, data []byte) {
+	t.Helper()
+
+	storeKey, err := remote.FullyQualifiedReference(ref)
+	require.NoError(t, err)
+	storeTestArtifactWithKey(t, storeKey, data)
+}
+
+func storeTestArtifactWithKey(t *testing.T, storeKey string, data []byte) {
 	t.Helper()
 
 	store, err := content.NewStore()
@@ -83,9 +93,8 @@ func storeTestArtifact(t *testing.T, ref string, data []byte) string {
 		"io.docker.agent.version": "test",
 	}).(v1.Image)
 
-	digest, err := store.StoreArtifact(img, ref)
+	_, err = store.StoreArtifact(img, storeKey)
 	require.NoError(t, err)
-	return digest
 }
 
 // stubOCIPull replaces the registry pull with fn for the test's duration.
@@ -185,7 +194,8 @@ func TestOCISource_Read_CacheIsScopedToRegistry(t *testing.T) {
 	// Same repository and tag on two different registries: distinct trust
 	// boundaries, so each must do its own pull instead of sharing an entry.
 	testData := []byte("version: v1\nname: scoped-agent")
-	storeTestArtifact(t, "test-scoped/agent:latest", testData)
+	storeTestArtifact(t, "registry-a.example.com/test-scoped/agent:latest", testData)
+	storeTestArtifact(t, "registry-b.example.com/test-scoped/agent:latest", testData)
 
 	var pulls atomic.Int32
 	stubOCIPull(t, func(context.Context, string, bool) (string, error) {
@@ -198,6 +208,35 @@ func TestOCISource_Read_CacheIsScopedToRegistry(t *testing.T) {
 	_, err = New("registry-b.example.com/test-scoped/agent:latest").Read(t.Context())
 	require.NoError(t, err)
 	assert.Equal(t, int32(2), pulls.Load(), "refs differing only by registry must not share a cache entry")
+}
+
+// Not parallel: stubs the package-level pullOCIArtifact and re-homes the
+// default content store via t.Setenv.
+func TestOCISource_Read_FallbackIsScopedToRegistry(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	resetOCIMemoizer(t)
+
+	refA := "registry-a.example.com/test-fallback/agent:latest"
+	refB := "registry-b.example.com/test-fallback/agent:latest"
+	storeTestArtifact(t, refA, []byte("version: v1\nname: registry-a"))
+	storeTestArtifact(t, refB, []byte("version: v1\nname: registry-b"))
+	stubOCIPull(t, func(context.Context, string, bool) (string, error) {
+		return "", errors.New("registry unreachable")
+	})
+
+	data, err := New(refA).Read(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, []byte("version: v1\nname: registry-a"), data)
+	data, err = New(refB).Read(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, []byte("version: v1\nname: registry-b"), data)
+
+	store, err := content.NewStore()
+	require.NoError(t, err)
+	_, err = store.GetArtifact("test-fallback/agent:latest")
+	require.ErrorIs(t, err, content.ErrStoreCorrupted, "registry-less legacy keys must not be populated or used as fallback")
 }
 
 // Not parallel: stubs the package-level pullOCIArtifact and re-homes the
@@ -256,16 +295,18 @@ func storeProtectedTestArtifact(t *testing.T, ref string, data []byte, key *prot
 func storeTestArtifactWithAnnotations(t *testing.T, ref string, data []byte, annotations map[string]string) {
 	t.Helper()
 
-	store, err := content.NewStore()
+	annotations["io.docker.agent.version"] = "test"
+	storeKey, err := remote.FullyQualifiedReference(ref)
 	require.NoError(t, err)
 
-	annotations["io.docker.agent.version"] = "test"
+	store, err := content.NewStore()
+	require.NoError(t, err)
 	layer := static.NewLayer(data, "application/yaml")
 	img, err := mutate.AppendLayers(empty.Image, layer)
 	require.NoError(t, err)
 	img = mutate.Annotations(img, annotations).(v1.Image)
 
-	_, err = store.StoreArtifact(img, ref)
+	_, err = store.StoreArtifact(img, storeKey)
 	require.NoError(t, err)
 }
 

--- a/pkg/config/ocisource/ocisource_test.go
+++ b/pkg/config/ocisource/ocisource_test.go
@@ -20,11 +20,32 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/docker/docker-agent/pkg/configsize"
 	"github.com/docker/docker-agent/pkg/content"
 	"github.com/docker/docker-agent/pkg/memoize"
 	"github.com/docker/docker-agent/pkg/protect"
 	"github.com/docker/docker-agent/pkg/remote"
 )
+
+func TestOCISource_Read_OversizedArtifactIsNotRedownloaded(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	resetOCIMemoizer(t)
+
+	const ref = "test-oversized/agent:latest"
+	storeTestArtifact(t, ref, make([]byte, configsize.MaxBytes+1))
+	var pulls atomic.Int32
+	stubOCIPull(t, func(context.Context, string, bool) (string, error) {
+		pulls.Add(1)
+		return "", nil
+	})
+
+	_, err := New(ref).Read(t.Context())
+	require.ErrorIs(t, err, configsize.ErrTooLarge)
+	require.NotErrorIs(t, err, content.ErrStoreCorrupted)
+	assert.Equal(t, int32(1), pulls.Load(), "an oversized valid artifact must not trigger a forced re-pull")
+}
 
 func TestOCISource_DigestReference_ServesFromCache(t *testing.T) {
 	t.Parallel()

--- a/pkg/config/sources.go
+++ b/pkg/config/sources.go
@@ -6,7 +6,6 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
-	"io"
 	"log/slog"
 	"net/http"
 	"net/url"
@@ -17,6 +16,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/docker/docker-agent/pkg/configsize"
 	"github.com/docker/docker-agent/pkg/environment"
 	"github.com/docker/docker-agent/pkg/httpclient"
 	"github.com/docker/docker-agent/pkg/paths"
@@ -320,22 +320,20 @@ func (a urlSource) read(ctx context.Context, cacheDir, cachePath, etagPath, encP
 	resp, err := client.Do(req)
 	if err != nil {
 		// Network error - try to use cached version
-		if cachedData, cacheErr := os.ReadFile(cachePath); cacheErr == nil {
+		if cachedData, cacheErr := readCachedConfig(cachePath); cacheErr == nil {
 			slog.DebugContext(ctx, "Network error fetching URL, using cached version", "url", a.url, "error", err)
 			a.adoptCachedEncryptedConfig(ctx, encPath, "")
 			return cachedData, nil
+		} else if errors.Is(cacheErr, configsize.ErrTooLarge) {
+			return nil, fmt.Errorf("reading cached configuration for %s: %w", a.url, cacheErr)
 		}
 		return nil, fmt.Errorf("%w: fetching %s: %w", ErrSourceFetchFailed, a.url, err)
 	}
 	defer resp.Body.Close()
 
-	// Capture the full encrypted agent config header. It is present on a 200
-	// (and persisted to encPath); a 304 carries only the digest, handled below.
-	a.captureEncryptedConfig(ctx, resp, encPath)
-
 	// 304 Not Modified - return cached content
 	if resp.StatusCode == http.StatusNotModified {
-		if cachedData, cacheErr := os.ReadFile(cachePath); cacheErr == nil {
+		if cachedData, cacheErr := readCachedConfig(cachePath); cacheErr == nil {
 			// Recover the encrypted config from disk, verifying it against the
 			// digest the server sent (when present). If it is missing or stale,
 			// self-heal by forcing a full reload so we get the config again.
@@ -366,24 +364,35 @@ func (a urlSource) read(ctx context.Context, cacheDir, cachePath, etagPath, encP
 			}
 			slog.DebugContext(ctx, "URL not modified, using cached version", "url", a.url)
 			return cachedData, nil
+		} else if errors.Is(cacheErr, configsize.ErrTooLarge) {
+			return nil, fmt.Errorf("reading cached configuration for %s: %w", a.url, cacheErr)
 		}
 		// Cache file missing despite 304, fall through to fetch again
 	}
 
 	if resp.StatusCode != http.StatusOK {
 		// HTTP error - try to use cached version
-		if cachedData, cacheErr := os.ReadFile(cachePath); cacheErr == nil {
+		if cachedData, cacheErr := readCachedConfig(cachePath); cacheErr == nil {
 			slog.DebugContext(ctx, "HTTP error fetching URL, using cached version", "url", a.url, "status", resp.Status)
 			a.adoptCachedEncryptedConfig(ctx, encPath, "")
 			return cachedData, nil
+		} else if errors.Is(cacheErr, configsize.ErrTooLarge) {
+			return nil, fmt.Errorf("reading cached configuration for %s: %w", a.url, cacheErr)
 		}
 		return nil, fmt.Errorf("%w: fetching %s: %s", ErrSourceFetchFailed, a.url, resp.Status)
 	}
 
-	data, err := io.ReadAll(resp.Body)
+	data, err := configsize.Read(resp.Body)
 	if err != nil {
+		if errors.Is(err, configsize.ErrTooLarge) {
+			return nil, fmt.Errorf("fetching %s: %w", a.url, err)
+		}
 		return nil, fmt.Errorf("%w: reading response body: %w", ErrSourceFetchFailed, err)
 	}
+
+	// Cache the response and any associated encrypted config only after the
+	// complete body passes the size limit.
+	a.captureEncryptedConfig(ctx, resp, encPath)
 
 	// Cache the response
 	if err := os.MkdirAll(cacheDir, 0o700); err == nil {
@@ -403,6 +412,15 @@ func (a urlSource) read(ctx context.Context, cacheDir, cachePath, etagPath, encP
 	}
 
 	return data, nil
+}
+
+func readCachedConfig(path string) ([]byte, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	data, readErr := configsize.Read(file)
+	return data, errors.Join(readErr, file.Close())
 }
 
 // githubHosts lists the hostnames that support GitHub token authentication.

--- a/pkg/config/sources_test.go
+++ b/pkg/config/sources_test.go
@@ -1,10 +1,13 @@
 package config
 
 import (
+	"errors"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -12,6 +15,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/docker/docker-agent/pkg/configsize"
 	"github.com/docker/docker-agent/pkg/environment"
 	"github.com/docker/docker-agent/pkg/httpclient"
 	"github.com/docker/docker-agent/pkg/paths"
@@ -46,6 +50,120 @@ func TestURLSource_Read(t *testing.T) {
 	data, err := source.Read(t.Context())
 	require.NoError(t, err)
 	assert.Equal(t, "test content", string(data))
+}
+
+func TestURLSource_Read_SizeLimit(t *testing.T) {
+	for _, test := range []struct {
+		name          string
+		size          int64
+		contentLength bool
+		wantError     bool
+	}{
+		{name: "exact boundary", size: configsize.MaxBytes, contentLength: true},
+		{name: "over boundary", size: configsize.MaxBytes + 1, contentLength: true, wantError: true},
+		{name: "unknown length over boundary", size: configsize.MaxBytes + 1, wantError: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			paths.SetDataDir(t.TempDir())
+			t.Cleanup(func() { paths.SetDataDir("") })
+
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				if test.contentLength {
+					w.Header().Set("Content-Length", strconv.FormatInt(test.size, 10))
+				}
+				w.Header().Set(httpclient.EncryptedConfigHeader, "must-not-be-cached")
+				_, _ = io.CopyN(w, zeroReader{}, test.size)
+			}))
+			t.Cleanup(server.Close)
+
+			source := newURLSourceForTest(server.URL, nil)
+			data, err := source.Read(t.Context())
+			if test.wantError {
+				require.ErrorIs(t, err, configsize.ErrTooLarge)
+				require.NotErrorIs(t, err, ErrSourceFetchFailed)
+				cachePath := filepath.Join(getURLCacheDir(), hashURL(server.URL))
+				_, cacheErr := os.Stat(cachePath)
+				require.ErrorIs(t, cacheErr, os.ErrNotExist)
+				_, encErr := os.Stat(cachePath + ".enc")
+				require.ErrorIs(t, encErr, os.ErrNotExist)
+				assert.Empty(t, source.(EncryptedConfigSource).EncryptedConfig())
+				return
+			}
+			require.NoError(t, err)
+			assert.Len(t, data, int(test.size))
+		})
+	}
+}
+
+type zeroReader struct{}
+
+func (zeroReader) Read(p []byte) (int, error) {
+	clear(p)
+	return len(p), nil
+}
+
+func TestURLSource_Read_CacheSizeLimit(t *testing.T) {
+	for _, test := range []struct {
+		name      string
+		response  string
+		size      int64
+		wantError bool
+	}{
+		{name: "304 exact boundary", response: "304", size: configsize.MaxBytes},
+		{name: "304 over boundary", response: "304", size: configsize.MaxBytes + 1, wantError: true},
+		{name: "network over boundary", response: "network", size: configsize.MaxBytes + 1, wantError: true},
+		{name: "HTTP error over boundary", response: "HTTP error", size: configsize.MaxBytes + 1, wantError: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			paths.SetDataDir(t.TempDir())
+			t.Cleanup(func() { paths.SetDataDir("") })
+
+			var server *httptest.Server
+			switch test.response {
+			case "304":
+				server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+					w.WriteHeader(http.StatusNotModified)
+				}))
+			case "network":
+				server = httptest.NewServer(http.NotFoundHandler())
+				server.Close()
+			case "HTTP error":
+				server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+					w.WriteHeader(http.StatusInternalServerError)
+				}))
+			default:
+				t.Fatalf("unknown response %q", test.response)
+			}
+			if test.response != "network" {
+				t.Cleanup(server.Close)
+			}
+
+			cachePath := filepath.Join(getURLCacheDir(), hashURL(server.URL))
+			require.NoError(t, os.MkdirAll(filepath.Dir(cachePath), 0o700))
+			require.NoError(t, writeZeroFile(cachePath, test.size))
+
+			data, err := newURLSourceForTest(server.URL, nil).Read(t.Context())
+			if test.wantError {
+				require.ErrorIs(t, err, configsize.ErrTooLarge)
+				require.NotErrorIs(t, err, ErrSourceFetchFailed)
+				info, statErr := os.Stat(cachePath)
+				require.NoError(t, statErr)
+				assert.Equal(t, test.size, info.Size(), "rejected cache bytes must be preserved")
+				return
+			}
+			require.NoError(t, err)
+			assert.Len(t, data, int(test.size))
+		})
+	}
+}
+
+func writeZeroFile(path string, size int64) error {
+	file, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+	_, copyErr := io.CopyN(file, zeroReader{}, size)
+	return errors.Join(copyErr, file.Close())
 }
 
 func TestURLSource_Read_HTTPError(t *testing.T) {

--- a/pkg/configsize/configsize.go
+++ b/pkg/configsize/configsize.go
@@ -1,0 +1,22 @@
+// Package configsize limits remotely loaded agent configurations.
+package configsize
+
+import (
+	"fmt"
+	"io"
+)
+
+const MaxBytes int64 = 32 << 20
+
+var ErrTooLarge = fmt.Errorf("agent configuration exceeds %d MiB limit", MaxBytes>>20)
+
+func Read(r io.Reader) ([]byte, error) {
+	data, err := io.ReadAll(io.LimitReader(r, MaxBytes+1))
+	if err != nil {
+		return nil, err
+	}
+	if int64(len(data)) > MaxBytes {
+		return nil, fmt.Errorf("%w (%d bytes maximum)", ErrTooLarge, MaxBytes)
+	}
+	return data, nil
+}

--- a/pkg/content/store.go
+++ b/pkg/content/store.go
@@ -1,13 +1,11 @@
 package content
 
 import (
-	"bytes"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -18,6 +16,7 @@ import (
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/tarball"
 
+	"github.com/docker/docker-agent/pkg/configsize"
 	"github.com/docker/docker-agent/pkg/paths"
 )
 
@@ -234,14 +233,15 @@ func (s *Store) GetArtifact(identifier string) (string, error) {
 	}
 	defer rc.Close()
 
-	// Read the full layer content into memory.
-	// Any I/O error here means the artifact cannot be trusted.
-	var buf bytes.Buffer
-	if _, err := io.Copy(&buf, rc); err != nil {
+	data, err := configsize.Read(rc)
+	if err != nil {
+		if errors.Is(err, configsize.ErrTooLarge) {
+			return "", err
+		}
 		return "", ErrStoreCorrupted
 	}
 
-	return buf.String(), nil
+	return string(data), nil
 }
 
 // ListArtifacts returns a list of all stored artifacts

--- a/pkg/content/store_test.go
+++ b/pkg/content/store_test.go
@@ -12,7 +12,44 @@ import (
 	"github.com/google/go-containerregistry/pkg/v1/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/docker/docker-agent/pkg/configsize"
 )
+
+func TestStoreGetArtifactSizeLimit(t *testing.T) {
+	t.Parallel()
+
+	for _, test := range []struct {
+		name      string
+		size      int64
+		wantError bool
+	}{
+		{name: "exact boundary", size: configsize.MaxBytes},
+		{name: "over boundary", size: configsize.MaxBytes + 1, wantError: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			store, err := NewStore(WithBaseDir(t.TempDir()))
+			require.NoError(t, err)
+			layer := static.NewLayer(make([]byte, test.size), types.OCIUncompressedLayer)
+			img, err := mutate.AppendLayers(empty.Image, layer)
+			require.NoError(t, err)
+			const ref = "size-test:latest"
+			_, err = store.StoreArtifact(img, ref)
+			require.NoError(t, err)
+
+			data, err := store.GetArtifact(ref)
+			if test.wantError {
+				require.ErrorIs(t, err, configsize.ErrTooLarge)
+				require.NotErrorIs(t, err, ErrStoreCorrupted)
+				return
+			}
+			require.NoError(t, err)
+			assert.Len(t, data, int(test.size))
+		})
+	}
+}
 
 func TestStoreBasicOperations(t *testing.T) {
 	t.Parallel()

--- a/pkg/remote/pull.go
+++ b/pkg/remote/pull.go
@@ -18,28 +18,9 @@ import (
 	desktoptransport "github.com/docker/docker-agent/pkg/desktop/transport"
 )
 
-// NormalizeReference parses an OCI reference and returns the normalized
-// store key that Pull uses to store artifacts. This ensures that equivalent
-// references (e.g. "myorg/review-pr" and
-// "index.docker.io/myorg/review-pr:latest") map to the same key.
-//
-// The registry host is deliberately stripped, so references that differ only
-// by registry map to the same key. Callers that need a registry-scoped
-// identity (e.g. cache keys spanning trust boundaries) must use
-// FullyQualifiedReference instead.
-func NormalizeReference(registryRef string) (string, error) {
-	ref, err := name.ParseReference(registryRef)
-	if err != nil {
-		return "", fmt.Errorf("parsing registry reference %s: %w", registryRef, err)
-	}
-	return ref.Context().RepositoryStr() + separator(ref) + ref.Identifier(), nil
-}
-
-// FullyQualifiedReference returns the fully-qualified form of an OCI
-// reference, including the registry host (e.g.
-// "index.docker.io/myorg/review-pr:latest"). Equivalent shorthand
-// forms map to the same value, while references that differ only by registry
-// map to different values — unlike NormalizeReference, which strips the host.
+// FullyQualifiedReference parses an OCI reference and returns its fully qualified
+// form, including the registry host. Equivalent shorthand forms map to the
+// same value, while references on different registries remain distinct.
 func FullyQualifiedReference(registryRef string) (string, error) {
 	ref, err := name.ParseReference(registryRef)
 	if err != nil {
@@ -74,6 +55,11 @@ func Pull(ctx context.Context, registryRef string, force bool, opts ...crane.Opt
 		return "", fmt.Errorf("parsing registry reference %s: %w", registryRef, err)
 	}
 
+	storeKey, err := FullyQualifiedReference(registryRef)
+	if err != nil {
+		return "", fmt.Errorf("normalizing registry reference %s: %w", registryRef, err)
+	}
+
 	s, err := newSession(o)
 	if err != nil {
 		return "", fmt.Errorf("creating registry session: %w", err)
@@ -89,7 +75,7 @@ func Pull(ctx context.Context, registryRef string, force bool, opts ...crane.Opt
 		return "", fmt.Errorf("creating content store: %w", err)
 	}
 
-	localRef := ref.Context().RepositoryStr() + separator(ref) + ref.Identifier()
+	localRef := storeKey
 	if !force {
 		if meta, metaErr := store.GetArtifactMetadata(localRef); metaErr == nil {
 			if meta.Digest == remoteDigest {
@@ -294,13 +280,4 @@ func hasCagentAnnotation(annotations map[string]string) bool {
 		_, exists = annotations["io.docker.cagent.version"]
 	}
 	return exists
-}
-
-// separator returns the separator used between repository and identifier.
-// For digests it returns "@", for tags it returns ":".
-func separator(ref name.Reference) string {
-	if _, ok := ref.(name.Digest); ok {
-		return "@"
-	}
-	return ":"
 }

--- a/pkg/remote/pull_test.go
+++ b/pkg/remote/pull_test.go
@@ -407,6 +407,40 @@ func testImage(t *testing.T, contents string) v1.Image {
 	return img
 }
 
+func TestPullKeepsRegistryScopedReferences(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+
+	serverA := httptest.NewServer(testregistry.New(testregistry.Logger(log.New(io.Discard, "", 0))))
+	defer serverA.Close()
+	serverB := httptest.NewServer(testregistry.New(testregistry.Logger(log.New(io.Discard, "", 0))))
+	defer serverB.Close()
+
+	refA := strings.TrimPrefix(serverA.URL, "http://") + "/same/agent:latest"
+	refB := strings.TrimPrefix(serverB.URL, "http://") + "/same/agent:latest"
+	imageA := mutate.Annotations(testImage(t, "registry-a"), map[string]string{"io.docker.agent.version": "test"}).(v1.Image)
+	imageB := mutate.Annotations(testImage(t, "registry-b"), map[string]string{"io.docker.agent.version": "test"}).(v1.Image)
+	require.NoError(t, crane.Push(imageA, refA, crane.Insecure))
+	require.NoError(t, crane.Push(imageB, refB, crane.Insecure))
+
+	_, err := Pull(t.Context(), refA, false, crane.Insecure)
+	require.NoError(t, err)
+	_, err = Pull(t.Context(), refB, false, crane.Insecure)
+	require.NoError(t, err)
+
+	store, err := content.NewStore()
+	require.NoError(t, err)
+	storedA, err := store.GetArtifact(refA)
+	require.NoError(t, err)
+	storedB, err := store.GetArtifact(refB)
+	require.NoError(t, err)
+	assert.Equal(t, "registry-a", storedA)
+	assert.Equal(t, "registry-b", storedB)
+	_, err = store.GetArtifact("same/agent:latest")
+	require.ErrorIs(t, err, content.ErrStoreCorrupted, "Pull must not populate a registry-less legacy key")
+}
+
 func TestPullRegistryNotFound(t *testing.T) {
 	t.Parallel()
 
@@ -461,7 +495,7 @@ func TestPullIntegration(t *testing.T) {
 	require.Error(t, err)
 }
 
-func TestNormalizeReference(t *testing.T) {
+func TestFullyQualifiedReference(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
@@ -472,44 +506,44 @@ func TestNormalizeReference(t *testing.T) {
 		{
 			name:     "short reference gets normalized",
 			ref:      "myorg/review-pr",
-			expected: "myorg/review-pr:latest",
+			expected: "index.docker.io/myorg/review-pr:latest",
 		},
 		{
 			name:     "fully qualified reference gets normalized to same key",
 			ref:      "index.docker.io/myorg/review-pr:latest",
-			expected: "myorg/review-pr:latest",
+			expected: "index.docker.io/myorg/review-pr:latest",
 		},
 		{
 			name:     "tagged reference preserves tag",
 			ref:      "myorg/review-pr:v1",
-			expected: "myorg/review-pr:v1",
+			expected: "index.docker.io/myorg/review-pr:v1",
 		},
 		{
 			name:     "digest reference preserves digest",
 			ref:      "myorg/review-pr@sha256:0000000000000000000000000000000000000000000000000000000000000000",
-			expected: "myorg/review-pr@sha256:0000000000000000000000000000000000000000000000000000000000000000",
+			expected: "index.docker.io/myorg/review-pr@sha256:0000000000000000000000000000000000000000000000000000000000000000",
 		},
 		{
 			name:     "non-docker-hub registry",
 			ref:      "ghcr.io/myorg/agent:v2",
-			expected: "myorg/agent:v2",
+			expected: "ghcr.io/myorg/agent:v2",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			result, err := NormalizeReference(tt.ref)
+			result, err := FullyQualifiedReference(tt.ref)
 			require.NoError(t, err)
 			assert.Equal(t, tt.expected, result)
 		})
 	}
 }
 
-func TestNormalizeReference_InvalidReference(t *testing.T) {
+func TestFullyQualifiedReference_InvalidReference(t *testing.T) {
 	t.Parallel()
 
-	_, err := NormalizeReference(":::invalid")
+	_, err := FullyQualifiedReference(":::invalid")
 	require.Error(t, err)
 }
 
@@ -532,45 +566,6 @@ func TestIsDigestReference(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			assert.Equal(t, tt.expected, IsDigestReference(tt.ref))
-		})
-	}
-}
-
-func TestSeparator(t *testing.T) {
-	t.Parallel()
-
-	tests := []struct {
-		name     string
-		ref      string
-		expected string
-	}{
-		{
-			name:     "tag reference uses colon",
-			ref:      "docker.io/library/alpine:latest",
-			expected: ":",
-		},
-		{
-			name:     "digest reference uses at sign",
-			ref:      "docker.io/library/alpine@sha256:0000000000000000000000000000000000000000000000000000000000000000",
-			expected: "@",
-		},
-		{
-			name:     "short tag reference uses colon",
-			ref:      "alpine:v1.0",
-			expected: ":",
-		},
-		{
-			name:     "short digest reference uses at sign",
-			ref:      "alpine@sha256:0000000000000000000000000000000000000000000000000000000000000000",
-			expected: "@",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			ref, err := name.ParseReference(tt.ref)
-			require.NoError(t, err)
-			assert.Equal(t, tt.expected, separator(ref))
 		})
 	}
 }

--- a/pkg/remote/push.go
+++ b/pkg/remote/push.go
@@ -21,13 +21,18 @@ func Push(ctx context.Context, reference string) error {
 		return fmt.Errorf("creating content store: %w", err)
 	}
 
-	img, err := store.GetArtifactImage(reference)
+	storeKey, err := FullyQualifiedReference(reference)
+	if err != nil {
+		return err
+	}
+
+	img, err := store.GetArtifactImage(storeKey)
 	if err != nil {
 		return fmt.Errorf("loading artifact from store: %w", err)
 	}
 
 	// Get metadata to restore annotations
-	metadata, err := store.GetArtifactMetadata(reference)
+	metadata, err := store.GetArtifactMetadata(storeKey)
 	if err != nil {
 		return fmt.Errorf("loading artifact metadata: %w", err)
 	}

--- a/pkg/runtime/persistence_observer.go
+++ b/pkg/runtime/persistence_observer.go
@@ -101,7 +101,7 @@ func (p *PersistenceObserver) OnEvent(ctx context.Context, sess *session.Session
 		// MessageAddedEvent payload, then reset for the next stream.
 		var err error
 		if p.streaming.messageID != 0 {
-			err = p.store.UpdateMessage(ctx, p.streaming.messageID, e.Message)
+			err = p.store.UpdateMessage(ctx, e.SessionID, p.streaming.messageID, e.Message)
 		} else {
 			_, err = p.store.AddMessage(ctx, e.SessionID, e.Message)
 		}
@@ -193,7 +193,7 @@ func (p *PersistenceObserver) persistStreamingContent(ctx context.Context, sessi
 		return
 	}
 
-	if err := p.store.UpdateMessage(ctx, p.streaming.messageID, msg); err != nil {
+	if err := p.store.UpdateMessage(ctx, sessionID, p.streaming.messageID, msg); err != nil {
 		slog.WarnContext(ctx, "Failed to update streaming message",
 			"session_id", sessionID, "message_id", p.streaming.messageID, "error", err)
 	}

--- a/pkg/runtime/remote_runtime.go
+++ b/pkg/runtime/remote_runtime.go
@@ -855,7 +855,7 @@ func (s *RemoteSessionStore) AddMessage(context.Context, string, *session.Messag
 	return 0, fmt.Errorf("add message: %w", ErrUnsupported)
 }
 
-func (s *RemoteSessionStore) UpdateMessage(context.Context, int64, *session.Message) error {
+func (s *RemoteSessionStore) UpdateMessage(context.Context, string, int64, *session.Message) error {
 	return fmt.Errorf("update message: %w", ErrUnsupported)
 }
 

--- a/pkg/server/listen.go
+++ b/pkg/server/listen.go
@@ -47,17 +47,11 @@ func listenFD(raw string) (net.Listener, error) {
 }
 
 func listenUnix(ctx context.Context, path string) (net.Listener, error) {
-	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
-		return nil, err
-	}
-
 	dir := filepath.Dir(path)
 	if err := os.MkdirAll(dir, 0o755); err != nil { //nolint:gosec // socket access is gated by socket file permissions, not directory
 		return nil, err
 	}
-
-	var lnConfig net.ListenConfig
-	return lnConfig.Listen(ctx, "unix", path)
+	return listenUnixSocket(ctx, path)
 }
 
 func listenTCP(ctx context.Context, addr string) (net.Listener, error) {

--- a/pkg/server/listen_test.go
+++ b/pkg/server/listen_test.go
@@ -185,9 +185,6 @@ func TestListen_Unix(t *testing.T) {
 	assert.Equal(t, "pong", string(body))
 }
 
-// TestListen_Unix_ReplacesStaleSocket verifies that a leftover socket file
-// from a previous run is removed so the bind succeeds (rather than failing
-// with "address already in use").
 func TestListen_Unix_ReplacesStaleSocket(t *testing.T) {
 	t.Parallel()
 
@@ -202,4 +199,93 @@ func TestListen_Unix_ReplacesStaleSocket(t *testing.T) {
 	require.NoError(t, err)
 	defer ln2.Close()
 	assert.Equal(t, "unix", ln2.Addr().Network())
+}
+
+func TestListen_Unix_PreservesRegularFile(t *testing.T) {
+	t.Parallel()
+
+	sockPath := filepath.Join(shortTempDir(t), "a.sock")
+	original := []byte("keep me")
+	require.NoError(t, os.WriteFile(sockPath, original, 0o640))
+
+	_, err := Listen(t.Context(), "unix://"+sockPath)
+	require.ErrorContains(t, err, "refusing to replace non-socket path")
+
+	got, err := os.ReadFile(sockPath)
+	require.NoError(t, err)
+	assert.Equal(t, original, got)
+}
+
+func TestListen_Unix_RejectsSymlink(t *testing.T) {
+	t.Parallel()
+
+	dir := shortTempDir(t)
+	target := filepath.Join(dir, "target")
+	sockPath := filepath.Join(dir, "a.sock")
+	require.NoError(t, os.WriteFile(target, []byte("keep me"), 0o600))
+	require.NoError(t, os.Symlink(target, sockPath))
+
+	_, err := Listen(t.Context(), "unix://"+sockPath)
+	require.ErrorContains(t, err, "refusing to replace non-socket path")
+
+	info, err := os.Lstat(sockPath)
+	require.NoError(t, err)
+	assert.NotZero(t, info.Mode()&os.ModeSymlink)
+}
+
+func TestListen_Unix_DoesNotUnlinkLiveSocket(t *testing.T) {
+	t.Parallel()
+
+	sockPath := filepath.Join(shortTempDir(t), "a.sock")
+	ln, err := Listen(t.Context(), "unix://"+sockPath)
+	require.NoError(t, err)
+	defer ln.Close()
+
+	_, err = Listen(t.Context(), "unix://"+sockPath)
+	require.ErrorContains(t, err, "already in use")
+
+	var dialer net.Dialer
+	conn, err := dialer.DialContext(t.Context(), "unix", sockPath)
+	require.NoError(t, err)
+	require.NoError(t, conn.Close())
+}
+
+func TestListen_Unix_SerializesConcurrentStarts(t *testing.T) {
+	t.Parallel()
+
+	sockPath := filepath.Join(shortTempDir(t), "a.sock")
+	const starts = 8
+	listeners := make(chan net.Listener, starts)
+	errs := make(chan error, starts)
+	var wg sync.WaitGroup
+	for range starts {
+		wg.Go(func() {
+			ln, err := Listen(t.Context(), "unix://"+sockPath)
+			if err != nil {
+				errs <- err
+				return
+			}
+			listeners <- ln
+		})
+	}
+	wg.Wait()
+	close(listeners)
+	close(errs)
+
+	var successful []net.Listener
+	for ln := range listeners {
+		successful = append(successful, ln)
+	}
+	t.Cleanup(func() {
+		for _, ln := range successful {
+			_ = ln.Close()
+		}
+	})
+	assert.Len(t, successful, 1)
+	assert.Len(t, errs, starts-1)
+
+	var dialer net.Dialer
+	conn, err := dialer.DialContext(t.Context(), "unix", sockPath)
+	require.NoError(t, err)
+	require.NoError(t, conn.Close())
 }

--- a/pkg/server/listen_unix.go
+++ b/pkg/server/listen_unix.go
@@ -3,10 +3,16 @@
 package server
 
 import (
+	"errors"
 	"fmt"
 	"net"
 	"runtime"
+	"syscall"
 )
+
+func isConnectionRefused(err error) bool {
+	return errors.Is(err, syscall.ECONNREFUSED)
+}
 
 func listenNamedPipe(string) (net.Listener, error) {
 	return nil, fmt.Errorf("named pipes not supported on %s", runtime.GOOS)

--- a/pkg/server/listen_unix_socket.go
+++ b/pkg/server/listen_unix_socket.go
@@ -1,0 +1,108 @@
+package server
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+	"sync"
+)
+
+var unixSocketListenMu sync.Mutex
+
+type unixSocketDialer func(context.Context, string) (net.Conn, error)
+
+type unixSocketRenamer func(string, string) (os.FileInfo, error)
+
+func listenUnixSocket(ctx context.Context, path string) (net.Listener, error) {
+	// Keep cooperating starts from observing the path between reclamation and bind.
+	unixSocketListenMu.Lock()
+	defer unixSocketListenMu.Unlock()
+
+	if err := prepareUnixSocket(ctx, path, dialUnixSocket, renameUnixSocket); err != nil {
+		return nil, err
+	}
+
+	var config net.ListenConfig
+	return config.Listen(ctx, "unix", path)
+}
+
+func dialUnixSocket(ctx context.Context, path string) (net.Conn, error) {
+	var dialer net.Dialer
+	return dialer.DialContext(ctx, "unix", path)
+}
+
+func renameUnixSocket(oldPath, newPath string) (os.FileInfo, error) {
+	if err := os.Rename(oldPath, newPath); err != nil {
+		return nil, err
+	}
+	return os.Lstat(newPath)
+}
+
+func prepareUnixSocket(ctx context.Context, path string, dial unixSocketDialer, rename unixSocketRenamer) error {
+	// Portable pathname operations cannot exclude a noncooperating process from
+	// replacing this entry. On a detected race, restore the moved entry without
+	// clobbering the path; the rename can still make the path briefly absent.
+	info, err := os.Lstat(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("inspecting unix socket %q: %w", path, err)
+	}
+	if info.Mode()&os.ModeSocket == 0 {
+		return fmt.Errorf("refusing to replace non-socket path %q", path)
+	}
+
+	conn, err := dial(ctx, path)
+	if err == nil {
+		_ = conn.Close()
+		return fmt.Errorf("unix socket %q is already in use", path)
+	}
+	if !isConnectionRefused(err) {
+		return fmt.Errorf("checking unix socket %q: %w", path, err)
+	}
+
+	quarantineDir, err := os.MkdirTemp(filepath.Dir(path), ".docker-agent-stale-socket-")
+	if err != nil {
+		return fmt.Errorf("creating unix socket quarantine: %w", err)
+	}
+	quarantined := filepath.Join(quarantineDir, "socket")
+	current, err := rename(path, quarantined)
+	if err != nil {
+		cleanupErr := os.Remove(quarantineDir)
+		return errors.Join(fmt.Errorf("quarantining stale unix socket %q: %w", path, err), cleanupErr)
+	}
+
+	if !os.SameFile(info, current) {
+		// A noncooperating process can replace the path between inspection and
+		// rename. Restore its entry without overwriting anything created since.
+		if err := restoreQuarantinedSocket(path, quarantined); err != nil {
+			return fmt.Errorf("unix socket %q changed while checking it: %w", path, err)
+		}
+		if err := os.Remove(quarantineDir); err != nil {
+			return fmt.Errorf("unix socket %q changed while checking it; replacement restored but removing quarantine directory: %w", path, err)
+		}
+		return fmt.Errorf("unix socket %q changed while checking it; replacement restored", path)
+	}
+
+	if err := os.Remove(quarantined); err != nil {
+		return fmt.Errorf("removing stale unix socket %q preserved at %q: %w", path, quarantined, err)
+	}
+	if err := os.Remove(quarantineDir); err != nil {
+		return fmt.Errorf("removing unix socket quarantine %q: %w", quarantineDir, err)
+	}
+	return nil
+}
+
+func restoreQuarantinedSocket(path, quarantined string) error {
+	if err := os.Link(quarantined, path); err != nil {
+		return fmt.Errorf("replacement preserved at %q (public path left unchanged): %w", quarantined, err)
+	}
+	if err := os.Remove(quarantined); err != nil {
+		return fmt.Errorf("replacement restored at %q but also preserved at %q: %w", path, quarantined, err)
+	}
+	return nil
+}

--- a/pkg/server/listen_unix_test.go
+++ b/pkg/server/listen_unix_test.go
@@ -1,0 +1,81 @@
+//go:build !windows
+
+package server
+
+import (
+	"context"
+	"net"
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsConnectionRefused_Unix(t *testing.T) {
+	t.Parallel()
+
+	assert.True(t, isConnectionRefused(syscall.ECONNREFUSED))
+	assert.False(t, isConnectionRefused(syscall.ECONNRESET))
+}
+
+func TestPrepareUnixSocket_RestoresLiveReplacement(t *testing.T) {
+	t.Parallel()
+
+	dir := shortTempDir(t)
+	sockPath := filepath.Join(dir, "a.sock")
+	stale, err := Listen(t.Context(), "unix://"+sockPath)
+	require.NoError(t, err)
+	defer stale.Close()
+	staleInfo, err := os.Lstat(sockPath)
+	require.NoError(t, err)
+
+	var replacement net.Listener
+	err = prepareUnixSocket(t.Context(), sockPath, func(context.Context, string) (net.Conn, error) {
+		return nil, syscall.ECONNREFUSED
+	}, func(oldPath, quarantined string) (os.FileInfo, error) {
+		replacementPath := filepath.Join(dir, "replacement")
+		var config net.ListenConfig
+		replacement, err = config.Listen(t.Context(), "unix", replacementPath)
+		require.NoError(t, err)
+		info, err := os.Lstat(replacementPath)
+		require.NoError(t, err)
+		require.False(t, os.SameFile(staleInfo, info), "replacement must have a distinct inode")
+		require.NoError(t, os.Rename(oldPath, filepath.Join(dir, "original")))
+		require.NoError(t, os.Rename(replacementPath, quarantined))
+		return info, nil
+	})
+	require.ErrorContains(t, err, "changed while checking it; replacement restored")
+	t.Cleanup(func() { _ = replacement.Close() })
+
+	var dialer net.Dialer
+	conn, err := dialer.DialContext(t.Context(), "unix", sockPath)
+	require.NoError(t, err, "the live replacement must remain reachable at its public path")
+	require.NoError(t, conn.Close())
+
+	artifacts, err := filepath.Glob(filepath.Join(dir, ".docker-agent-stale-socket-*"))
+	require.NoError(t, err)
+	assert.Empty(t, artifacts)
+}
+
+func TestRestoreQuarantinedSocket_DoesNotClobberPublicPath(t *testing.T) {
+	t.Parallel()
+
+	dir := shortTempDir(t)
+	path := filepath.Join(dir, "a.sock")
+	quarantined := filepath.Join(dir, "quarantined")
+	require.NoError(t, os.WriteFile(path, []byte("new entry"), 0o600))
+	require.NoError(t, os.WriteFile(quarantined, []byte("preserved entry"), 0o600))
+
+	err := restoreQuarantinedSocket(path, quarantined)
+	require.ErrorContains(t, err, "public path left unchanged")
+
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Equal(t, "new entry", string(data))
+	data, err = os.ReadFile(quarantined)
+	require.NoError(t, err)
+	assert.Equal(t, "preserved entry", string(data))
+}

--- a/pkg/server/listen_windows.go
+++ b/pkg/server/listen_windows.go
@@ -1,10 +1,16 @@
 package server
 
 import (
+	"errors"
 	"net"
 
 	winio "github.com/Microsoft/go-winio"
+	"golang.org/x/sys/windows"
 )
+
+func isConnectionRefused(err error) bool {
+	return errors.Is(err, windows.WSAECONNREFUSED)
+}
 
 func listenNamedPipe(path string) (net.Listener, error) {
 	return winio.ListenPipe(path, nil)

--- a/pkg/server/listen_windows_test.go
+++ b/pkg/server/listen_windows_test.go
@@ -1,0 +1,17 @@
+//go:build windows
+
+package server
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"golang.org/x/sys/windows"
+)
+
+func TestIsConnectionRefused_Windows(t *testing.T) {
+	t.Parallel()
+
+	assert.True(t, isConnectionRefused(windows.WSAECONNREFUSED))
+	assert.False(t, isConnectionRefused(windows.WSAECONNRESET))
+}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -328,7 +328,7 @@ func (s *Server) forkSession(c echo.Context) error {
 		InputTokens:   forked.InputTokens,
 		OutputTokens:  forked.OutputTokens,
 		WorkingDir:    forked.WorkingDir,
-		Permissions:   forked.Permissions,
+		Permissions:   forked.ClonePermissions(),
 	})
 }
 
@@ -350,7 +350,7 @@ func (s *Server) getSession(c echo.Context) error {
 		InputTokens:   inputTokens,
 		OutputTokens:  outputTokens,
 		WorkingDir:    sess.WorkingDir,
-		Permissions:   sess.Permissions,
+		Permissions:   sess.ClonePermissions(),
 	})
 }
 

--- a/pkg/server/session_manager.go
+++ b/pkg/server/session_manager.go
@@ -1050,7 +1050,9 @@ func (sm *SessionManager) RunSession(ctx context.Context, sessionID, agentFilena
 		} else if titleToEmit != "" {
 			// Re-emit the existing title so late-joining SSE consumers
 			// and boards can pick it up without an extra API call.
-			streamChan <- runtime.SessionTitle(sess.ID, titleToEmit)
+			if !sendStreamEvent(streamCtx, streamChan, runtime.SessionTitle(sess.ID, titleToEmit)) {
+				return
+			}
 		}
 
 		stream := runtimeSession.runtime.RunStream(streamCtx, sess)
@@ -1058,18 +1060,17 @@ func (sm *SessionManager) RunSession(ctx context.Context, sessionID, agentFilena
 			select {
 			case event, ok := <-titleEvents:
 				titleEvents = nil
-				if ok {
-					streamChan <- event
+				if ok && !sendStreamEvent(streamCtx, streamChan, event) {
+					return
 				}
 			case event, ok := <-stream:
 				if !ok {
 					stream = nil
 					continue
 				}
-				if streamCtx.Err() != nil {
+				if streamCtx.Err() != nil || !sendStreamEvent(streamCtx, streamChan, event) {
 					return
 				}
-				streamChan <- event
 			}
 		}
 
@@ -1077,8 +1078,8 @@ func (sm *SessionManager) RunSession(ctx context.Context, sessionID, agentFilena
 		// for a slow title provider before finalizing the stream.
 		select {
 		case event, ok := <-titleEvents:
-			if ok {
-				streamChan <- event
+			if ok && !sendStreamEvent(streamCtx, streamChan, event) {
+				return
 			}
 		default:
 		}
@@ -1089,6 +1090,15 @@ func (sm *SessionManager) RunSession(ctx context.Context, sessionID, agentFilena
 	}()
 
 	return streamChan, nil
+}
+
+func sendStreamEvent(ctx context.Context, events chan<- runtime.Event, event runtime.Event) bool {
+	select {
+	case events <- event:
+		return true
+	case <-ctx.Done():
+		return false
+	}
 }
 
 // ResumeSession resumes a paused session with an optional rejection reason or tool name.

--- a/pkg/server/session_manager.go
+++ b/pkg/server/session_manager.go
@@ -12,6 +12,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"go.opentelemetry.io/otel"
@@ -41,7 +42,9 @@ type activeRuntimes struct {
 	session  *session.Session        // The actual session object used by the runtime
 	titleGen *sessiontitle.Generator // Title generator (includes fallback models)
 
-	streaming sync.Mutex // Held while a RunStream is in progress; serialises concurrent requests
+	streaming   sync.Mutex  // Held while a RunStream is in progress; serialises concurrent requests
+	modelSwitch sync.Mutex  // Serialises model changes with manager-owned session persistence
+	deleting    atomic.Bool // Set before deletion waits for an in-flight model transaction
 }
 
 // SessionManager manages sessions for HTTP and Connect-RPC servers.
@@ -65,6 +68,12 @@ type SessionManager struct {
 	// constructor in runtimeForSession. Test seam: lets a build fail
 	// deterministically after the team has been loaded.
 	newRuntime func(context.Context, *team.Team, ...runtime.Opt) (runtime.Runtime, error)
+
+	// beforeRunModelSwitch is a test seam for the RunSession lock boundary.
+	beforeRunModelSwitch func()
+
+	// beforePersistActiveSession is a test seam for the persistence lock boundary.
+	beforePersistActiveSession func()
 
 	refreshInterval time.Duration
 
@@ -828,18 +837,62 @@ func (sm *SessionManager) GetSessions(ctx context.Context) ([]*session.Session, 
 // removes the session from all registries. Callers that need to wait for
 // the stream to fully stop should call WaitStopped afterwards.
 func (sm *SessionManager) DeleteSession(ctx context.Context, sessionID string) error {
+	return sm.deleteSession(ctx, sessionID, true)
+}
+
+type deleteSessionFunc func(context.Context, string) error
+
+func runBatchDelete(ctx context.Context, sessionIDs []string, deleteSession deleteSessionFunc) (int, []string) {
+	deleted := 0
+	var failed []string
+	for _, sessionID := range sessionIDs {
+		if err := deleteSession(ctx, sessionID); err != nil {
+			failed = append(failed, sessionID)
+		} else {
+			deleted++
+		}
+	}
+	return deleted, failed
+}
+
+func (sm *SessionManager) deleteSession(ctx context.Context, sessionID string, trackStopped bool) error {
 	sm.mux.Lock()
-	defer sm.mux.Unlock()
 	sess, err := sm.sessionStore.GetSession(ctx, sessionID)
 	if err != nil {
+		sm.mux.Unlock()
 		return err
 	}
+	sessionRuntime, active := sm.runtimeSessions.Load(sess.ID)
+	if !active {
+		if err := sm.sessionStore.DeleteSession(ctx, sessionID); err != nil {
+			sm.mux.Unlock()
+			return err
+		}
+		sm.finishSessionDeletion(sess.ID, nil, trackStopped)
+		sm.mux.Unlock()
+		return nil
+	}
+	sessionRuntime.deleting.Store(true)
+	sm.mux.Unlock()
 
+	sessionRuntime.modelSwitch.Lock()
 	if err := sm.sessionStore.DeleteSession(ctx, sessionID); err != nil {
+		sessionRuntime.deleting.Store(false)
+		sessionRuntime.modelSwitch.Unlock()
 		return err
 	}
+	sessionRuntime.modelSwitch.Unlock()
 
-	if sessionRuntime, ok := sm.runtimeSessions.Load(sess.ID); ok {
+	sm.mux.Lock()
+	defer sm.mux.Unlock()
+	sm.finishSessionDeletion(sess.ID, sessionRuntime, trackStopped)
+	return nil
+}
+
+// finishSessionDeletion removes manager state after the store row is gone.
+// The caller holds sm.mux.
+func (sm *SessionManager) finishSessionDeletion(sessionID string, sessionRuntime *activeRuntimes, trackStopped bool) {
+	if sessionRuntime != nil {
 		// Server-owned runtimes (done == nil) carry the manager's own
 		// elicitation sink (see runtimeForSession); clear it so a detached
 		// background job that elicits after this point hits the runtime's
@@ -853,39 +906,39 @@ func (sm *SessionManager) DeleteSession(ctx context.Context, sessionID string) e
 		if sessionRuntime.cancel != nil {
 			sessionRuntime.cancel()
 		}
-		// Keep the entry in deletedSessions so WaitStopped can probe the
-		// streaming mutex after the runtime is deregistered.
-		sm.deletedSessions.Store(sess.ID, sessionRuntime)
-		sm.runtimeSessions.Delete(sess.ID)
+		if current, ok := sm.runtimeSessions.Load(sessionID); ok && current == sessionRuntime {
+			sm.runtimeSessions.Delete(sessionID)
+		}
+		if trackStopped {
+			sm.deletedSessions.Store(sessionID, sessionRuntime)
+		}
 
-		// Background cleanup: remove the deletedSessions entry once the
-		// stream goroutine has exited. This prevents a memory leak when
-		// the caller does not use ?wait=true.
-		go func() {
-			ticker := time.NewTicker(100 * time.Millisecond)
-			defer ticker.Stop()
-			deadline := time.After(5 * time.Minute)
-			for {
-				if sessionRuntime.streaming.TryLock() {
-					sessionRuntime.streaming.Unlock()
-					sm.deletedSessions.Delete(sess.ID)
-					return
+		if trackStopped {
+			// Background cleanup prevents leaks when the caller omits ?wait=true.
+			go func() {
+				ticker := time.NewTicker(100 * time.Millisecond)
+				defer ticker.Stop()
+				deadline := time.After(5 * time.Minute)
+				for {
+					if sessionRuntime.streaming.TryLock() {
+						sessionRuntime.streaming.Unlock()
+						sm.deletedSessions.Delete(sessionID)
+						return
+					}
+					select {
+					case <-deadline:
+						sm.deletedSessions.Delete(sessionID)
+						return
+					case <-ticker.C:
+					}
 				}
-				select {
-				case <-deadline:
-					sm.deletedSessions.Delete(sess.ID)
-					return
-				case <-ticker.C:
-				}
-			}
-		}()
+			}()
+		}
 	}
-	sm.dropEventLog(sess.ID)
-	sm.followUpInjectors.Delete(sess.ID)
-	sm.followUpKeys.Delete(sess.ID)
-	sm.pendingSafetyDefaults.Delete(sess.ID)
-
-	return nil
+	sm.dropEventLog(sessionID)
+	sm.followUpInjectors.Delete(sessionID)
+	sm.followUpKeys.Delete(sessionID)
+	sm.pendingSafetyDefaults.Delete(sessionID)
 }
 
 // WaitStopped blocks until the session's runtime stream goroutine has fully
@@ -936,20 +989,26 @@ var (
 // history.
 func (sm *SessionManager) RunSession(ctx context.Context, sessionID, agentFilename, currentAgent string, messages []api.Message, modelOverride string) (<-chan runtime.Event, error) {
 	sm.mux.Lock()
-	defer sm.mux.Unlock()
-	sess, err := sm.sessionStore.GetSession(ctx, sessionID)
-	if err != nil {
-		return nil, err
-	}
-
 	runtimeSession, exists := sm.runtimeSessions.Load(sessionID)
 
 	streamCtx, cancel := context.WithCancel(ctx)
-	var titleGen *sessiontitle.Generator
+	var (
+		sess     *session.Session
+		titleGen *sessiontitle.Generator
+		err      error
+	)
 	if !exists {
+		sess, err = sm.sessionStore.GetSession(ctx, sessionID)
+		if err != nil {
+			sm.mux.Unlock()
+			cancel()
+			return nil, err
+		}
+
 		var rt runtime.Runtime
 		rt, titleGen, err = sm.runtimeForSession(ctx, sess, agentFilename, currentAgent, sm.runConfig)
 		if err != nil {
+			sm.mux.Unlock()
 			cancel()
 			return nil, err
 		}
@@ -971,6 +1030,7 @@ func (sm *SessionManager) RunSession(ctx context.Context, sessionID, agentFilena
 	// progress, which would produce a tool_use without a matching
 	// tool_result and cause provider errors.
 	if !runtimeSession.streaming.TryLock() {
+		sm.mux.Unlock()
 		cancel()
 		return nil, ErrSessionBusy
 	}
@@ -981,21 +1041,47 @@ func (sm *SessionManager) RunSession(ctx context.Context, sessionID, agentFilena
 	if runtimeSession.done == nil {
 		runtimeSession.cancel = cancel
 	}
+	sm.mux.Unlock()
+
+	// Model mutation may perform provider I/O. Coordinate it per session,
+	// outside sm.mux, while streaming excludes both direct and managed runs.
+	if sm.beforeRunModelSwitch != nil {
+		sm.beforeRunModelSwitch()
+	}
+	runtimeSession.modelSwitch.Lock()
+	defer runtimeSession.modelSwitch.Unlock()
+
+	if !sm.runtimeActive(sessionID, runtimeSession) {
+		runtimeSession.streaming.Unlock()
+		cancel()
+		return nil, ErrSessionNotRunning
+	}
+
+	if exists {
+		sess = runtimeSession.session
+	}
 
 	// Apply the model override (if any) before persisting the user
 	// messages so that an invalid ref does not leave an orphaned user
-	// message in the history. We hold both sm.mux and streaming, so we
-	// can mutate session fields directly; on store-write failure below
-	// we roll the runtime back to its previous override.
-	prevOverride, hadPrevOverride, undoModelOverride, err := sm.applyRunModelOverride(ctx, runtimeSession, modelOverride)
+	// message in the history. The streaming and modelSwitch locks keep the
+	// runtime, persisted snapshot, live session, and rollback in one transaction.
+	undoModelOverride, err := sm.applyRunModelOverride(ctx, runtimeSession, modelOverride)
 	if err != nil {
 		runtimeSession.streaming.Unlock()
 		cancel()
 		return nil, err
 	}
 
+	if modelOverride != "" {
+		if err := ctx.Err(); err != nil {
+			undoModelOverride(context.WithoutCancel(ctx))
+			runtimeSession.streaming.Unlock()
+			cancel()
+			return nil, err
+		}
+	}
 	if err := sm.applyAgentSwitchCommands(ctx, runtimeSession.runtime, messages); err != nil {
-		undoModelOverride(ctx, prevOverride, hadPrevOverride)
+		undoModelOverride(context.WithoutCancel(ctx))
 		runtimeSession.streaming.Unlock()
 		cancel()
 		return nil, err
@@ -1012,7 +1098,7 @@ func (sm *SessionManager) RunSession(ctx context.Context, sessionID, agentFilena
 	}
 
 	if err := sm.sessionStore.UpdateSession(ctx, sess); err != nil {
-		undoModelOverride(ctx, prevOverride, hadPrevOverride)
+		undoModelOverride(context.WithoutCancel(ctx))
 		runtimeSession.streaming.Unlock()
 		cancel()
 		return nil, err
@@ -1084,7 +1170,7 @@ func (sm *SessionManager) RunSession(ctx context.Context, sessionID, agentFilena
 		default:
 		}
 
-		if err := sm.sessionStore.UpdateSession(ctx, sess); err != nil {
+		if err := sm.persistActiveSession(ctx, sessionID, runtimeSession, sess); err != nil {
 			return
 		}
 	}()
@@ -1101,14 +1187,25 @@ func sendStreamEvent(ctx context.Context, events chan<- runtime.Event, event run
 	}
 }
 
+func (sm *SessionManager) runtimeActive(sessionID string, rs *activeRuntimes) bool {
+	if rs.deleting.Load() {
+		return false
+	}
+	active, ok := sm.runtimeSessions.Load(sessionID)
+	return ok && active == rs
+}
+
 // ResumeSession resumes a paused session with an optional rejection reason or tool name.
 func (sm *SessionManager) ResumeSession(ctx context.Context, sessionID, confirmation, reason, toolName string) error {
-	sm.mux.Lock()
-	defer sm.mux.Unlock()
-
 	rt, exists := sm.runtimeSessions.Load(sessionID)
 	if !exists {
 		return errors.New("session not found")
+	}
+
+	rt.modelSwitch.Lock()
+	defer rt.modelSwitch.Unlock()
+	if !sm.runtimeActive(sessionID, rt) {
+		return ErrSessionNotRunning
 	}
 
 	// Mirror + persist mid-turn session mutations synchronously —
@@ -1254,9 +1351,9 @@ func (sm *SessionManager) recallSession(ctx context.Context, sessionID string, m
 	}
 
 	runCtx, runCancel := context.WithCancel(context.WithoutCancel(ctx))
-	sm.mux.Lock()
-	if _, stillExists := sm.runtimeSessions.Load(sessionID); !stillExists {
-		sm.mux.Unlock()
+	rt.modelSwitch.Lock()
+	if !sm.runtimeActive(sessionID, rt) {
+		rt.modelSwitch.Unlock()
 		rt.streaming.Unlock()
 		runCancel()
 		return ErrSessionNotRunning
@@ -1266,7 +1363,7 @@ func (sm *SessionManager) recallSession(ctx context.Context, sessionID string, m
 		var err error
 		sess, err = sm.sessionStore.GetSession(ctx, sessionID)
 		if err != nil {
-			sm.mux.Unlock()
+			rt.modelSwitch.Unlock()
 			rt.streaming.Unlock()
 			runCancel()
 			return err
@@ -1274,7 +1371,7 @@ func (sm *SessionManager) recallSession(ctx context.Context, sessionID string, m
 	}
 	sess.AddMessage(session.UserMessage(msg.Content, msg.MultiContent...))
 	if err := sm.sessionStore.UpdateSession(ctx, sess); err != nil {
-		sm.mux.Unlock()
+		rt.modelSwitch.Unlock()
 		rt.streaming.Unlock()
 		runCancel()
 		return err
@@ -1285,7 +1382,7 @@ func (sm *SessionManager) recallSession(ctx context.Context, sessionID string, m
 	if rt.done == nil {
 		rt.cancel = runCancel
 	}
-	sm.mux.Unlock()
+	rt.modelSwitch.Unlock()
 
 	_, skipMirroredElicitation := rt.runtime.(elicitationSinkMirror)
 	go func() {
@@ -1304,12 +1401,7 @@ func (sm *SessionManager) recallSession(ctx context.Context, sessionID string, m
 				pe.log.append(event)
 			}
 		}
-		sm.mux.Lock()
-		defer sm.mux.Unlock()
-		if _, stillExists := sm.runtimeSessions.Load(sessionID); !stillExists {
-			return
-		}
-		if err := sm.sessionStore.UpdateSession(context.WithoutCancel(ctx), sess); err != nil {
+		if err := sm.persistActiveSession(context.WithoutCancel(ctx), sessionID, rt, sess); err != nil && !errors.Is(err, ErrSessionNotRunning) {
 			slog.WarnContext(ctx, "Failed to persist recalled session", "session_id", sessionID, "error", err)
 		}
 	}()
@@ -1337,21 +1429,17 @@ func (sm *SessionManager) ResumeElicitation(ctx context.Context, sessionID, acti
 // toggle round-trip.
 func (sm *SessionManager) ToggleToolApproval(ctx context.Context, sessionID string) error {
 	sm.mux.Lock()
-	defer sm.mux.Unlock()
-
-	// Mirror onto the live runtime session so the dispatcher picks up
-	// the change on the next tool call, not just the next turn. If the
-	// store write fails, toggle back (ToggleYolo is its own inverse) so
-	// the live session never diverges from what a reload would produce —
-	// the caller got an error, so the toggle must not have half-happened.
-	if rt, ok := sm.runtimeSessions.Load(sessionID); ok && rt.session != nil {
-		rt.session.ToggleYolo()
-		if err := sm.sessionStore.UpdateSession(ctx, rt.session); err != nil {
-			rt.session.ToggleYolo()
-			return err
-		}
-		return nil
+	rt, active := sm.runtimeSessions.Load(sessionID)
+	if active && rt.session != nil {
+		sess := rt.session
+		sm.mux.Unlock()
+		return sm.updateActiveSession(ctx, sessionID, rt, sess, func() {
+			sess.ToggleYolo()
+		}, func() {
+			sess.ToggleYolo()
+		})
 	}
+	defer sm.mux.Unlock()
 
 	sess, err := sm.sessionStore.GetSession(ctx, sessionID)
 	if err != nil {
@@ -1367,14 +1455,15 @@ func (sm *SessionManager) SetSessionSafetyPolicy(ctx context.Context, sessionID 
 		return fmt.Errorf("invalid safety_policy: %q", policy)
 	}
 	sm.mux.Lock()
-	defer sm.mux.Unlock()
-
-	// Mirror onto the live runtime session so the dispatcher picks up
-	// the new policy on the next tool call, not just the next turn.
-	if rt, ok := sm.runtimeSessions.Load(sessionID); ok && rt.session != nil {
-		rt.session.SetSafetyPolicy(policy)
-		return sm.sessionStore.UpdateSession(ctx, rt.session)
+	rt, active := sm.runtimeSessions.Load(sessionID)
+	if active && rt.session != nil {
+		sess := rt.session
+		sm.mux.Unlock()
+		return sm.updateActiveSession(ctx, sessionID, rt, sess, func() {
+			sess.SetSafetyPolicy(policy)
+		}, nil)
 	}
+	defer sm.mux.Unlock()
 
 	sess, err := sm.sessionStore.GetSession(ctx, sessionID)
 	if err != nil {
@@ -1387,12 +1476,15 @@ func (sm *SessionManager) SetSessionSafetyPolicy(ctx context.Context, sessionID 
 // UpdateSessionPermissions updates the permissions for a session.
 func (sm *SessionManager) UpdateSessionPermissions(ctx context.Context, sessionID string, perms *session.PermissionsConfig) error {
 	sm.mux.Lock()
-	defer sm.mux.Unlock()
-
-	if rt, ok := sm.runtimeSessions.Load(sessionID); ok && rt.session != nil {
-		rt.session.SetPermissions(perms)
-		return sm.sessionStore.UpdateSession(ctx, rt.session)
+	rt, active := sm.runtimeSessions.Load(sessionID)
+	if active && rt.session != nil {
+		sess := rt.session
+		sm.mux.Unlock()
+		return sm.updateActiveSession(ctx, sessionID, rt, sess, func() {
+			sess.SetPermissions(perms)
+		}, nil)
 	}
+	defer sm.mux.Unlock()
 
 	sess, err := sm.sessionStore.GetSession(ctx, sessionID)
 	if err != nil {
@@ -1402,20 +1494,46 @@ func (sm *SessionManager) UpdateSessionPermissions(ctx context.Context, sessionI
 	return sm.sessionStore.UpdateSession(ctx, sess)
 }
 
+func (sm *SessionManager) persistActiveSession(ctx context.Context, sessionID string, rt *activeRuntimes, sess *session.Session) error {
+	return sm.updateActiveSession(ctx, sessionID, rt, sess, nil, nil)
+}
+
+func (sm *SessionManager) updateActiveSession(ctx context.Context, sessionID string, rt *activeRuntimes, sess *session.Session, update, rollback func()) error {
+	if sm.beforePersistActiveSession != nil {
+		sm.beforePersistActiveSession()
+	}
+	rt.modelSwitch.Lock()
+	defer rt.modelSwitch.Unlock()
+	if !sm.runtimeActive(sessionID, rt) || rt.session != sess {
+		return ErrSessionNotRunning
+	}
+	if update != nil {
+		update()
+	}
+	if err := sm.sessionStore.UpdateSession(ctx, sess); err != nil {
+		if rollback != nil {
+			rollback()
+		}
+		return err
+	}
+	return nil
+}
+
 // UpdateSessionTitle updates the title for a session.
 // If the session is actively running, it also updates the in-memory session
 // object to prevent subsequent runtime saves from overwriting the title.
 func (sm *SessionManager) UpdateSessionTitle(ctx context.Context, sessionID, title string) error {
 	sm.mux.Lock()
-	defer sm.mux.Unlock()
-
-	// If session is actively running, update the in-memory session object directly.
-	// This ensures the runtime's saveSession won't overwrite our manual edit.
-	if rt, ok := sm.runtimeSessions.Load(sessionID); ok && rt.session != nil {
-		rt.session.SetTitle(title)
+	rt, active := sm.runtimeSessions.Load(sessionID)
+	if active && rt.session != nil {
+		sess := rt.session
+		sm.mux.Unlock()
 		slog.DebugContext(ctx, "Updated title for active session", "session_id", sessionID, "title", title)
-		return sm.sessionStore.UpdateSession(ctx, rt.session)
+		return sm.updateActiveSession(ctx, sessionID, rt, sess, func() {
+			sess.SetTitle(title)
+		}, nil)
 	}
+	defer sm.mux.Unlock()
 
 	// Session is not actively running, load from store and update
 	sess, err := sm.sessionStore.GetSession(ctx, sessionID)
@@ -1445,12 +1563,11 @@ func (sm *SessionManager) generateTitle(ctx context.Context, sess *session.Sessi
 		return
 	}
 
-	// Update the in-memory session
-	sess.SetTitle(title)
-
-	// Persist the title
-	if err := sm.sessionStore.UpdateSession(ctx, sess); err != nil {
-		slog.ErrorContext(ctx, "Failed to persist generated title", "session_id", sess.ID, "error", err)
+	// Persist only while this exact live session remains active.
+	rs, ok := sm.runtimeSessions.Load(sess.ID)
+	if !ok || sm.updateActiveSession(ctx, sess.ID, rs, sess, func() {
+		sess.SetTitle(title)
+	}, nil) != nil {
 		return
 	}
 
@@ -1580,7 +1697,8 @@ func (sm *SessionManager) runtimeForSession(ctx context.Context, sess *session.S
 	// Apply any stored per-agent model overrides so that a session
 	// resumed (or freshly created with overrides via CreateSession) uses
 	// the requested models instead of the agent's defaults.
-	applyStoredOverrides(ctx, sess.ID, run, sess.AgentModelOverrides)
+	overrides, _ := sess.ModelStateSnapshot()
+	applyStoredOverrides(ctx, sess.ID, run, overrides)
 
 	titleModels := agt.TitleModels(ctx)
 	var titleGen *sessiontitle.Generator
@@ -1724,70 +1842,48 @@ func (sm *SessionManager) resolveSource(agentFilename string) (config.Source, er
 	return nil, fmt.Errorf("%w: agent not found: %s", ErrAgentNotFound, agentFilename)
 }
 
-// applyRunModelOverride applies modelRef as the per-agent model override
-// on the session backing rs. It mirrors the in-memory mutations that
-// SetSessionAgentModel performs, but without acquiring sm.mux (the
-// caller already holds it) and without an explicit store write — the
-// caller's pending UpdateSession persists the override alongside any
-// user messages in a single round trip.
-//
-// Returns the previous override value (and whether one existed) plus an
-// undo function. If the subsequent store write fails the caller must
-// invoke undo to roll the runtime override back; the in-memory session
-// fields are owned by the caller and rolled back inline.
-func (sm *SessionManager) applyRunModelOverride(ctx context.Context, rs *activeRuntimes, modelRef string) (prevOverride string, hadPrev bool, undo func(context.Context, string, bool), err error) {
-	noop := func(context.Context, string, bool) {}
+// applyRunModelOverride applies modelRef to the runtime and live session.
+// The caller holds modelSwitch and persists the resulting session snapshot.
+// The returned undo restores both runtime and complete model state.
+func (sm *SessionManager) applyRunModelOverride(ctx context.Context, rs *activeRuntimes, modelRef string) (undo func(context.Context), err error) {
+	noop := func(context.Context) {}
 	if modelRef == "" {
-		return "", false, noop, nil
+		return noop, nil
 	}
 	if !rs.runtime.SupportsModelSwitching() {
-		return "", false, noop, ErrModelSwitchingNotSupported
+		return noop, ErrModelSwitchingNotSupported
 	}
 
 	agentName := rs.runtime.CurrentAgentName(ctx)
 	sess := rs.session
-
-	if sess != nil && sess.AgentModelOverrides != nil {
-		prevOverride, hadPrev = sess.AgentModelOverrides[agentName]
+	var previousOverrides map[string]string
+	var previousCustomModels []string
+	if sess != nil {
+		previousOverrides, previousCustomModels = sess.ModelStateSnapshot()
 	}
+	prevOverride, hadPrev := previousOverrides[agentName]
 
 	if err := rs.runtime.SetAgentModel(ctx, agentName, modelRef); err != nil {
-		return "", false, noop, err
+		return noop, err
 	}
 
-	var appendedCustom bool
 	if sess != nil {
-		if sess.AgentModelOverrides == nil {
-			sess.AgentModelOverrides = make(map[string]string)
-		}
-		sess.AgentModelOverrides[agentName] = modelRef
-		if strings.Contains(modelRef, "/") && !slices.Contains(sess.CustomModelsUsed, modelRef) {
-			sess.CustomModelsUsed = append(sess.CustomModelsUsed, modelRef)
-			appendedCustom = true
-		}
+		sess.SetAgentModelOverride(agentName, modelRef)
 	}
 
-	undo = func(ctx context.Context, prev string, had bool) {
-		rollback := prev
-		if !had {
+	undo = func(ctx context.Context) {
+		rollback := prevOverride
+		if !hadPrev {
 			rollback = ""
 		}
 		if rbErr := rs.runtime.SetAgentModel(ctx, agentName, rollback); rbErr != nil {
 			slog.ErrorContext(ctx, "Failed to roll back runtime model override", "agent", agentName, "error", rbErr)
 		}
-		if sess == nil {
-			return
-		}
-		if had {
-			sess.AgentModelOverrides[agentName] = prev
-		} else {
-			delete(sess.AgentModelOverrides, agentName)
-		}
-		if appendedCustom {
-			sess.CustomModelsUsed = sess.CustomModelsUsed[:len(sess.CustomModelsUsed)-1]
+		if sess != nil {
+			sess.ReplaceModelState(previousOverrides, previousCustomModels)
 		}
 	}
-	return prevOverride, hadPrev, undo, nil
+	return undo, nil
 }
 
 // applyAgentSwitchCommands is the HTTP analogue of
@@ -2004,23 +2100,20 @@ func (sm *SessionManager) AvailableSessionModels(ctx context.Context, sessionID 
 
 	agentName := rs.runtime.CurrentAgentName(ctx)
 
-	// Snapshot the override and custom-model history under sm.mux so the
-	// read is atomic with respect to SetSessionAgentModel writes. The
-	// (potentially slow) runtime.AvailableModels call must NOT happen
-	// under sm.mux: it can perform network I/O (provider discovery,
-	// models.dev catalog lookup) and would block every other session
-	// operation in the manager.
-	sm.mux.Lock()
+	// Model state is protected by Session.mu; modelSwitch only serializes runtime
+	// calls and store transactions for this active runtime.
+	if rs.deleting.Load() {
+		return "", "", nil, ErrSessionNotRunning
+	}
+	rs.modelSwitch.Lock()
 	current := ""
 	var customRefs []string
 	if rs.session != nil {
-		current = rs.session.AgentModelOverrides[agentName]
-		if n := len(rs.session.CustomModelsUsed); n > 0 {
-			customRefs = make([]string, n)
-			copy(customRefs, rs.session.CustomModelsUsed)
-		}
+		overrides, refs := rs.session.ModelStateSnapshot()
+		current = overrides[agentName]
+		customRefs = refs
 	}
-	sm.mux.Unlock()
+	rs.modelSwitch.Unlock()
 
 	choices := runtime.DecorateModelChoices(rs.runtime.AvailableModels(ctx), current, customRefs)
 	return agentName, current, choices, nil
@@ -2047,30 +2140,24 @@ func (sm *SessionManager) SetSessionAgentModel(ctx context.Context, sessionID, m
 		return "", "", ErrModelSwitchingNotSupported
 	}
 
-	agentName := rs.runtime.CurrentAgentName(ctx)
-	sess := rs.session
+	rs.modelSwitch.Lock()
+	defer rs.modelSwitch.Unlock()
 
-	// Snapshot current state so we can roll back if persistence fails
-	// after we've already mutated the runtime.
-	var (
-		hadOverride     bool
-		prevOverride    string
-		hadOverridesMap bool
-	)
-	if sess != nil {
-		sm.mux.Lock()
-		hadOverridesMap = sess.AgentModelOverrides != nil
-		if hadOverridesMap {
-			prevOverride, hadOverride = sess.AgentModelOverrides[agentName]
-		}
-		sm.mux.Unlock()
+	if err := ctx.Err(); err != nil {
+		return "", "", err
+	}
+	if !sm.runtimeActive(sessionID, rs) {
+		return "", "", ErrSessionNotRunning
 	}
 
-	// Runtime mutation runs without sm.mux so it doesn't block other
-	// session operations during slow provider creation. The per-session
-	// modelSwitch lock above keeps SetAgentModel + UpdateSession + any
-	// rollback atomic with respect to other model-switch calls on this
-	// session.
+	agentName := rs.runtime.CurrentAgentName(ctx)
+	sess := rs.session
+	var prevOverride string
+	var hadOverride bool
+	if sess != nil {
+		prevOverride, hadOverride = sess.AgentModelOverride(agentName)
+	}
+
 	if err := rs.runtime.SetAgentModel(ctx, agentName, modelRef); err != nil {
 		return "", "", err
 	}
@@ -2079,47 +2166,31 @@ func (sm *SessionManager) SetSessionAgentModel(ctx context.Context, sessionID, m
 		return agentName, modelRef, nil
 	}
 
-	// Clone the session for the store write. We'll apply mutations to the
-	// clone, persist it, and only then update the live session. This ensures
-	// concurrent readers never observe a not-yet-persisted state.
-	// Title and the token/cost triple are taken through the locked accessors
-	// because the runtime stream goroutine writes them concurrently.
-	title := sess.TitleSnapshot()
-	inputTokens, outputTokens, cost := sess.TokensAndCost()
-	updatedSess := &session.Session{
-		ID:         sess.ID,
-		Title:      title,
-		CreatedAt:  sess.CreatedAt,
-		Origin:     sess.Origin,
-		WorkingDir: sess.WorkingDir,
-		// SafetyPolicy must travel with ToolsApproved: omitting it would
-		// reset a strict/balanced session to the legacy default on reload.
-		SafetyPolicy:            sess.SafetyPolicy,
-		ToolsApproved:           sess.ToolsApproved,
-		Permissions:             sess.ClonePermissions(),
-		Attributes:              sess.AttributesSnapshot(),
-		MaxIterations:           sess.MaxIterations,
-		MaxConsecutiveToolCalls: sess.MaxConsecutiveToolCalls,
-		MaxOldToolCallTokens:    sess.MaxOldToolCallTokens,
-		MaxToolResultTokens:     sess.MaxToolResultTokens,
-		InputTokens:             inputTokens,
-		OutputTokens:            outputTokens,
-		Cost:                    cost,
-		Starred:                 sess.Starred,
+	if err := ctx.Err(); err != nil {
+		rollback := prevOverride
+		if !hadOverride {
+			rollback = ""
+		}
+		if rbErr := rs.runtime.SetAgentModel(context.WithoutCancel(ctx), agentName, rollback); rbErr != nil {
+			slog.ErrorContext(ctx, "Failed to roll back runtime model override", "session_id", sessionID, "agent", agentName, "error", rbErr)
+		}
+		return "", "", err
+	}
+	if !sm.runtimeActive(sessionID, rs) {
+		rollback := prevOverride
+		if !hadOverride {
+			rollback = ""
+		}
+		if err := rs.runtime.SetAgentModel(context.WithoutCancel(ctx), agentName, rollback); err != nil {
+			slog.ErrorContext(ctx, "Failed to roll back runtime model override", "session_id", sessionID, "agent", agentName, "error", err)
+		}
+		return "", "", ErrSessionNotRunning
 	}
 
-	// Clone the maps/slices under sm.mux to avoid data races
-	sm.mux.Lock()
-	if sess.AgentModelOverrides != nil {
-		updatedSess.AgentModelOverrides = maps.Clone(sess.AgentModelOverrides)
-	}
-	if len(sess.CustomModelsUsed) > 0 {
-		updatedSess.CustomModelsUsed = append([]string(nil), sess.CustomModelsUsed...)
-	}
-	sm.mux.Unlock()
-
-	// Apply the mutations to the cloned session
-	var appendedCustomUsed bool
+	// Persist a complete snapshot so model changes cannot discard messages or
+	// metadata added since the runtime was attached.
+	updatedSess := sess.Clone()
+	updatedSess.Origin = sess.Origin
 	if modelRef == "" {
 		delete(updatedSess.AgentModelOverrides, agentName)
 	} else {
@@ -2127,17 +2198,11 @@ func (sm *SessionManager) SetSessionAgentModel(ctx context.Context, sessionID, m
 			updatedSess.AgentModelOverrides = make(map[string]string)
 		}
 		updatedSess.AgentModelOverrides[agentName] = modelRef
-
-		// Track inline provider/model references so they remain easy to
-		// re-select via the model picker (mirrors App.SetCurrentAgentModel).
 		if strings.Contains(modelRef, "/") && !slices.Contains(updatedSess.CustomModelsUsed, modelRef) {
 			updatedSess.CustomModelsUsed = append(updatedSess.CustomModelsUsed, modelRef)
-			appendedCustomUsed = true
 		}
 	}
 
-	// Persist the cloned session. If this fails, the live session is
-	// unchanged and we only need to roll back the runtime.
 	if err := sm.sessionStore.UpdateSession(ctx, updatedSess); err != nil {
 		rollback := prevOverride
 		if !hadOverride {
@@ -2149,22 +2214,7 @@ func (sm *SessionManager) SetSessionAgentModel(ctx context.Context, sessionID, m
 		return "", "", fmt.Errorf("failed to persist model override: %w", err)
 	}
 
-	// Store write succeeded. Now apply the mutations to the live session
-	// under sm.mux so concurrent readers observe the change atomically.
-	sm.mux.Lock()
-	if modelRef == "" {
-		delete(sess.AgentModelOverrides, agentName)
-	} else {
-		if sess.AgentModelOverrides == nil {
-			sess.AgentModelOverrides = make(map[string]string)
-		}
-		sess.AgentModelOverrides[agentName] = modelRef
-
-		if appendedCustomUsed {
-			sess.CustomModelsUsed = append(sess.CustomModelsUsed, modelRef)
-		}
-	}
-	sm.mux.Unlock()
+	sess.SetAgentModelOverride(agentName, modelRef)
 
 	slog.DebugContext(ctx, "Updated session model override", "session_id", sessionID, "agent", agentName, "model", modelRef)
 	return agentName, modelRef, nil
@@ -2172,37 +2222,9 @@ func (sm *SessionManager) SetSessionAgentModel(ctx context.Context, sessionID, m
 
 // BatchDeleteSessions deletes multiple sessions in a single operation.
 func (sm *SessionManager) BatchDeleteSessions(ctx context.Context, sessionIDs []string) (int, []string) {
-	sm.mux.Lock()
-	defer sm.mux.Unlock()
-
-	deleted := 0
-	var failed []string
-
-	for _, sessionID := range sessionIDs {
-		if err := sm.sessionStore.DeleteSession(ctx, sessionID); err != nil {
-			failed = append(failed, sessionID)
-		} else {
-			deleted++
-			if sessionRuntime, ok := sm.runtimeSessions.Load(sessionID); ok {
-				// Same as DeleteSession: silence the manager-registered
-				// elicitation sink on server-owned runtimes so post-delete
-				// background elicitations fast-decline instead of parking.
-				if sessionRuntime.done == nil {
-					sessionRuntime.runtime.OnElicitationRequest(nil)
-				}
-				if sessionRuntime.cancel != nil {
-					sessionRuntime.cancel()
-				}
-				sm.runtimeSessions.Delete(sessionID)
-			}
-			sm.dropEventLog(sessionID)
-			sm.followUpInjectors.Delete(sessionID)
-			sm.followUpKeys.Delete(sessionID)
-			sm.pendingSafetyDefaults.Delete(sessionID)
-		}
-	}
-
-	return deleted, failed
+	return runBatchDelete(ctx, sessionIDs, func(ctx context.Context, sessionID string) error {
+		return sm.deleteSession(ctx, sessionID, false)
+	})
 }
 
 // BatchExportSessions exports multiple sessions as JSON

--- a/pkg/server/session_manager.go
+++ b/pkg/server/session_manager.go
@@ -1039,9 +1039,14 @@ func (sm *SessionManager) RunSession(ctx context.Context, sessionID, agentFilena
 		defer cancel()
 		defer runtimeSession.streaming.Unlock()
 
-		// Start title generation in parallel if needed
+		var titleEvents <-chan runtime.Event
 		if needsTitle {
-			go sm.generateTitle(ctx, sess, titleGen, userMessages, streamChan)
+			ch := make(chan runtime.Event, 1)
+			titleEvents = ch
+			go func() {
+				defer close(ch)
+				sm.generateTitle(ctx, sess, titleGen, userMessages, ch)
+			}()
 		} else if titleToEmit != "" {
 			// Re-emit the existing title so late-joining SSE consumers
 			// and boards can pick it up without an extra API call.
@@ -1049,11 +1054,33 @@ func (sm *SessionManager) RunSession(ctx context.Context, sessionID, agentFilena
 		}
 
 		stream := runtimeSession.runtime.RunStream(streamCtx, sess)
-		for event := range stream {
-			if streamCtx.Err() != nil {
-				return
+		for stream != nil {
+			select {
+			case event, ok := <-titleEvents:
+				titleEvents = nil
+				if ok {
+					streamChan <- event
+				}
+			case event, ok := <-stream:
+				if !ok {
+					stream = nil
+					continue
+				}
+				if streamCtx.Err() != nil {
+					return
+				}
+				streamChan <- event
 			}
-			streamChan <- event
+		}
+
+		// Forward a title that completed alongside the runtime without waiting
+		// for a slow title provider before finalizing the stream.
+		select {
+		case event, ok := <-titleEvents:
+			if ok {
+				streamChan <- event
+			}
+		default:
 		}
 
 		if err := sm.sessionStore.UpdateSession(ctx, sess); err != nil {

--- a/pkg/server/session_manager.go
+++ b/pkg/server/session_manager.go
@@ -435,11 +435,10 @@ func (sm *SessionManager) AttachRuntime(ctx context.Context, sessionID string, r
 
 // GetSession retrieves a session by ID.
 func (sm *SessionManager) GetSession(ctx context.Context, id string) (*session.Session, error) {
-	sess, err := sm.sessionStore.GetSession(ctx, id)
-	if err != nil {
-		return nil, err
+	if rs, ok := sm.runtimeSessions.Load(id); ok && rs.session != nil {
+		return rs.session.Clone(), nil
 	}
-	return sess, nil
+	return sm.sessionStore.GetSession(ctx, id)
 }
 
 // WaitSessionAttached blocks until a runtime is attached for sessionID (i.e.
@@ -546,7 +545,7 @@ func (sm *SessionManager) GetSessionSnapshot(ctx context.Context, id string) (*a
 		Messages:      sess.GetAllMessages(),
 		ToolsApproved: sess.ToolsApproved,
 		SafetyPolicy:  sess.SafetyPolicy,
-		Permissions:   sess.Permissions,
+		Permissions:   sess.ClonePermissions(),
 		InputTokens:   inputTokens,
 		OutputTokens:  outputTokens,
 		Streaming:     streaming,
@@ -1388,13 +1387,17 @@ func (sm *SessionManager) SetSessionSafetyPolicy(ctx context.Context, sessionID 
 func (sm *SessionManager) UpdateSessionPermissions(ctx context.Context, sessionID string, perms *session.PermissionsConfig) error {
 	sm.mux.Lock()
 	defer sm.mux.Unlock()
+
+	if rt, ok := sm.runtimeSessions.Load(sessionID); ok && rt.session != nil {
+		rt.session.SetPermissions(perms)
+		return sm.sessionStore.UpdateSession(ctx, rt.session)
+	}
+
 	sess, err := sm.sessionStore.GetSession(ctx, sessionID)
 	if err != nil {
 		return err
 	}
-
-	sess.Permissions = perms
-
+	sess.SetPermissions(perms)
 	return sm.sessionStore.UpdateSession(ctx, sess)
 }
 
@@ -2094,7 +2097,7 @@ func (sm *SessionManager) SetSessionAgentModel(ctx context.Context, sessionID, m
 		// reset a strict/balanced session to the legacy default on reload.
 		SafetyPolicy:            sess.SafetyPolicy,
 		ToolsApproved:           sess.ToolsApproved,
-		Permissions:             sess.Permissions,
+		Permissions:             sess.ClonePermissions(),
 		Attributes:              sess.AttributesSnapshot(),
 		MaxIterations:           sess.MaxIterations,
 		MaxConsecutiveToolCalls: sess.MaxConsecutiveToolCalls,
@@ -2259,7 +2262,7 @@ func (sm *SessionManager) ExportSessionForRecovery(ctx context.Context, sessionI
 		"output_tokens":  outputTokens,
 		"working_dir":    sess.WorkingDir,
 		"tools_approved": sess.ToolsApproved,
-		"permissions":    sess.Permissions,
+		"permissions":    sess.ClonePermissions(),
 	}
 	// Recorded errors are session items, not messages, so GetAllMessages
 	// drops them. Export them separately: recovery exports feed diagnostics,

--- a/pkg/server/session_manager.go
+++ b/pkg/server/session_manager.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"slices"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -1935,14 +1936,12 @@ func (sm *SessionManager) UpdateMessage(ctx context.Context, sessionID, msgID st
 		defer rt.streaming.Unlock()
 	}
 
-	// Parse msgID as int64
-	var msgPos int64
-	_, err := fmt.Sscanf(msgID, "%d", &msgPos)
+	msgPos, err := strconv.ParseInt(msgID, 10, 64)
 	if err != nil {
-		return fmt.Errorf("invalid message ID: %w", err)
+		return fmt.Errorf("invalid message ID %q: %w", msgID, err)
 	}
 
-	return sm.sessionStore.UpdateMessage(ctx, msgPos, msg)
+	return sm.sessionStore.UpdateMessage(ctx, sessionID, msgPos, msg)
 }
 
 // AddSummary adds a summary to a session.

--- a/pkg/server/session_manager_test.go
+++ b/pkg/server/session_manager_test.go
@@ -199,6 +199,53 @@ func TestRunSession_TitleCanFinishAfterRuntimeStream(t *testing.T) {
 	}, 2*time.Second, 10*time.Millisecond)
 }
 
+func TestRunSession_CancellationUnblocksExistingTitle(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+	sess := session.New(session.WithTitle("Existing title"))
+	sm := newTestSessionManager(t, sess, &fakeRuntime{})
+
+	events, err := sm.RunSession(ctx, sess.ID, "agent", "root", []api.Message{{Content: "hello"}}, "")
+	require.NoError(t, err)
+	assertSessionStreamingEventuallyUnlocked(t, sm, sess.ID)
+	for range events {
+	}
+}
+
+func TestSendStreamEvent_CancellationUnblocks(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(t.Context())
+	result := make(chan bool)
+	go func() {
+		result <- sendStreamEvent(ctx, make(chan runtime.Event), runtime.SessionTitle("session", "title"))
+	}()
+	cancel()
+
+	select {
+	case sent := <-result:
+		require.False(t, sent)
+	case <-time.After(2 * time.Second):
+		t.Fatal("event send did not stop after cancellation")
+	}
+}
+
+func assertSessionStreamingEventuallyUnlocked(t *testing.T, sm *SessionManager, sessionID string) {
+	t.Helper()
+
+	runtimeSession, ok := sm.runtimeSessions.Load(sessionID)
+	require.True(t, ok)
+	require.Eventually(t, func() bool {
+		if !runtimeSession.streaming.TryLock() {
+			return false
+		}
+		runtimeSession.streaming.Unlock()
+		return true
+	}, 2*time.Second, 10*time.Millisecond)
+}
+
 // TestRunSession_ConcurrentRequestReturnsErrSessionBusy verifies that a
 // second RunSession call on a session that is already streaming returns
 // ErrSessionBusy instead of silently interleaving messages.

--- a/pkg/server/session_manager_test.go
+++ b/pkg/server/session_manager_test.go
@@ -345,6 +345,37 @@ func TestAddMessage_RejectsWhileSessionStreaming(t *testing.T) {
 	require.NoError(t, sm.AddMessage(ctx, sess.ID, session.UserMessage("accepted")))
 }
 
+func TestUpdateMessageRejectsWrongSessionAndMalformedID(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	store := session.NewInMemorySessionStore()
+	owner := session.New()
+	other := session.New()
+	require.NoError(t, store.AddSession(ctx, owner))
+	require.NoError(t, store.AddSession(ctx, other))
+	messageID, err := store.AddMessage(ctx, owner.ID, session.UserMessage("original"))
+	require.NoError(t, err)
+
+	sm := NewSessionManager(ctx, config.Sources{}, store, 0, &config.RuntimeConfig{})
+	guard := sm.AttachRuntime(ctx, owner.ID, &fakeRuntime{}, owner)
+	guard.Lock()
+	defer guard.Unlock()
+
+	err = sm.UpdateMessage(ctx, other.ID, strconv.FormatInt(messageID, 10), session.UserMessage("wrong session"))
+	require.ErrorIs(t, err, session.ErrNotFound)
+	err = sm.UpdateMessage(ctx, owner.ID, strconv.FormatInt(messageID, 10), session.UserMessage("busy bypass"))
+	require.ErrorIs(t, err, ErrSessionBusy)
+	err = sm.UpdateMessage(ctx, other.ID, strconv.FormatInt(messageID, 10)+"junk", session.UserMessage("malformed"))
+	require.ErrorContains(t, err, "invalid message ID")
+
+	stored, err := store.GetSession(ctx, owner.ID)
+	require.NoError(t, err)
+	messages := stored.GetAllMessages()
+	require.Len(t, messages, 1)
+	assert.Equal(t, "original", messages[0].Message.Content)
+}
+
 // TestUpdateMessage_RejectsWhileSessionStreaming mirrors
 // TestAddMessage_RejectsWhileSessionStreaming for UpdateMessage.
 func TestUpdateMessage_RejectsWhileSessionStreaming(t *testing.T) {
@@ -444,10 +475,10 @@ func (s *blockingStore) AddMessage(ctx context.Context, sessionID string, msg *s
 	return s.Store.AddMessage(ctx, sessionID, msg)
 }
 
-func (s *blockingStore) UpdateMessage(ctx context.Context, messageID int64, msg *session.Message) error {
+func (s *blockingStore) UpdateMessage(ctx context.Context, sessionID string, messageID int64, msg *session.Message) error {
 	close(s.entered)
 	<-s.release
-	return s.Store.UpdateMessage(ctx, messageID, msg)
+	return s.Store.UpdateMessage(ctx, sessionID, messageID, msg)
 }
 
 // assertAttachedGuardBlockedDuringMutation drives the reviewer's

--- a/pkg/server/session_manager_test.go
+++ b/pkg/server/session_manager_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
@@ -25,6 +26,8 @@ import (
 	"github.com/docker/docker-agent/pkg/concurrent"
 	"github.com/docker/docker-agent/pkg/config"
 	"github.com/docker/docker-agent/pkg/config/types"
+	"github.com/docker/docker-agent/pkg/model/provider/base"
+	"github.com/docker/docker-agent/pkg/modelsdev"
 	"github.com/docker/docker-agent/pkg/runtime"
 	"github.com/docker/docker-agent/pkg/session"
 	"github.com/docker/docker-agent/pkg/session/sqlitestore"
@@ -82,6 +85,38 @@ func (f *fakeRuntime) OnElicitationRequest(func(runtime.Event)) {}
 
 func (f *fakeRuntime) CurrentAgentName(context.Context) string { return "root" }
 
+// delayedTitleProvider lets a RunSession title request finish after the
+// runtime stream has already closed.
+type delayedTitleProvider struct {
+	started chan struct{}
+	release chan struct{}
+}
+
+func (p *delayedTitleProvider) ID() modelsdev.ID { return modelsdev.NewID("test", "title") }
+
+func (p *delayedTitleProvider) CreateChatCompletionStream(context.Context, []chat.Message, []tools.Tool) (chat.MessageStream, error) {
+	close(p.started)
+	return &delayedTitleStream{release: p.release}, nil
+}
+
+func (p *delayedTitleProvider) BaseConfig() base.Config { return base.Config{} }
+
+type delayedTitleStream struct {
+	release  chan struct{}
+	received bool
+}
+
+func (s *delayedTitleStream) Recv() (chat.MessageStreamResponse, error) {
+	if s.received {
+		return chat.MessageStreamResponse{}, io.EOF
+	}
+	<-s.release
+	s.received = true
+	return chat.MessageStreamResponse{Choices: []chat.MessageStreamChoice{{Delta: chat.MessageDelta{Content: "Delayed title"}}}}, nil
+}
+
+func (s *delayedTitleStream) Close() {}
+
 // SupportsModelSwitching reports false by default. Tests that exercise
 // the /models endpoints embed fakeRuntime and override this.
 func (f *fakeRuntime) SupportsModelSwitching() bool { return false }
@@ -134,6 +169,34 @@ func TestAttachRuntime_RegistersRuntimeForExternalDriver(t *testing.T) {
 
 	// Steer routes through the attached runtime, not a freshly built one.
 	require.NoError(t, sm.SteerSession(ctx, sess.ID, []api.Message{{Content: "hi"}}))
+}
+
+func TestRunSession_TitleCanFinishAfterRuntimeStream(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	sess := session.New()
+	sm := newTestSessionManager(t, sess, &fakeRuntime{})
+	provider := &delayedTitleProvider{started: make(chan struct{}), release: make(chan struct{})}
+	runtimeSession, ok := sm.runtimeSessions.Load(sess.ID)
+	require.True(t, ok)
+	runtimeSession.titleGen = sessiontitle.New(provider)
+
+	events, err := sm.RunSession(ctx, sess.ID, "agent", "root", []api.Message{{Content: "hello"}}, "")
+	require.NoError(t, err)
+
+	select {
+	case <-provider.started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("title generation did not start")
+	}
+	for range events {
+	}
+
+	close(provider.release)
+	require.Eventually(t, func() bool {
+		return sess.TitleSnapshot() == "Delayed title"
+	}, 2*time.Second, 10*time.Millisecond)
 }
 
 // TestRunSession_ConcurrentRequestReturnsErrSessionBusy verifies that a

--- a/pkg/server/session_manager_test.go
+++ b/pkg/server/session_manager_test.go
@@ -1055,6 +1055,120 @@ func TestUserMessageOrdinalToItemIndex(t *testing.T) {
 	require.ErrorIs(t, err, ErrForkOutOfRange)
 }
 
+func TestUpdateSessionPermissionsUsesActiveSession(t *testing.T) {
+	t.Parallel()
+
+	stores := []struct {
+		name string
+		new  func(*testing.T) session.Store
+	}{
+		{
+			name: "in-memory",
+			new: func(*testing.T) session.Store {
+				return session.NewInMemorySessionStore()
+			},
+		},
+		{
+			name: "sqlite",
+			new: func(t *testing.T) session.Store {
+				t.Helper()
+				store, err := sqlitestore.New(t.Context(), filepath.Join(t.TempDir(), "sessions.db"))
+				require.NoError(t, err)
+				t.Cleanup(func() { _ = store.Close() })
+				return store
+			},
+		},
+	}
+
+	for _, tc := range stores {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			store := tc.new(t)
+			stored := session.New(session.WithTitle("stored"), session.WithPermissions(&session.PermissionsConfig{Allow: []string{"old"}}))
+			require.NoError(t, store.AddSession(t.Context(), stored))
+			require.NoError(t, store.UpdateSession(t.Context(), stored))
+
+			live := stored
+			live.SetTitle("live")
+			sm := NewSessionManager(t.Context(), config.Sources{}, store, 0, &config.RuntimeConfig{})
+			sm.runtimeSessions.Store(live.ID, &activeRuntimes{runtime: &fakeRuntime{}, session: live})
+
+			perms := &session.PermissionsConfig{Allow: []string{"new"}, Deny: []string{"dangerous"}}
+			require.NoError(t, sm.UpdateSessionPermissions(t.Context(), live.ID, perms))
+			perms.Allow[0] = "mutated-by-caller"
+
+			assert.Equal(t, []string{"new"}, live.ClonePermissions().Allow)
+			got, err := sm.GetSession(t.Context(), live.ID)
+			require.NoError(t, err)
+			assert.Equal(t, "live", got.TitleSnapshot(), "active state must win over the stale store clone")
+			assert.Equal(t, []string{"new"}, got.ClonePermissions().Allow)
+
+			// A later runtime save must retain the policy update.
+			live.SetTitle("saved later")
+			require.NoError(t, store.UpdateSession(t.Context(), live))
+			reloaded, err := store.GetSession(t.Context(), live.ID)
+			require.NoError(t, err)
+			assert.Equal(t, "saved later", reloaded.TitleSnapshot())
+			assert.Equal(t, []string{"new"}, reloaded.ClonePermissions().Allow)
+			assert.Equal(t, []string{"dangerous"}, reloaded.ClonePermissions().Deny)
+		})
+	}
+}
+
+func TestUpdateSessionPermissionsConcurrentReads(t *testing.T) {
+	t.Parallel()
+
+	store := session.NewInMemorySessionStore()
+	live := session.New()
+	require.NoError(t, store.AddSession(t.Context(), live))
+	require.NoError(t, store.UpdateSession(t.Context(), live))
+
+	sm := NewSessionManager(t.Context(), config.Sources{}, store, 0, &config.RuntimeConfig{})
+	sm.runtimeSessions.Store(live.ID, &activeRuntimes{runtime: &fakeRuntime{}, session: live})
+
+	const iterations = 100
+	errs := make(chan error, 2)
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		for i := range iterations {
+			if err := sm.UpdateSessionPermissions(t.Context(), live.ID, &session.PermissionsConfig{
+				Allow: []string{strconv.Itoa(i)},
+			}); err != nil {
+				errs <- err
+				return
+			}
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for range iterations {
+			got, err := sm.GetSession(t.Context(), live.ID)
+			if err != nil {
+				errs <- err
+				return
+			}
+			_ = got.ClonePermissions()
+
+			snapshot, err := sm.GetSessionSnapshot(t.Context(), live.ID)
+			if err != nil {
+				errs <- err
+				return
+			}
+			if snapshot.Permissions != nil {
+				_ = snapshot.Permissions.Allow
+			}
+		}
+	}()
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		require.NoError(t, err)
+	}
+}
+
 // TestAddMessage_SQLitePersistedToolResultCappedOnReload pins the read-time
 // backstop for the generic API path: SessionManager.AddMessage persists a
 // tool result through the store without Session.AddMessage's ingest-time

--- a/pkg/server/session_models_test.go
+++ b/pkg/server/session_models_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"sync"
 	"testing"
@@ -369,6 +370,492 @@ func (s *failingStore) UpdateSession(ctx context.Context, sess *session.Session)
 		return errors.New("synthetic store failure")
 	}
 	return s.Store.UpdateSession(ctx, sess)
+}
+
+type blockingUpdateStore struct {
+	session.Store
+
+	mu      sync.Mutex
+	started chan int
+	release []chan struct{}
+	fail    map[int]error
+	updates int
+}
+
+func (s *blockingUpdateStore) UpdateSession(ctx context.Context, sess *session.Session) error {
+	s.mu.Lock()
+	index := s.updates
+	s.updates++
+	var release chan struct{}
+	if index < len(s.release) {
+		release = s.release[index]
+	}
+	fail := s.fail[index]
+	s.mu.Unlock()
+
+	if s.started != nil {
+		s.started <- index
+	}
+	if release != nil {
+		select {
+		case <-release:
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+	if fail != nil {
+		return fail
+	}
+	return s.Store.UpdateSession(ctx, sess)
+}
+
+type deleteBarrierStore struct {
+	session.Store
+
+	deleted chan struct{}
+	release chan struct{}
+}
+
+func (s *deleteBarrierStore) DeleteSession(ctx context.Context, sessionID string) error {
+	if err := s.Store.DeleteSession(ctx, sessionID); err != nil {
+		return err
+	}
+	close(s.deleted)
+	select {
+	case <-s.release:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func TestSessionManager_DeleteDuringRecallPersistenceDoesNotResurrect(t *testing.T) {
+	for _, batch := range []bool{false, true} {
+		t.Run(fmt.Sprintf("batch=%t", batch), func(t *testing.T) {
+			ctx := t.Context()
+			sess := session.New()
+			base := session.NewInMemorySessionStore()
+			require.NoError(t, base.AddSession(ctx, sess))
+			store := &deleteBarrierStore{
+				Store:   base,
+				deleted: make(chan struct{}),
+				release: make(chan struct{}),
+			}
+			fake := &fakeRuntime{release: make(chan struct{})}
+			sm := NewSessionManager(ctx, config.Sources{}, store, 0, &config.RuntimeConfig{})
+			sm.AttachRuntime(ctx, sess.ID, fake, sess)
+			rs, ok := sm.runtimeSessions.Load(sess.ID)
+			require.True(t, ok)
+
+			persistEntered := make(chan struct{})
+			persistProceed := make(chan struct{})
+			sm.beforePersistActiveSession = func() {
+				close(persistEntered)
+				<-persistProceed
+			}
+
+			require.NoError(t, sm.recallSession(ctx, sess.ID, runtime.QueuedMessage{Content: "wake up"}))
+			require.Eventually(t, func() bool {
+				return fake.concurrentStreams.Load() == 1
+			}, time.Second, time.Millisecond)
+
+			type deleteResult struct {
+				deleted int
+				failed  []string
+				err     error
+			}
+			deleteDone := make(chan deleteResult, 1)
+			go func() {
+				if batch {
+					deleted, failed := sm.BatchDeleteSessions(ctx, []string{sess.ID})
+					deleteDone <- deleteResult{deleted: deleted, failed: failed}
+					return
+				}
+				deleteDone <- deleteResult{err: sm.DeleteSession(ctx, sess.ID)}
+			}()
+
+			select {
+			case <-store.deleted:
+			case <-time.After(time.Second):
+				t.Fatal("delete did not reach the post-store barrier")
+			}
+			close(fake.release)
+			select {
+			case <-persistEntered:
+			case <-time.After(time.Second):
+				t.Fatal("recall did not reach final persistence")
+			}
+
+			// Keep deletion cleanup waiting on sm.mux while allowing its
+			// modelSwitch lock to go. Recall persistence must reject the
+			// deleting runtime without taking sm.mux first.
+			sm.mux.Lock()
+			close(persistProceed)
+			close(store.release)
+			recallFinished := assert.Eventually(t, func() bool {
+				if !rs.streaming.TryLock() {
+					return false
+				}
+				rs.streaming.Unlock()
+				return true
+			}, time.Second, time.Millisecond)
+			sm.mux.Unlock()
+			require.True(t, recallFinished)
+
+			result := <-deleteDone
+			if batch {
+				assert.Equal(t, 1, result.deleted)
+				assert.Empty(t, result.failed)
+			} else {
+				require.NoError(t, result.err)
+			}
+			_, err := store.GetSession(ctx, sess.ID)
+			assert.ErrorIs(t, err, session.ErrNotFound)
+		})
+	}
+}
+
+func TestSessionManager_SetSessionAgentModel_SerializesSuccessfulSwitches(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	base := session.NewInMemorySessionStore()
+	firstRelease := make(chan struct{})
+	store := &blockingUpdateStore{
+		Store:   base,
+		started: make(chan int, 2),
+		release: []chan struct{}{firstRelease},
+		fail:    make(map[int]error),
+	}
+	sess := session.New()
+	sess.AddMessage(session.UserMessage("history"))
+	require.NoError(t, store.AddSession(ctx, sess))
+
+	fake := newModelSwitchingRuntime(nil)
+	sm := NewSessionManager(ctx, config.Sources{}, store, 0, &config.RuntimeConfig{})
+	sm.AttachRuntime(ctx, sess.ID, fake, sess)
+
+	firstDone := make(chan error, 1)
+	go func() {
+		_, _, err := sm.SetSessionAgentModel(ctx, sess.ID, "openai/first")
+		firstDone <- err
+	}()
+	require.Equal(t, 0, <-store.started)
+
+	secondDone := make(chan error, 1)
+	go func() {
+		_, _, err := sm.SetSessionAgentModel(ctx, sess.ID, "openai/second")
+		secondDone <- err
+	}()
+
+	select {
+	case index := <-store.started:
+		t.Fatalf("second switch reached persistence before first committed: update %d", index)
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	close(firstRelease)
+	require.NoError(t, <-firstDone)
+	require.Equal(t, 1, <-store.started)
+	require.NoError(t, <-secondDone)
+
+	stored, err := store.GetSession(ctx, sess.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "openai/second", stored.AgentModelOverrides["root"])
+	require.Len(t, stored.GetAllMessages(), 1)
+	assert.Equal(t, "history", stored.GetAllMessages()[0].Message.Content)
+
+	fake.mu.Lock()
+	defer fake.mu.Unlock()
+	assert.Equal(t, "openai/second", fake.overrides["root"])
+}
+
+func TestSessionManager_SetSessionAgentModel_FailedRollbackCannotRaceSuccess(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	base := session.NewInMemorySessionStore()
+	firstRelease := make(chan struct{})
+	store := &blockingUpdateStore{
+		Store:   base,
+		started: make(chan int, 2),
+		release: []chan struct{}{firstRelease},
+		fail:    map[int]error{0: errors.New("synthetic first update failure")},
+	}
+	sess := session.New()
+	require.NoError(t, store.AddSession(ctx, sess))
+
+	fake := newModelSwitchingRuntime(nil)
+	sm := NewSessionManager(ctx, config.Sources{}, store, 0, &config.RuntimeConfig{})
+	sm.AttachRuntime(ctx, sess.ID, fake, sess)
+
+	failedDone := make(chan error, 1)
+	go func() {
+		_, _, err := sm.SetSessionAgentModel(ctx, sess.ID, "openai/failed")
+		failedDone <- err
+	}()
+	require.Equal(t, 0, <-store.started)
+
+	successDone := make(chan error, 1)
+	go func() {
+		_, _, err := sm.SetSessionAgentModel(ctx, sess.ID, "openai/success")
+		successDone <- err
+	}()
+
+	select {
+	case index := <-store.started:
+		t.Fatalf("successful switch overtook failed transaction: update %d", index)
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	close(firstRelease)
+	require.Error(t, <-failedDone)
+	require.Equal(t, 1, <-store.started)
+	require.NoError(t, <-successDone)
+
+	stored, err := store.GetSession(ctx, sess.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "openai/success", stored.AgentModelOverrides["root"])
+	assert.Equal(t, "openai/success", sess.AgentModelOverrides["root"])
+
+	fake.mu.Lock()
+	defer fake.mu.Unlock()
+	assert.Equal(t, "openai/success", fake.overrides["root"])
+}
+
+func TestSessionManager_RunSessionWaitsForModelSwitch(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	base := session.NewInMemorySessionStore()
+	release := make(chan struct{})
+	store := &blockingUpdateStore{
+		Store:   base,
+		started: make(chan int, 2),
+		release: []chan struct{}{release},
+		fail:    make(map[int]error),
+	}
+	sess := session.New()
+	require.NoError(t, store.AddSession(ctx, sess))
+
+	fake := newModelSwitchingRuntime(nil)
+	sm := NewSessionManager(ctx, config.Sources{}, store, 0, &config.RuntimeConfig{})
+	sm.AttachRuntime(ctx, sess.ID, fake, sess)
+
+	switchDone := make(chan error, 1)
+	go func() {
+		_, _, err := sm.SetSessionAgentModel(ctx, sess.ID, "openai/switch")
+		switchDone <- err
+	}()
+	require.Equal(t, 0, <-store.started)
+
+	runDone := make(chan error, 1)
+	go func() {
+		stream, err := sm.RunSession(ctx, sess.ID, "agent", "root", []api.Message{{Content: "after switch"}}, "openai/run")
+		if err == nil {
+			for range stream {
+			}
+		}
+		runDone <- err
+	}()
+
+	select {
+	case index := <-store.started:
+		t.Fatalf("run persisted before model switch committed: update %d", index)
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	close(release)
+	require.NoError(t, <-switchDone)
+	require.Equal(t, 1, <-store.started)
+	require.NoError(t, <-runDone)
+
+	rs, ok := sm.runtimeSessions.Load(sess.ID)
+	require.True(t, ok)
+	live := rs.session.GetAllMessages()
+	require.Len(t, live, 1)
+	assert.Equal(t, "after switch", live[0].Message.Content)
+
+	stored, err := store.GetSession(ctx, sess.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "openai/run", stored.AgentModelOverrides["root"])
+}
+
+func TestSessionManager_ModelSwitchConcurrentSessionSaves(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	store := session.NewInMemorySessionStore()
+	sess := session.New()
+	require.NoError(t, store.AddSession(ctx, sess))
+	fake := newModelSwitchingRuntime(nil)
+	sm := NewSessionManager(ctx, config.Sources{}, store, 0, &config.RuntimeConfig{})
+	sm.AttachRuntime(ctx, sess.ID, fake, sess)
+
+	const iterations = 100
+	errs := make(chan error, 3)
+	var wg sync.WaitGroup
+	wg.Add(3)
+	go func() {
+		defer wg.Done()
+		for i := range iterations {
+			_, _, err := sm.SetSessionAgentModel(ctx, sess.ID, fmt.Sprintf("openai/model-%d", i))
+			if err != nil {
+				errs <- err
+				return
+			}
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for i := range iterations {
+			if err := sm.UpdateSessionPermissions(ctx, sess.ID, &session.PermissionsConfig{
+				Allow: []string{fmt.Sprintf("tool-%d", i)},
+			}); err != nil {
+				errs <- err
+				return
+			}
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for i := range iterations {
+			policy := session.SafetyPolicyStrict
+			if i%2 == 0 {
+				policy = session.SafetyPolicyBalanced
+			}
+			if err := sm.SetSessionSafetyPolicy(ctx, sess.ID, policy); err != nil {
+				errs <- err
+				return
+			}
+		}
+	}()
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		require.NoError(t, err)
+	}
+
+	stored, err := store.GetSession(ctx, sess.ID)
+	require.NoError(t, err)
+	assert.NotEmpty(t, stored.AgentModelOverrides["root"])
+	assert.NotNil(t, stored.Permissions)
+}
+
+func TestSessionManager_RunSessionDeletedWhileWaitingForModelSwitch(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	store := session.NewInMemorySessionStore()
+	sess := session.New()
+	require.NoError(t, store.AddSession(ctx, sess))
+	fake := newModelSwitchingRuntime(nil)
+	sm := NewSessionManager(ctx, config.Sources{}, store, 0, &config.RuntimeConfig{})
+	sm.AttachRuntime(ctx, sess.ID, fake, sess)
+
+	rs, ok := sm.runtimeSessions.Load(sess.ID)
+	require.True(t, ok)
+	rs.modelSwitch.Lock()
+
+	reachedModelSwitch := make(chan struct{})
+	sm.beforeRunModelSwitch = func() { close(reachedModelSwitch) }
+	runDone := make(chan error, 1)
+	go func() {
+		_, err := sm.RunSession(ctx, sess.ID, "agent", "root", []api.Message{{Content: "must not persist"}}, "openai/new")
+		runDone <- err
+	}()
+	<-reachedModelSwitch
+
+	deleteDone := make(chan error, 1)
+	go func() { deleteDone <- sm.DeleteSession(ctx, sess.ID) }()
+	require.Eventually(t, rs.deleting.Load, 2*time.Second, 10*time.Millisecond)
+	rs.modelSwitch.Unlock()
+
+	require.ErrorIs(t, <-runDone, ErrSessionNotRunning)
+	require.NoError(t, <-deleteDone)
+	_, err := store.GetSession(ctx, sess.ID)
+	require.ErrorIs(t, err, session.ErrNotFound)
+	assert.Empty(t, sess.GetAllMessages())
+	fake.mu.Lock()
+	defer fake.mu.Unlock()
+	assert.Empty(t, fake.overrides)
+}
+
+func TestSessionManager_SetSessionAgentModelDeletedDuringProviderCall(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	store := session.NewInMemorySessionStore()
+	sess := session.New()
+	require.NoError(t, store.AddSession(ctx, sess))
+	called := make(chan struct{}, 1)
+	release := make(chan struct{})
+	fake := newModelSwitchingRuntime(nil)
+	fake.setAgentModelCalled = called
+	fake.setAgentModelDelay = release
+	sm := NewSessionManager(ctx, config.Sources{}, store, 0, &config.RuntimeConfig{})
+	sm.AttachRuntime(ctx, sess.ID, fake, sess)
+
+	switchDone := make(chan error, 1)
+	go func() {
+		_, _, err := sm.SetSessionAgentModel(ctx, sess.ID, "openai/new")
+		switchDone <- err
+	}()
+	require.Eventually(t, func() bool { return len(called) == 1 }, 2*time.Second, 10*time.Millisecond)
+
+	deleteDone := make(chan error, 1)
+	go func() { deleteDone <- sm.DeleteSession(ctx, sess.ID) }()
+	require.Eventually(t, func() bool {
+		rs, ok := sm.runtimeSessions.Load(sess.ID)
+		return ok && rs.deleting.Load()
+	}, 2*time.Second, 10*time.Millisecond)
+	close(release)
+
+	require.ErrorIs(t, <-switchDone, ErrSessionNotRunning)
+	require.NoError(t, <-deleteDone)
+	_, err := store.GetSession(ctx, sess.ID)
+	require.ErrorIs(t, err, session.ErrNotFound)
+	_, exists := sess.AgentModelOverride("root")
+	assert.False(t, exists)
+}
+
+func TestSessionManager_BatchDeleteWhileModelSwitchWaits(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	store := session.NewInMemorySessionStore()
+	sess := session.New()
+	require.NoError(t, store.AddSession(ctx, sess))
+	fake := newModelSwitchingRuntime(nil)
+	sm := NewSessionManager(ctx, config.Sources{}, store, 0, &config.RuntimeConfig{})
+	sm.AttachRuntime(ctx, sess.ID, fake, sess)
+
+	rs, ok := sm.runtimeSessions.Load(sess.ID)
+	require.True(t, ok)
+	rs.modelSwitch.Lock()
+
+	switchDone := make(chan error, 1)
+	go func() {
+		_, _, err := sm.SetSessionAgentModel(ctx, sess.ID, "openai/new")
+		switchDone <- err
+	}()
+
+	batchDone := make(chan struct{})
+	var deleted int
+	var failed []string
+	go func() {
+		deleted, failed = sm.BatchDeleteSessions(ctx, []string{sess.ID})
+		close(batchDone)
+	}()
+	require.Eventually(t, rs.deleting.Load, 2*time.Second, 10*time.Millisecond)
+	rs.modelSwitch.Unlock()
+
+	require.ErrorIs(t, <-switchDone, ErrSessionNotRunning)
+	<-batchDone
+	assert.Equal(t, 1, deleted)
+	assert.Empty(t, failed)
+	_, err := store.GetSession(ctx, sess.ID)
+	require.ErrorIs(t, err, session.ErrNotFound)
 }
 
 // When the session store rejects the persistence write, the in-memory

--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -1795,7 +1795,7 @@ func (s *Session) ClonePermissions() *PermissionsConfig {
 func (s *Session) SetPermissions(perms *PermissionsConfig) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	s.Permissions = perms
+	s.Permissions = perms.Clone()
 }
 
 // SetToolsApproved is the legacy --yolo toggle. Prefer

--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -370,12 +370,11 @@ type Session struct {
 	Attributes map[string]string `json:"attributes,omitempty"`
 
 	// AgentModelOverrides stores per-agent model overrides for this session.
-	// Key is the agent name, value is the model reference (e.g., "openai/gpt-4o" or a named model from config).
-	// When a session is loaded, these overrides are reapplied to the runtime.
+	// Shared-session callers must use the model-state accessors below.
 	AgentModelOverrides map[string]string `json:"agent_model_overrides,omitempty"`
 
 	// CustomModelsUsed tracks custom models (provider/model format) used during this session.
-	// These are shown in the model picker for easy re-selection.
+	// Shared-session callers must use the model-state accessors below.
 	CustomModelsUsed []string `json:"custom_models_used,omitempty"`
 
 	// AttachedFiles records absolute paths of files the user attached to this
@@ -1781,6 +1780,46 @@ func (s *Session) GetSafetyPolicy() SafetyPolicy {
 		return SafetyPolicyAutonomous
 	}
 	return policy
+}
+
+// ModelStateSnapshot returns independent copies of the session's model state.
+func (s *Session) ModelStateSnapshot() (map[string]string, []string) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return cloneStringMap(s.AgentModelOverrides), cloneStringSlice(s.CustomModelsUsed)
+}
+
+// AgentModelOverride returns the override for agentName, if present.
+func (s *Session) AgentModelOverride(agentName string) (string, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	modelRef, ok := s.AgentModelOverrides[agentName]
+	return modelRef, ok
+}
+
+// SetAgentModelOverride updates an override and custom-model history atomically.
+func (s *Session) SetAgentModelOverride(agentName, modelRef string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if modelRef == "" {
+		delete(s.AgentModelOverrides, agentName)
+		return
+	}
+	if s.AgentModelOverrides == nil {
+		s.AgentModelOverrides = make(map[string]string)
+	}
+	s.AgentModelOverrides[agentName] = modelRef
+	if strings.Contains(modelRef, "/") && !slices.Contains(s.CustomModelsUsed, modelRef) {
+		s.CustomModelsUsed = append(s.CustomModelsUsed, modelRef)
+	}
+}
+
+// ReplaceModelState atomically restores model state from independent copies.
+func (s *Session) ReplaceModelState(overrides map[string]string, customModels []string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.AgentModelOverrides = cloneStringMap(overrides)
+	s.CustomModelsUsed = cloneStringSlice(customModels)
 }
 
 // ClonePermissions returns a deep copy of the session's PermissionsConfig.

--- a/pkg/session/store.go
+++ b/pkg/session/store.go
@@ -109,11 +109,11 @@ type Store interface {
 	// Returns the ID of the created message item.
 	AddMessage(ctx context.Context, sessionID string, msg *Message) (int64, error)
 
-	// UpdateMessage updates an existing message by its ID.
+	// UpdateMessage updates a message belonging to sessionID by its ID.
 	// This is called on each streaming delta to keep the persisted message
 	// in sync with the in-progress content, and once more with the final
 	// payload when the message completes.
-	UpdateMessage(ctx context.Context, messageID int64, msg *Message) error
+	UpdateMessage(ctx context.Context, sessionID string, messageID int64, msg *Message) error
 
 	// AddSubSession creates a sub-session and links it to the parent.
 	// The sub-session is stored as a separate session row with parent_id set.
@@ -325,32 +325,31 @@ func (s *InMemorySessionStore) AddMessage(_ context.Context, sessionID string, m
 	return id, nil
 }
 
-// UpdateMessage updates an existing message by its ID.
-func (s *InMemorySessionStore) UpdateMessage(_ context.Context, messageID int64, msg *Message) error {
+// UpdateMessage updates a message belonging to sessionID by its ID.
+func (s *InMemorySessionStore) UpdateMessage(_ context.Context, sessionID string, messageID int64, msg *Message) error {
+	if sessionID == "" {
+		return ErrEmptyID
+	}
+	session, exists := s.sessions.Load(sessionID)
+	if !exists {
+		return ErrNotFound
+	}
+
 	// Create a deep copy of the message to avoid mutating the caller's pointer,
 	// which may be shared with another Session object.
 	updated := cloneMessage(msg)
 	updated.ID = messageID
 
-	// For in-memory store, we need to find the message across all sessions
-	var found bool
-	s.sessions.Range(func(_ string, session *Session) bool {
-		session.mu.Lock()
-		defer session.mu.Unlock()
-		for i := range session.Messages {
-			if session.Messages[i].Message == nil || session.Messages[i].Message.ID != messageID {
-				continue
-			}
-			session.Messages[i].Message = updated
-			found = true
-			return false
+	session.mu.Lock()
+	defer session.mu.Unlock()
+	for i := range session.Messages {
+		if session.Messages[i].Message == nil || session.Messages[i].Message.ID != messageID {
+			continue
 		}
-		return true
-	})
-	if !found {
-		return ErrNotFound
+		session.Messages[i].Message = updated
+		return nil
 	}
-	return nil
+	return ErrNotFound
 }
 
 // AddSubSession creates a sub-session and links it to the parent.
@@ -1172,16 +1171,19 @@ func (s *SQLiteSessionStore) AddMessage(ctx context.Context, sessionID string, m
 	return id, nil
 }
 
-// UpdateMessage updates an existing message by its ID.
-func (s *SQLiteSessionStore) UpdateMessage(ctx context.Context, messageID int64, msg *Message) error {
+// UpdateMessage updates a message belonging to sessionID by its ID.
+func (s *SQLiteSessionStore) UpdateMessage(ctx context.Context, sessionID string, messageID int64, msg *Message) error {
+	if sessionID == "" {
+		return ErrEmptyID
+	}
 	msgJSON, err := json.Marshal(msg.Message)
 	if err != nil {
 		return fmt.Errorf("marshaling message: %w", err)
 	}
 
 	result, err := s.db.ExecContext(ctx,
-		`UPDATE session_items SET message_json = ?, implicit = ? WHERE id = ?`,
-		string(msgJSON), msg.Implicit, messageID)
+		`UPDATE session_items SET message_json = ?, implicit = ? WHERE session_id = ? AND id = ?`,
+		string(msgJSON), msg.Implicit, sessionID, messageID)
 	if err != nil {
 		return fmt.Errorf("updating message: %w", err)
 	}

--- a/pkg/session/store_update_message_test.go
+++ b/pkg/session/store_update_message_test.go
@@ -1,0 +1,53 @@
+package session
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStoresUpdateMessageIsScopedToSession(t *testing.T) {
+	for _, storeFactory := range []struct {
+		name string
+		new  func(*testing.T) Store
+	}{
+		{name: "memory", new: func(t *testing.T) Store {
+			t.Helper()
+			return NewInMemorySessionStore()
+		}},
+		{name: "sqlite", new: func(t *testing.T) Store {
+			t.Helper()
+			store, err := newSQLiteStoreForTest(t, filepath.Join(t.TempDir(), "sessions.db"))
+			require.NoError(t, err)
+			return store
+		}},
+	} {
+		t.Run(storeFactory.name, func(t *testing.T) {
+			ctx := t.Context()
+			store := storeFactory.new(t)
+			t.Cleanup(func() { require.NoError(t, store.Close()) })
+
+			owner := New()
+			other := New()
+			require.NoError(t, store.AddSession(ctx, owner))
+			require.NoError(t, store.AddSession(ctx, other))
+			messageID, err := store.AddMessage(ctx, owner.ID, UserMessage("original"))
+			require.NoError(t, err)
+
+			err = store.UpdateMessage(ctx, other.ID, messageID, UserMessage("wrong session"))
+			require.ErrorIs(t, err, ErrNotFound)
+			stored, err := store.GetSession(ctx, owner.ID)
+			require.NoError(t, err)
+			require.Len(t, stored.GetAllMessages(), 1)
+			assert.Equal(t, "original", stored.GetAllMessages()[0].Message.Content)
+
+			require.NoError(t, store.UpdateMessage(ctx, owner.ID, messageID, UserMessage("updated")))
+			stored, err = store.GetSession(ctx, owner.ID)
+			require.NoError(t, err)
+			require.Len(t, stored.GetAllMessages(), 1)
+			assert.Equal(t, "updated", stored.GetAllMessages()[0].Message.Content)
+		})
+	}
+}

--- a/pkg/tools/builtin/agent/agent.go
+++ b/pkg/tools/builtin/agent/agent.go
@@ -238,6 +238,10 @@ type Handler struct {
 	runner Runner
 	wg     sync.WaitGroup
 	tasks  *concurrent.Map[string, *task]
+
+	admissionMu sync.Mutex
+	activeTasks int
+	stopping    bool
 }
 
 // NewHandler creates a new Handler with the given Runner.
@@ -268,6 +272,12 @@ func (h *Handler) totalTaskCount() int {
 }
 
 func (h *Handler) pruneCompleted() {
+	h.admissionMu.Lock()
+	defer h.admissionMu.Unlock()
+	h.pruneCompletedLocked()
+}
+
+func (h *Handler) pruneCompletedLocked() {
 	var toDelete []string
 	h.tasks.Range(func(id string, t *task) bool {
 		if s := t.loadStatus(); s != taskRunning {
@@ -315,18 +325,25 @@ func (h *Handler) HandleRun(ctx context.Context, sess *session.Session, toolCall
 		return tools.ResultError(fmt.Sprintf("agent %q is not in the sub-agents list. This agent has no sub-agents configured.", params.Agent)), nil
 	}
 
-	// Enforce concurrency cap.
-	if h.runningTaskCount() >= maxConcurrentTasks {
+	// Admission, insertion, and pruning are one transaction. StopAll uses the
+	// same lock to prevent Wait racing a new WaitGroup task.
+	h.admissionMu.Lock()
+	if h.stopping {
+		h.admissionMu.Unlock()
+		return tools.ResultError("background agent handler is stopping"), nil
+	}
+	if h.activeTasks >= maxConcurrentTasks {
+		h.admissionMu.Unlock()
 		return tools.ResultError(fmt.Sprintf("maximum concurrent background agent tasks (%d) reached; stop or wait for existing tasks to complete", maxConcurrentTasks)), nil
 	}
-
-	// Enforce total cap, pruning finished tasks first.
 	if h.totalTaskCount() >= maxTotalTasks {
-		h.pruneCompleted()
+		h.pruneCompletedLocked()
 		if h.totalTaskCount() >= maxTotalTasks {
+			h.admissionMu.Unlock()
 			return tools.ResultError(fmt.Sprintf("maximum total background agent tasks (%d) reached; view and discard old tasks first", maxTotalTasks)), nil
 		}
 	}
+	h.activeTasks++
 
 	taskID := newTaskID()
 
@@ -354,6 +371,7 @@ func (h *Handler) HandleRun(ctx context.Context, sess *session.Session, toolCall
 	h.tasks.Store(taskID, t)
 
 	h.wg.Go(func() {
+		defer h.releaseAdmission()
 		defer cancel()
 
 		// Each background task starts its own trace (WithNewRoot)
@@ -434,9 +452,16 @@ func (h *Handler) HandleRun(ctx context.Context, sess *session.Session, toolCall
 			slog.DebugContext(tracedCtx, "Background agent task completed", "task_id", taskID, "agent", params.Agent)
 		}
 	})
+	h.admissionMu.Unlock()
 
 	return tools.ResultSuccess(fmt.Sprintf("Background agent task started with ID: %s\nAgent: %s\nTask: %s",
 		taskID, params.Agent, params.Task)), nil
+}
+
+func (h *Handler) releaseAdmission() {
+	h.admissionMu.Lock()
+	defer h.admissionMu.Unlock()
+	h.activeTasks--
 }
 
 // HandleList lists all background agent tasks.
@@ -505,12 +530,20 @@ func (h *Handler) HandleStop(_ context.Context, _ *session.Session, toolCall too
 // StopAll cancels all running tasks and waits for their goroutines to exit.
 // Called during runtime shutdown to ensure clean teardown.
 func (h *Handler) StopAll() {
+	var cancels []context.CancelFunc
+	h.admissionMu.Lock()
+	h.stopping = true
 	h.tasks.Range(func(_ string, t *task) bool {
 		if t.casStatus(taskRunning, taskStopped) {
-			t.cancel()
+			cancels = append(cancels, t.cancel)
 		}
 		return true
 	})
+	h.admissionMu.Unlock()
+
+	for _, cancel := range cancels {
+		cancel()
+	}
 	h.wg.Wait()
 }
 

--- a/pkg/tools/builtin/agent/agent_test.go
+++ b/pkg/tools/builtin/agent/agent_test.go
@@ -92,6 +92,9 @@ func newTestHandlerWithRunner(r Runner) *Handler {
 }
 
 func insertTask(h *Handler, id, agentName string, status taskStatus) *task {
+	h.admissionMu.Lock()
+	defer h.admissionMu.Unlock()
+
 	t := &task{
 		id:        id,
 		agentName: agentName,
@@ -100,6 +103,9 @@ func insertTask(h *Handler, id, agentName string, status taskStatus) *task {
 		startTime: time.Now(),
 	}
 	t.status.Store(int32(status))
+	if status == taskRunning {
+		h.activeTasks++
+	}
 	h.tasks.Store(id, t)
 	return t
 }
@@ -509,6 +515,108 @@ func TestHandleRun_ConcurrencyCapEnforced(t *testing.T) {
 	require.NoError(t, err)
 	assert.True(t, result.IsError)
 	assert.Contains(t, result.Output, "maximum concurrent")
+}
+
+type blockingRunner struct {
+	started   atomic.Int32
+	active    atomic.Int32
+	maxActive atomic.Int32
+	release   chan struct{}
+}
+
+func (*blockingRunner) CurrentAgentSubAgentNames() []string { return []string{"sub"} }
+
+func (r *blockingRunner) RunAgent(ctx context.Context, _ RunParams) *RunResult {
+	r.started.Add(1)
+	active := r.active.Add(1)
+	defer r.active.Add(-1)
+	for {
+		maxActive := r.maxActive.Load()
+		if active <= maxActive || r.maxActive.CompareAndSwap(maxActive, active) {
+			break
+		}
+	}
+	select {
+	case <-r.release:
+	case <-ctx.Done():
+	}
+	return &RunResult{}
+}
+
+func TestHandleRun_ConcurrentAdmissionEnforcesCap(t *testing.T) {
+	t.Parallel()
+
+	runner := &blockingRunner{release: make(chan struct{})}
+	h := newTestHandlerWithRunner(runner)
+	t.Cleanup(h.StopAll)
+	tc := makeToolCall(t, RunBackgroundAgentArgs{Agent: "sub", Task: "work"})
+
+	start := make(chan struct{})
+	results := make(chan *tools.ToolCallResult, 2*maxConcurrentTasks)
+	var calls sync.WaitGroup
+	for range 2 * maxConcurrentTasks {
+		calls.Go(func() {
+			<-start
+			result, err := h.HandleRun(t.Context(), session.New(), tc)
+			require.NoError(t, err)
+			results <- result
+		})
+	}
+	close(start)
+	calls.Wait()
+	close(results)
+
+	var admitted int
+	for result := range results {
+		if !result.IsError {
+			admitted++
+		}
+	}
+	assert.Equal(t, maxConcurrentTasks, admitted)
+	require.Eventually(t, func() bool {
+		return runner.started.Load() == maxConcurrentTasks
+	}, time.Second, time.Millisecond)
+	assert.LessOrEqual(t, runner.maxActive.Load(), int32(maxConcurrentTasks))
+	assert.Equal(t, maxConcurrentTasks, h.totalTaskCount())
+
+	close(runner.release)
+	h.wg.Wait()
+}
+
+func TestHandleRun_RejectsAdmissionDuringShutdown(t *testing.T) {
+	t.Parallel()
+
+	runner := &blockingRunner{release: make(chan struct{})}
+	h := newTestHandlerWithRunner(runner)
+	tc := makeToolCall(t, RunBackgroundAgentArgs{Agent: "sub", Task: "work"})
+
+	first, err := h.HandleRun(t.Context(), session.New(), tc)
+	require.NoError(t, err)
+	require.False(t, first.IsError)
+	require.Eventually(t, func() bool { return runner.started.Load() == 1 }, time.Second, time.Millisecond)
+
+	stopped := make(chan struct{})
+	go func() {
+		h.StopAll()
+		close(stopped)
+	}()
+
+	require.Eventually(t, func() bool {
+		h.admissionMu.Lock()
+		defer h.admissionMu.Unlock()
+		return h.stopping
+	}, time.Second, time.Millisecond)
+
+	result, err := h.HandleRun(t.Context(), session.New(), tc)
+	require.NoError(t, err)
+	assert.True(t, result.IsError)
+	assert.Contains(t, result.Output, "stopping")
+	select {
+	case <-stopped:
+	case <-time.After(time.Second):
+		t.Fatal("StopAll did not finish")
+	}
+	assert.Equal(t, int32(1), runner.started.Load())
 }
 
 func TestHandleRun_InvalidJSON(t *testing.T) {

--- a/pkg/tools/builtin/backgroundjobs/backgroundjobs.go
+++ b/pkg/tools/builtin/backgroundjobs/backgroundjobs.go
@@ -50,6 +50,8 @@ const (
 	// that survives indefinitely while logging, they should redirect its output
 	// (e.g. `myserver > log.txt 2>&1 &`).
 	waitDelayAfterJobExit = 1 * time.Second
+	gracefulStopTimeout   = 500 * time.Millisecond
+	forcedStopTimeout     = 2 * time.Second
 )
 
 // ToolSet manages long-running shell commands.
@@ -82,19 +84,21 @@ const (
 )
 
 type backgroundJob struct {
-	id           string
-	cmd          string
-	cwd          string
-	process      *os.Process
-	processGroup *processGroup
-	outputMu     sync.RWMutex
-	output       *bytes.Buffer
-	startTime    time.Time
-	status       atomic.Int32
-	exitCode     int
-	err          error
-	done         chan struct{}
-	rt           tools.Runtime
+	id            string
+	cmd           string
+	cwd           string
+	process       *os.Process
+	processGroup  *processGroup
+	outputMu      sync.RWMutex
+	output        *bytes.Buffer
+	startTime     time.Time
+	status        atomic.Int32
+	exitCode      int
+	err           error
+	done          chan struct{}
+	stopRequested atomic.Bool
+	stopMu        sync.Mutex
+	rt            tools.Runtime
 }
 
 // limitedWriter wraps a buffer and stops writing after maxSize bytes. It uses
@@ -314,10 +318,10 @@ func (h *backgroundJobsHandler) monitorJob(ctx context.Context, job *backgroundJ
 		}
 	}
 
-	if !job.status.CompareAndSwap(statusRunning, newStatus) {
-		job.outputMu.Unlock()
-		return
+	if job.stopRequested.Load() {
+		newStatus = statusStopped
 	}
+	job.status.Store(newStatus)
 
 	status := job.status.Load()
 	exitCode := job.exitCode
@@ -436,16 +440,47 @@ func (h *backgroundJobsHandler) StopBackgroundJob(_ context.Context, params Stop
 		return tools.ResultError("Job not found: " + params.JobID), nil
 	}
 
-	if !job.status.CompareAndSwap(statusRunning, statusStopped) {
-		currentStatus := job.status.Load()
-		return tools.ResultError(fmt.Sprintf("Job %s is not running (current status: %s)", params.JobID, statusToString(currentStatus))), nil
+	if err := stopBackgroundJob(job); err != nil {
+		return tools.ResultError("Error: " + err.Error()), nil
 	}
-
-	if err := kill(job.process, job.processGroup); err != nil {
-		return tools.ResultError(fmt.Sprintf("Job %s marked as stopped, but error killing process: %s", params.JobID, err)), nil
-	}
-
 	return tools.ResultSuccess(fmt.Sprintf("Job %s stopped successfully", params.JobID)), nil
+}
+
+func stopBackgroundJob(job *backgroundJob) error {
+	job.stopMu.Lock()
+	defer job.stopMu.Unlock()
+	if job.status.Load() != statusRunning {
+		return fmt.Errorf("job %s is not running (current status: %s)", job.id, statusToString(job.status.Load()))
+	}
+
+	if err := terminateProcess(job.process, job.processGroup, false); err != nil {
+		if job.status.Load() == statusRunning {
+			return fmt.Errorf("error stopping job %s: %w", job.id, err)
+		}
+		return nil
+	}
+	job.stopRequested.Store(true)
+	if !waitForJob(job.done, gracefulStopTimeout) {
+		if err := terminateProcess(job.process, job.processGroup, true); err != nil && job.status.Load() == statusRunning {
+			return fmt.Errorf("error force-stopping job %s: %w", job.id, err)
+		}
+		if !waitForJob(job.done, forcedStopTimeout) {
+			return fmt.Errorf("timed out waiting for job %s to stop", job.id)
+		}
+	}
+
+	return nil
+}
+
+func waitForJob(done <-chan struct{}, timeout time.Duration) bool {
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+	select {
+	case <-done:
+		return true
+	case <-timer.C:
+		return false
+	}
 }
 
 func formatBackgroundJobRecall(job *backgroundJob, status int32, exitCode int, output string) string {
@@ -468,7 +503,7 @@ func reapSpawnedChild(cmd *exec.Cmd, pg *processGroup) {
 	if cmd == nil || cmd.Process == nil {
 		return
 	}
-	_ = kill(cmd.Process, pg)
+	_ = terminateProcess(cmd.Process, pg, false)
 
 	done := make(chan struct{})
 	go func() {
@@ -478,7 +513,7 @@ func reapSpawnedChild(cmd *exec.Cmd, pg *processGroup) {
 	select {
 	case <-done:
 	case <-time.After(2 * time.Second):
-		_ = cmd.Process.Kill()
+		_ = terminateProcess(cmd.Process, pg, true)
 		<-done
 	}
 }
@@ -625,11 +660,26 @@ func (t *ToolSet) Start(context.Context) error {
 }
 
 func (t *ToolSet) Stop(context.Context) error {
+	var wg sync.WaitGroup
+	errs := make(chan error)
 	t.handler.jobs.Range(func(_ string, job *backgroundJob) bool {
-		if job.status.CompareAndSwap(statusRunning, statusStopped) {
-			_ = kill(job.process, job.processGroup)
+		if job.status.Load() == statusRunning {
+			wg.Go(func() {
+				if err := stopBackgroundJob(job); err != nil {
+					errs <- err
+				}
+			})
 		}
 		return true
 	})
-	return nil
+	go func() {
+		wg.Wait()
+		close(errs)
+	}()
+
+	var stopErr error
+	for err := range errs {
+		stopErr = errors.Join(stopErr, err)
+	}
+	return stopErr
 }

--- a/pkg/tools/builtin/backgroundjobs/backgroundjobs_test.go
+++ b/pkg/tools/builtin/backgroundjobs/backgroundjobs_test.go
@@ -279,6 +279,83 @@ func TestBackgroundJobsTool_WaitBackgroundJob_Stopped(t *testing.T) {
 		"stopped jobs should not show an exit code")
 }
 
+func TestBackgroundJobsTool_StopEscalatesWhenSIGTERMIgnored(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX signals; skipped on Windows")
+	}
+
+	tool := newTestTool(t)
+	t.Cleanup(func() { _ = tool.Stop(t.Context()) })
+	_, err := tool.handler.RunBackgroundJob(t.Context(), RunBackgroundJobArgs{
+		Cmd: `trap '' TERM; echo ready; while :; do sleep 1; done`,
+	}, tools.NopRuntime{})
+	require.NoError(t, err)
+
+	var job *backgroundJob
+	tool.handler.jobs.Range(func(_ string, candidate *backgroundJob) bool {
+		job = candidate
+		return false
+	})
+	require.NotNil(t, job)
+	require.Eventually(t, func() bool {
+		job.outputMu.RLock()
+		defer job.outputMu.RUnlock()
+		return strings.Contains(job.output.String(), "ready")
+	}, time.Second, 10*time.Millisecond)
+
+	started := time.Now()
+	result, err := tool.handler.StopBackgroundJob(t.Context(), StopBackgroundJobArgs{JobID: job.id})
+	require.NoError(t, err)
+	assert.False(t, result.IsError)
+	assert.Less(t, time.Since(started), 5*time.Second)
+	select {
+	case <-job.done:
+	case <-time.After(time.Second):
+		t.Fatal("process survived stop escalation")
+	}
+	assert.Equal(t, statusStopped, job.status.Load())
+
+	result, err = tool.handler.StopBackgroundJob(t.Context(), StopBackgroundJobArgs{JobID: job.id})
+	require.NoError(t, err)
+	assert.True(t, result.IsError)
+	assert.Contains(t, result.Output, "not running")
+}
+
+func TestBackgroundJobsTool_StopWaitsForRealExit(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX signals; skipped on Windows")
+	}
+
+	tool := newTestTool(t)
+	t.Cleanup(func() { _ = tool.Stop(t.Context()) })
+	_, err := tool.handler.RunBackgroundJob(t.Context(), RunBackgroundJobArgs{
+		Cmd: `trap 'sleep 0.1; exit 0' TERM; echo ready; while :; do sleep 1; done`,
+	}, tools.NopRuntime{})
+	require.NoError(t, err)
+
+	var job *backgroundJob
+	tool.handler.jobs.Range(func(_ string, candidate *backgroundJob) bool {
+		job = candidate
+		return false
+	})
+	require.NotNil(t, job)
+	require.Eventually(t, func() bool {
+		job.outputMu.RLock()
+		defer job.outputMu.RUnlock()
+		return strings.Contains(job.output.String(), "ready")
+	}, time.Second, 10*time.Millisecond)
+
+	result, err := tool.handler.StopBackgroundJob(t.Context(), StopBackgroundJobArgs{JobID: job.id})
+	require.NoError(t, err)
+	assert.False(t, result.IsError)
+	select {
+	case <-job.done:
+	default:
+		t.Fatal("stop returned before the command exited")
+	}
+	assert.Equal(t, statusStopped, job.status.Load())
+}
+
 func TestBackgroundJobsTool_RunBackgroundJob(t *testing.T) {
 	t.Parallel()
 	tool := newTestTool(t)

--- a/pkg/tools/builtin/backgroundjobs/cmd_js.go
+++ b/pkg/tools/builtin/backgroundjobs/cmd_js.go
@@ -18,6 +18,6 @@ func createProcessGroup(_ *os.Process) (*processGroup, error) {
 	return &processGroup{}, nil
 }
 
-func kill(_ *os.Process, _ *processGroup) error {
+func terminateProcess(_ *os.Process, _ *processGroup, _ bool) error {
 	return errors.New("background_jobs: process termination not supported on js/wasm")
 }

--- a/pkg/tools/builtin/backgroundjobs/cmd_unix.go
+++ b/pkg/tools/builtin/backgroundjobs/cmd_unix.go
@@ -17,6 +17,10 @@ func createProcessGroup(_ *os.Process) (*processGroup, error) {
 	return &processGroup{}, nil
 }
 
-func kill(proc *os.Process, _ *processGroup) error {
-	return syscall.Kill(-proc.Pid, syscall.SIGTERM)
+func terminateProcess(proc *os.Process, _ *processGroup, force bool) error {
+	signal := syscall.SIGTERM
+	if force {
+		signal = syscall.SIGKILL
+	}
+	return syscall.Kill(-proc.Pid, signal)
 }

--- a/pkg/tools/builtin/backgroundjobs/cmd_windows.go
+++ b/pkg/tools/builtin/backgroundjobs/cmd_windows.go
@@ -56,7 +56,7 @@ func createProcessGroup(proc *os.Process) (*processGroup, error) {
 	}, nil
 }
 
-func kill(proc *os.Process, pg *processGroup) error {
+func terminateProcess(proc *os.Process, pg *processGroup, _ bool) error {
 	if pg != nil {
 		if pg.processHandle != 0 {
 			_ = windows.CloseHandle(pg.processHandle)

--- a/pkg/tools/builtin/mcpcatalog/mcpcatalog.go
+++ b/pkg/tools/builtin/mcpcatalog/mcpcatalog.go
@@ -710,7 +710,7 @@ func (t *Toolset) handleEnable(ctx context.Context, args EnableArgs) (*tools.Too
 		// default callback. If a future entry needs custom scopes / a fixed
 		// client_id / a non-default callback, extend Auth in servers.go and
 		// plumb the resulting *RemoteOAuthConfig through here.
-		mcpToolset := mcp.NewRemoteToolset(id, server.URL, server.Transport, nil, nil)
+		mcpToolset := mcp.NewRemoteToolsetWithAllowPrivateIPs(id, server.URL, server.Transport, nil, nil, server.allowPrivateIPs)
 
 		// Re-attach the captured handlers so OAuth flows behave
 		// identically to a YAML-declared mcp.remote toolset. Apply

--- a/pkg/tools/builtin/mcpcatalog/mcpcatalog_test.go
+++ b/pkg/tools/builtin/mcpcatalog/mcpcatalog_test.go
@@ -856,11 +856,12 @@ func TestToolsExposesEnabledServerTools(t *testing.T) {
 	// Inject a synthetic catalog entry that points at the test server.
 	const id = "test-server"
 	server := Server{
-		ID:        id,
-		Title:     "Test",
-		URL:       srv.URL,
-		Transport: "streamable-http",
-		Auth:      Auth{Type: "none"},
+		ID:              id,
+		Title:           "Test",
+		URL:             srv.URL,
+		Transport:       "streamable-http",
+		Auth:            Auth{Type: "none"},
+		allowPrivateIPs: true,
 	}
 	ts.catalog.Servers = append(ts.catalog.Servers, server)
 	ts.byID[id] = server
@@ -929,11 +930,12 @@ func TestHandleEnable_OAuthDCR_ChallengePRMScopeFallback(t *testing.T) {
 
 	const id = "test-oauth-dcr-server"
 	server := Server{
-		ID:        id,
-		Title:     "OAuth DCR Test Server",
-		URL:       srv.URL,
-		Transport: "streamable-http",
-		Auth:      Auth{Type: "oauth"},
+		ID:              id,
+		Title:           "OAuth DCR Test Server",
+		URL:             srv.URL,
+		Transport:       "streamable-http",
+		Auth:            Auth{Type: "oauth"},
+		allowPrivateIPs: true,
 	}
 	ts.catalog.Servers = append(ts.catalog.Servers, server)
 	ts.byID[id] = server

--- a/pkg/tools/builtin/mcpcatalog/servers.go
+++ b/pkg/tools/builtin/mcpcatalog/servers.go
@@ -39,6 +39,8 @@ type Server struct {
 	Icon        string   `json:"icon,omitempty"`
 	Readme      string   `json:"readme,omitempty"`
 	Auth        Auth     `json:"auth"`
+
+	allowPrivateIPs bool
 }
 
 // Auth describes how to authenticate against a remote MCP server.

--- a/pkg/tools/builtin/scheduler/scheduler.go
+++ b/pkg/tools/builtin/scheduler/scheduler.go
@@ -16,8 +16,9 @@ const (
 	ToolNameListSchedules  = "list_schedules"
 	ToolNameCancelSchedule = "cancel_schedule"
 
-	category    = "scheduler"
-	loopMaxWait = time.Minute
+	category         = "scheduler"
+	loopMaxWait      = time.Minute
+	recallRetryDelay = time.Minute
 )
 
 func CreateToolSet() (tools.ToolSet, error) {
@@ -96,8 +97,10 @@ func (t *ToolSet) fireDue(ctx context.Context, now time.Time) {
 	if rt == nil {
 		return
 	}
-	for _, sc := range t.store.popDue(now) {
-		if err := rt.Recall(ctx, formatFire(sc)); err != nil {
+	for _, sc := range t.store.claimDue(now) {
+		err := rt.Recall(ctx, formatFire(sc))
+		t.store.finishFire(sc.ID, now, err == nil)
+		if err != nil {
 			slog.WarnContext(ctx, "Failed to enqueue scheduled recall",
 				"schedule_id", sc.ID, "schedule_name", sc.Name, "error", err)
 		}

--- a/pkg/tools/builtin/scheduler/scheduler_test.go
+++ b/pkg/tools/builtin/scheduler/scheduler_test.go
@@ -20,6 +20,7 @@ type fakeRuntime struct {
 	recalls   []string
 	recall    bool
 	recallErr error
+	recallFn  func() error
 }
 
 func (f *fakeRuntime) EmitOutput(context.Context, string) {}
@@ -28,6 +29,9 @@ func (f *fakeRuntime) Recall(_ context.Context, msg string) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.recalls = append(f.recalls, msg)
+	if f.recallFn != nil {
+		return f.recallFn()
+	}
 	return f.recallErr
 }
 
@@ -122,6 +126,77 @@ func TestFireDueCallsRecall(t *testing.T) {
 	require.Contains(t, msgs[0], "run backup")
 	require.Contains(t, msgs[0], "bkp")
 	require.Len(t, ts.store.list(), 1)
+}
+
+func TestFireDueRetriesOneShotAfterRecallError(t *testing.T) {
+	t.Parallel()
+
+	ts := newTestToolSet()
+	attempts := 0
+	rt := &fakeRuntime{
+		recall: true,
+		recallFn: func() error {
+			attempts++
+			if attempts == 1 {
+				return errors.New("host went away")
+			}
+			return nil
+		},
+	}
+
+	_, err := ts.createSchedule(t.Context(),
+		CreateScheduleArgs{Prompt: "do once", When: "in:10m"}, rt)
+	require.NoError(t, err)
+
+	dueAt := testNow.Add(10 * time.Minute)
+	ts.fireDue(t.Context(), dueAt)
+	require.Len(t, rt.messages(), 1)
+	require.Len(t, ts.store.list(), 1)
+
+	ts.fireDue(t.Context(), dueAt)
+	require.Len(t, rt.messages(), 1)
+
+	ts.fireDue(t.Context(), dueAt.Add(recallRetryDelay))
+	require.Len(t, rt.messages(), 2)
+	require.Empty(t, ts.store.list())
+}
+
+func TestCancelScheduleDuringRecallDoesNotRetry(t *testing.T) {
+	t.Parallel()
+
+	ts := newTestToolSet()
+	started := make(chan struct{})
+	proceed := make(chan struct{})
+	rt := &fakeRuntime{
+		recall: true,
+		recallFn: func() error {
+			close(started)
+			<-proceed
+			return errors.New("host went away")
+		},
+	}
+
+	_, err := ts.createSchedule(t.Context(),
+		CreateScheduleArgs{Prompt: "do once", When: "in:10m"}, rt)
+	require.NoError(t, err)
+	id := ts.store.list()[0].ID
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		ts.fireDue(t.Context(), testNow.Add(10*time.Minute))
+	}()
+	<-started
+
+	res, err := ts.cancelSchedule(t.Context(), CancelScheduleArgs{ID: id})
+	require.NoError(t, err)
+	require.False(t, res.IsError)
+	close(proceed)
+	<-done
+
+	require.Empty(t, ts.store.list())
+	ts.fireDue(t.Context(), testNow.Add(10*time.Minute+recallRetryDelay))
+	require.Len(t, rt.messages(), 1)
 }
 
 func TestFireDueContinuesAfterRecallError(t *testing.T) {

--- a/pkg/tools/builtin/scheduler/store.go
+++ b/pkg/tools/builtin/scheduler/store.go
@@ -20,13 +20,19 @@ type Schedule struct {
 func (s Schedule) Recurring() bool { return s.Interval > 0 }
 
 type store struct {
-	mu   sync.Mutex
-	seq  int
-	byID map[string]*Schedule
+	mu       sync.Mutex
+	seq      int
+	byID     map[string]*Schedule
+	inFlight map[string]time.Time
+	retryDue map[string]time.Time
 }
 
 func newStore() *store {
-	return &store{byID: make(map[string]*Schedule)}
+	return &store{
+		byID:     make(map[string]*Schedule),
+		inFlight: make(map[string]time.Time),
+		retryDue: make(map[string]time.Time),
+	}
 }
 
 func (s *store) add(name, prompt, when string, now time.Time) (Schedule, error) {
@@ -71,31 +77,64 @@ func (s *store) cancel(id string) bool {
 		return false
 	}
 	delete(s.byID, id)
+	delete(s.inFlight, id)
+	delete(s.retryDue, id)
 	return true
 }
 
-func (s *store) popDue(now time.Time) []Schedule {
+func (s *store) claimDue(now time.Time) []Schedule {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	var fired []Schedule
+	var due []Schedule
 	for id, sc := range s.byID {
 		if sc.NextFire.After(now) {
 			continue
 		}
-		fired = append(fired, *sc)
-		if sc.Interval > 0 {
-			next := sc.NextFire.Add(sc.Interval)
-			for !next.After(now) {
-				next = next.Add(sc.Interval)
-			}
-			sc.NextFire = next
-		} else {
-			delete(s.byID, id)
+		if _, ok := s.inFlight[id]; ok {
+			continue
 		}
+		due = append(due, *sc)
+		logicalDue := sc.NextFire
+		if retryDue, ok := s.retryDue[id]; ok {
+			logicalDue = retryDue
+		}
+		s.inFlight[id] = logicalDue
 	}
-	sortSchedules(fired)
-	return fired
+	sortSchedules(due)
+	return due
+}
+
+func (s *store) finishFire(id string, now time.Time, success bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	due, ok := s.inFlight[id]
+	if !ok {
+		return
+	}
+	delete(s.inFlight, id)
+
+	sc, ok := s.byID[id]
+	if !ok {
+		return
+	}
+	if !success {
+		s.retryDue[id] = due
+		sc.NextFire = now.Add(recallRetryDelay)
+		return
+	}
+	delete(s.retryDue, id)
+	if !sc.Recurring() {
+		delete(s.byID, id)
+		return
+	}
+
+	next := due.Add(sc.Interval)
+	for !next.After(now) {
+		next = next.Add(sc.Interval)
+	}
+	sc.NextFire = next
 }
 
 func (s *store) untilNext(now time.Time) (time.Duration, bool) {
@@ -104,7 +143,10 @@ func (s *store) untilNext(now time.Time) (time.Duration, bool) {
 
 	var soonest time.Time
 	found := false
-	for _, sc := range s.byID {
+	for id, sc := range s.byID {
+		if _, ok := s.inFlight[id]; ok {
+			continue
+		}
 		if !found || sc.NextFire.Before(soonest) {
 			soonest = sc.NextFire
 			found = true

--- a/pkg/tools/builtin/scheduler/store_test.go
+++ b/pkg/tools/builtin/scheduler/store_test.go
@@ -47,46 +47,95 @@ func TestStoreCancel(t *testing.T) {
 	require.False(t, s.cancel(sc.ID))
 }
 
-func TestStorePopDueOneShot(t *testing.T) {
+func TestStoreClaimDueOneShot(t *testing.T) {
 	t.Parallel()
 
 	s := newStore()
 	sc, err := s.add("once", "do once", "in:10m", testNow)
 	require.NoError(t, err)
 
-	require.Empty(t, s.popDue(testNow.Add(9*time.Minute)))
-	fired := s.popDue(testNow.Add(10 * time.Minute))
-	require.Len(t, fired, 1)
-	require.Equal(t, sc.ID, fired[0].ID)
+	require.Empty(t, s.claimDue(testNow.Add(9*time.Minute)))
+	due := s.claimDue(testNow.Add(10 * time.Minute))
+	require.Len(t, due, 1)
+	require.Equal(t, sc.ID, due[0].ID)
+	require.Empty(t, s.claimDue(testNow.Add(10*time.Minute)))
+
+	s.finishFire(sc.ID, testNow.Add(10*time.Minute), true)
 	require.Empty(t, s.list())
 }
 
-func TestStorePopDueRecurringReArms(t *testing.T) {
+func TestStoreFinishFireRecurringReArms(t *testing.T) {
 	t.Parallel()
 
 	s := newStore()
-	_, err := s.add("loop", "tick", "every:1h", testNow)
+	sc, err := s.add("loop", "tick", "every:1h", testNow)
 	require.NoError(t, err)
 
-	fired := s.popDue(testNow.Add(time.Hour))
-	require.Len(t, fired, 1)
+	due := s.claimDue(testNow.Add(time.Hour))
+	require.Len(t, due, 1)
+	s.finishFire(sc.ID, testNow.Add(time.Hour), true)
 
-	require.Empty(t, s.popDue(testNow.Add(time.Hour)))
+	require.Empty(t, s.claimDue(testNow.Add(time.Hour)))
 	list := s.list()
 	require.Len(t, list, 1)
 	require.Equal(t, testNow.Add(2*time.Hour), list[0].NextFire)
 }
 
-func TestStorePopDueSkipsMissedSlots(t *testing.T) {
+func TestStoreFinishFireRecurringSkipsMissedSlots(t *testing.T) {
 	t.Parallel()
 
 	s := newStore()
-	_, err := s.add("loop", "tick", "every:1h", testNow)
+	sc, err := s.add("loop", "tick", "every:1h", testNow)
 	require.NoError(t, err)
 
-	fired := s.popDue(testNow.Add(3*time.Hour + 30*time.Minute))
-	require.Len(t, fired, 1)
+	due := s.claimDue(testNow.Add(3*time.Hour + 30*time.Minute))
+	require.Len(t, due, 1)
+	s.finishFire(sc.ID, testNow.Add(3*time.Hour+30*time.Minute), true)
 	require.Equal(t, testNow.Add(4*time.Hour), s.list()[0].NextFire)
+}
+
+func TestStoreFinishFireFailureRetriesWithoutChangingRecurringCadence(t *testing.T) {
+	t.Parallel()
+
+	s := newStore()
+	sc, err := s.add("loop", "tick", "every:1h", testNow)
+	require.NoError(t, err)
+
+	due := s.claimDue(testNow.Add(time.Hour))
+	require.Len(t, due, 1)
+	s.finishFire(sc.ID, testNow.Add(time.Hour), false)
+	require.Equal(t, testNow.Add(time.Hour+recallRetryDelay), s.list()[0].NextFire)
+
+	retryAt := testNow.Add(time.Hour + recallRetryDelay)
+	due = s.claimDue(retryAt)
+	require.Len(t, due, 1)
+	s.finishFire(sc.ID, retryAt, true)
+	require.Equal(t, testNow.Add(2*time.Hour), s.list()[0].NextFire)
+}
+
+func TestStoreCancelWhileFiring(t *testing.T) {
+	t.Parallel()
+
+	s := newStore()
+	sc, err := s.add("once", "do once", "in:10m", testNow)
+	require.NoError(t, err)
+	require.Len(t, s.claimDue(testNow.Add(10*time.Minute)), 1)
+
+	require.True(t, s.cancel(sc.ID))
+	s.finishFire(sc.ID, testNow.Add(10*time.Minute), false)
+	require.Empty(t, s.list())
+}
+
+func TestStoreUntilNextIgnoresInFlightSchedules(t *testing.T) {
+	t.Parallel()
+
+	s := newStore()
+	_, err := s.add("x", "do x", "in:5m", testNow)
+	require.NoError(t, err)
+	require.Len(t, s.claimDue(testNow.Add(5*time.Minute)), 1)
+
+	_, ok := s.untilNext(testNow.Add(5 * time.Minute))
+	require.False(t, ok)
 }
 
 func TestStoreUntilNext(t *testing.T) {

--- a/pkg/tools/builtin/tasks/tasks.go
+++ b/pkg/tools/builtin/tasks/tasks.go
@@ -16,7 +16,6 @@ import (
 
 	"github.com/docker/docker-agent/pkg/config"
 	"github.com/docker/docker-agent/pkg/config/latest"
-	"github.com/docker/docker-agent/pkg/path"
 	"github.com/docker/docker-agent/pkg/tools"
 	"github.com/docker/docker-agent/pkg/tools/toolsetpath"
 )
@@ -201,13 +200,22 @@ func now() string {
 
 func (t *ToolSet) resolveDescription(description, filePath string) (string, error) {
 	if filePath != "" {
-		validatedPath, err := path.ValidatePathInDirectory(filePath, t.basePath)
+		root, err := os.OpenRoot(t.basePath)
 		if err != nil {
-			return "", fmt.Errorf("invalid file path: %w", err)
+			return "", fmt.Errorf("opening task directory: %w", err)
 		}
-		data, err := os.ReadFile(validatedPath)
+		defer root.Close()
+
+		name := filePath
+		if filepath.IsAbs(name) {
+			name, err = filepath.Rel(t.basePath, name)
+			if err != nil {
+				return "", fmt.Errorf("invalid file path: %w", err)
+			}
+		}
+		data, err := root.ReadFile(name)
 		if err != nil {
-			return "", fmt.Errorf("reading file %s: %w", validatedPath, err)
+			return "", fmt.Errorf("reading file %s: %w", filePath, err)
 		}
 		return string(data), nil
 	}

--- a/pkg/tools/builtin/tasks/tasks.go
+++ b/pkg/tools/builtin/tasks/tasks.go
@@ -1,6 +1,7 @@
 package tasks
 
 import (
+	"bytes"
 	"cmp"
 	"context"
 	"encoding/json"
@@ -14,8 +15,10 @@ import (
 
 	"github.com/google/uuid"
 
+	"github.com/docker/docker-agent/pkg/atomicfile"
 	"github.com/docker/docker-agent/pkg/config"
 	"github.com/docker/docker-agent/pkg/config/latest"
+	"github.com/docker/docker-agent/pkg/memory/database"
 	"github.com/docker/docker-agent/pkg/tools"
 	"github.com/docker/docker-agent/pkg/tools/toolsetpath"
 )
@@ -94,6 +97,7 @@ type ToolSet struct {
 	mu       sync.Mutex
 	filePath string
 	basePath string
+	fileLock *database.FileLock
 }
 
 var (
@@ -123,6 +127,7 @@ func New(storagePath string) *ToolSet {
 	return &ToolSet{
 		filePath: storagePath,
 		basePath: filepath.Dir(storagePath),
+		fileLock: database.NewFileLock(storagePath + ".lock"),
 	}
 }
 
@@ -157,7 +162,16 @@ func (t *ToolSet) save(store taskStore) error {
 	if err != nil {
 		return fmt.Errorf("marshaling task store: %w", err)
 	}
-	return os.WriteFile(t.filePath, data, 0o600)
+	return atomicfile.Write(t.filePath, bytes.NewReader(data), 0o600)
+}
+
+func (t *ToolSet) lock(ctx context.Context) (func(), error) {
+	if err := t.fileLock.Lock(ctx); err != nil {
+		return nil, fmt.Errorf("locking task store: %w", err)
+	}
+	return func() {
+		_ = t.fileLock.Unlock()
+	}, nil
 }
 
 func effectiveStatus(task Task, tasks map[string]Task) TaskStatus {
@@ -283,7 +297,7 @@ type RemoveDependencyArgs struct {
 
 // Tool handlers
 
-func (t *ToolSet) createTask(_ context.Context, params CreateTaskArgs) (*tools.ToolCallResult, error) {
+func (t *ToolSet) createTask(ctx context.Context, params CreateTaskArgs) (*tools.ToolCallResult, error) {
 	desc, err := t.resolveDescription(params.Description, params.Path)
 	if err != nil {
 		return tools.ResultError(err.Error()), nil
@@ -298,6 +312,11 @@ func (t *ToolSet) createTask(_ context.Context, params CreateTaskArgs) (*tools.T
 
 	t.mu.Lock()
 	defer t.mu.Unlock()
+	release, err := t.lock(ctx)
+	if err != nil {
+		return tools.ResultError(err.Error()), nil
+	}
+	defer release()
 
 	store := t.load()
 	id := uuid.New().String()
@@ -347,9 +366,14 @@ func (t *ToolSet) getTask(_ context.Context, params GetTaskArgs) (*tools.ToolCal
 	return taskWithEffectiveResult(task, store.Tasks), nil
 }
 
-func (t *ToolSet) updateTask(_ context.Context, params UpdateTaskArgs) (*tools.ToolCallResult, error) {
+func (t *ToolSet) updateTask(ctx context.Context, params UpdateTaskArgs) (*tools.ToolCallResult, error) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
+	release, err := t.lock(ctx)
+	if err != nil {
+		return tools.ResultError(err.Error()), nil
+	}
+	defer release()
 
 	store := t.load()
 	task, ok := store.Tasks[params.ID]
@@ -401,9 +425,14 @@ func (t *ToolSet) updateTask(_ context.Context, params UpdateTaskArgs) (*tools.T
 	return taskResult(task), nil
 }
 
-func (t *ToolSet) deleteTask(_ context.Context, params DeleteTaskArgs) (*tools.ToolCallResult, error) {
+func (t *ToolSet) deleteTask(ctx context.Context, params DeleteTaskArgs) (*tools.ToolCallResult, error) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
+	release, err := t.lock(ctx)
+	if err != nil {
+		return tools.ResultError(err.Error()), nil
+	}
+	defer release()
 
 	store := t.load()
 	if _, ok := store.Tasks[params.ID]; !ok {
@@ -490,9 +519,14 @@ func (t *ToolSet) nextTask(_ context.Context, _ tools.ToolCall, _ tools.Runtime)
 	return tools.ResultSuccess("No actionable tasks. Everything is either done or blocked."), nil
 }
 
-func (t *ToolSet) addDependency(_ context.Context, params AddDependencyArgs) (*tools.ToolCallResult, error) {
+func (t *ToolSet) addDependency(ctx context.Context, params AddDependencyArgs) (*tools.ToolCallResult, error) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
+	release, err := t.lock(ctx)
+	if err != nil {
+		return tools.ResultError(err.Error()), nil
+	}
+	defer release()
 
 	store := t.load()
 	task, ok := store.Tasks[params.TaskID]
@@ -522,9 +556,14 @@ func (t *ToolSet) addDependency(_ context.Context, params AddDependencyArgs) (*t
 	return taskResult(task), nil
 }
 
-func (t *ToolSet) removeDependency(_ context.Context, params RemoveDependencyArgs) (*tools.ToolCallResult, error) {
+func (t *ToolSet) removeDependency(ctx context.Context, params RemoveDependencyArgs) (*tools.ToolCallResult, error) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
+	release, err := t.lock(ctx)
+	if err != nil {
+		return tools.ResultError(err.Error()), nil
+	}
+	defer release()
 
 	store := t.load()
 	task, ok := store.Tasks[params.TaskID]

--- a/pkg/tools/builtin/tasks/tasks.go
+++ b/pkg/tools/builtin/tasks/tasks.go
@@ -5,6 +5,7 @@ import (
 	"cmp"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -139,19 +140,22 @@ Persistent task management with priorities (critical > high > medium > low), sta
 A task is automatically blocked if any dependency is not done. Use next_task to get the highest-priority actionable task.`
 }
 
-func (t *ToolSet) load() taskStore {
+func (t *ToolSet) load() (taskStore, error) {
 	data, err := os.ReadFile(t.filePath)
+	if errors.Is(err, os.ErrNotExist) {
+		return taskStore{Tasks: make(map[string]Task)}, nil
+	}
 	if err != nil {
-		return taskStore{Tasks: make(map[string]Task)}
+		return taskStore{}, fmt.Errorf("reading task store: %w", err)
 	}
 	var store taskStore
 	if err := json.Unmarshal(data, &store); err != nil {
-		return taskStore{Tasks: make(map[string]Task)}
+		return taskStore{}, fmt.Errorf("parsing task store: %w", err)
 	}
 	if store.Tasks == nil {
 		store.Tasks = make(map[string]Task)
 	}
-	return store
+	return store, nil
 }
 
 func (t *ToolSet) save(store taskStore) error {
@@ -318,7 +322,10 @@ func (t *ToolSet) createTask(ctx context.Context, params CreateTaskArgs) (*tools
 	}
 	defer release()
 
-	store := t.load()
+	store, err := t.load()
+	if err != nil {
+		return tools.ResultError(err.Error()), nil
+	}
 	id := uuid.New().String()
 
 	deps := params.Dependencies
@@ -357,7 +364,10 @@ func (t *ToolSet) getTask(_ context.Context, params GetTaskArgs) (*tools.ToolCal
 	t.mu.Lock()
 	defer t.mu.Unlock()
 
-	store := t.load()
+	store, err := t.load()
+	if err != nil {
+		return tools.ResultError(err.Error()), nil
+	}
 	task, ok := store.Tasks[params.ID]
 	if !ok {
 		return tools.ResultError("task not found: " + params.ID), nil
@@ -375,7 +385,10 @@ func (t *ToolSet) updateTask(ctx context.Context, params UpdateTaskArgs) (*tools
 	}
 	defer release()
 
-	store := t.load()
+	store, err := t.load()
+	if err != nil {
+		return tools.ResultError(err.Error()), nil
+	}
 	task, ok := store.Tasks[params.ID]
 	if !ok {
 		return tools.ResultError("task not found: " + params.ID), nil
@@ -434,7 +447,10 @@ func (t *ToolSet) deleteTask(ctx context.Context, params DeleteTaskArgs) (*tools
 	}
 	defer release()
 
-	store := t.load()
+	store, err := t.load()
+	if err != nil {
+		return tools.ResultError(err.Error()), nil
+	}
 	if _, ok := store.Tasks[params.ID]; !ok {
 		return tools.ResultError("task not found: " + params.ID), nil
 	}
@@ -463,7 +479,10 @@ func (t *ToolSet) listTasks(_ context.Context, params ListTasksArgs) (*tools.Too
 	t.mu.Lock()
 	defer t.mu.Unlock()
 
-	store := t.load()
+	store, err := t.load()
+	if err != nil {
+		return tools.ResultError(err.Error()), nil
+	}
 	var tasks []taskWithEffective
 	for _, task := range store.Tasks {
 		tasks = append(tasks, taskWithEffective{
@@ -500,7 +519,10 @@ func (t *ToolSet) nextTask(_ context.Context, _ tools.ToolCall, _ tools.Runtime)
 	t.mu.Lock()
 	defer t.mu.Unlock()
 
-	store := t.load()
+	store, err := t.load()
+	if err != nil {
+		return tools.ResultError(err.Error()), nil
+	}
 	var tasks []taskWithEffective
 	for _, task := range store.Tasks {
 		tasks = append(tasks, taskWithEffective{
@@ -528,7 +550,10 @@ func (t *ToolSet) addDependency(ctx context.Context, params AddDependencyArgs) (
 	}
 	defer release()
 
-	store := t.load()
+	store, err := t.load()
+	if err != nil {
+		return tools.ResultError(err.Error()), nil
+	}
 	task, ok := store.Tasks[params.TaskID]
 	if !ok {
 		return tools.ResultError("task not found: " + params.TaskID), nil
@@ -565,7 +590,10 @@ func (t *ToolSet) removeDependency(ctx context.Context, params RemoveDependencyA
 	}
 	defer release()
 
-	store := t.load()
+	store, err := t.load()
+	if err != nil {
+		return tools.ResultError(err.Error()), nil
+	}
 	task, ok := store.Tasks[params.TaskID]
 	if !ok {
 		return tools.ResultError("task not found: " + params.TaskID), nil

--- a/pkg/tools/builtin/tasks/tasks_test.go
+++ b/pkg/tools/builtin/tasks/tasks_test.go
@@ -122,19 +122,42 @@ func TestTasksTool_CreateTask_FromFile(t *testing.T) {
 	t.Parallel()
 	tool := newTestTasksTool(t)
 
-	mdFile := filepath.Join(tool.basePath, "desc.md")
+	require.NoError(t, os.Mkdir(filepath.Join(tool.basePath, "docs"), 0o755))
+	mdFile := filepath.Join(tool.basePath, "docs", "desc.md")
 	require.NoError(t, os.WriteFile(mdFile, []byte("# Description\nFrom file"), 0o644))
+	require.NoError(t, os.Symlink(filepath.Join("docs", "desc.md"), filepath.Join(tool.basePath, "desc-link.md")))
 
-	result, err := tool.createTask(t.Context(), CreateTaskArgs{
-		Title: "File task",
-		Path:  mdFile,
-	})
+	for _, path := range []string{mdFile, filepath.Join("docs", "desc.md"), "desc-link.md"} {
+		result, err := tool.createTask(t.Context(), CreateTaskArgs{
+			Title: "File task",
+			Path:  path,
+		})
+		require.NoError(t, err)
+		require.False(t, result.IsError, "%s: %s", path, result.Output)
+
+		var task Task
+		require.NoError(t, json.Unmarshal([]byte(result.Output), &task))
+		require.Equal(t, "# Description\nFrom file", task.Description)
+	}
+}
+
+func TestTasksTool_CreateTask_RejectsDescriptionOutsideBasePath(t *testing.T) {
+	t.Parallel()
+	tool := newTestTasksTool(t)
+
+	outsideDir := t.TempDir()
+	outside := filepath.Join(outsideDir, "outside.md")
+	require.NoError(t, os.WriteFile(outside, []byte("secret"), 0o600))
+	require.NoError(t, os.Symlink(outside, filepath.Join(tool.basePath, "outside-link.md")))
+
+	relOutside, err := filepath.Rel(tool.basePath, outside)
 	require.NoError(t, err)
-	assert.False(t, result.IsError)
-
-	var task Task
-	require.NoError(t, json.Unmarshal([]byte(result.Output), &task))
-	assert.Equal(t, "# Description\nFrom file", task.Description)
+	for _, path := range []string{outside, relOutside, "outside-link.md"} {
+		result, err := tool.createTask(t.Context(), CreateTaskArgs{Title: "File task", Path: path})
+		require.NoError(t, err)
+		require.True(t, result.IsError)
+		require.NotContains(t, result.Output, "secret")
+	}
 }
 
 func TestTasksTool_GetTask(t *testing.T) {

--- a/pkg/tools/builtin/tasks/tasks_test.go
+++ b/pkg/tools/builtin/tasks/tasks_test.go
@@ -2,8 +2,10 @@ package tasks
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -29,6 +31,36 @@ func TestTasksTool_DisplayNames(t *testing.T) {
 		assert.NotEmpty(t, tl.DisplayName())
 		assert.NotEqual(t, tl.Name, tl.DisplayName())
 	}
+}
+
+func TestTasksTool_ConcurrentInstancesKeepEveryCreate(t *testing.T) {
+	t.Parallel()
+
+	const count = 40
+	storagePath := filepath.Join(t.TempDir(), "tasks.json")
+	type createResult struct {
+		result *tools.ToolCallResult
+		err    error
+	}
+	results := make(chan createResult, count)
+	var wg sync.WaitGroup
+	for i := range count {
+		wg.Go(func() {
+			result, err := New(storagePath).createTask(t.Context(), CreateTaskArgs{
+				Title: fmt.Sprintf("Task %d", i),
+			})
+			results <- createResult{result: result, err: err}
+		})
+	}
+	wg.Wait()
+	close(results)
+
+	for got := range results {
+		require.NoError(t, got.err)
+		require.False(t, got.result.IsError, got.result.Output)
+	}
+	store := New(storagePath).load()
+	require.Len(t, store.Tasks, count)
 }
 
 func TestTasksTool_CreateTask(t *testing.T) {

--- a/pkg/tools/builtin/tasks/tasks_test.go
+++ b/pkg/tools/builtin/tasks/tasks_test.go
@@ -59,8 +59,61 @@ func TestTasksTool_ConcurrentInstancesKeepEveryCreate(t *testing.T) {
 		require.NoError(t, got.err)
 		require.False(t, got.result.IsError, got.result.Output)
 	}
-	store := New(storagePath).load()
+	store, err := New(storagePath).load()
+	require.NoError(t, err)
 	require.Len(t, store.Tasks, count)
+}
+
+func TestTasksTool_MissingStoreStartsEmpty(t *testing.T) {
+	t.Parallel()
+
+	tool := newTestTasksTool(t)
+	store, err := tool.load()
+	require.NoError(t, err)
+	assert.Empty(t, store.Tasks)
+
+	result, err := tool.createTask(t.Context(), CreateTaskArgs{Title: "First"})
+	require.NoError(t, err)
+	require.False(t, result.IsError, result.Output)
+}
+
+func TestTasksTool_MalformedStoreIsPreserved(t *testing.T) {
+	t.Parallel()
+
+	for _, test := range []struct {
+		name string
+		run  func(*ToolSet) (*tools.ToolCallResult, error)
+	}{
+		{
+			name: "create",
+			run: func(tool *ToolSet) (*tools.ToolCallResult, error) {
+				return tool.createTask(t.Context(), CreateTaskArgs{Title: "New"})
+			},
+		},
+		{
+			name: "update",
+			run: func(tool *ToolSet) (*tools.ToolCallResult, error) {
+				return tool.updateTask(t.Context(), UpdateTaskArgs{ID: "existing", Title: "Changed"})
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			tool := newTestTasksTool(t)
+			original := []byte(`{"tasks":`)
+			require.NoError(t, os.WriteFile(tool.filePath, original, 0o600))
+
+			result, err := test.run(tool)
+			require.NoError(t, err)
+			require.True(t, result.IsError)
+			assert.Contains(t, result.Output, "parsing task store")
+
+			got, err := os.ReadFile(tool.filePath)
+			require.NoError(t, err)
+			assert.Equal(t, original, got)
+		})
+	}
 }
 
 func TestTasksTool_CreateTask(t *testing.T) {

--- a/pkg/tools/mcp/mcp.go
+++ b/pkg/tools/mcp/mcp.go
@@ -252,7 +252,7 @@ func NewRemoteToolset(name, urlString, transport string, headers map[string]stri
 }
 
 // NewRemoteToolsetWithAllowPrivateIPs creates a new remote MCP toolset and
-// optionally permits OAuth helper requests to dial non-public IP addresses.
+// optionally permits requests to dial non-public IP addresses.
 func NewRemoteToolsetWithAllowPrivateIPs(
 	name, urlString, transport string,
 	headers map[string]string,

--- a/pkg/tools/mcp/remote.go
+++ b/pkg/tools/mcp/remote.go
@@ -330,7 +330,7 @@ func (c *remoteMCPClient) expandHeaders(ctx context.Context, headers map[string]
 }
 
 func (c *remoteMCPClient) headerTransport() http.RoundTripper {
-	base := http.DefaultTransport
+	base := httpclient.TransportForAllowPrivateIPs(c.allowPrivateIPs)
 	origin := c.url
 	if path, ok := unixSocketPath(c.url); ok {
 		t := http.DefaultTransport.(*http.Transport).Clone()

--- a/pkg/tools/mcp/remote_test.go
+++ b/pkg/tools/mcp/remote_test.go
@@ -96,7 +96,7 @@ func TestRemoteClientCustomHeaders(t *testing.T) {
 		"Authorization": "Bearer custom-token",
 	}
 
-	client := newRemoteClient(server.URL, "sse", expectedHeaders, NewInMemoryTokenStore(), nil, false, nil)
+	client := newRemoteClient(server.URL, "sse", expectedHeaders, NewInMemoryTokenStore(), nil, true, nil)
 
 	// Try to initialize (which will make the HTTP request)
 	// We don't care if it succeeds or fails, we just need it to make the request
@@ -159,7 +159,7 @@ func TestRemoteClientHeadersWithStreamable(t *testing.T) {
 		"X-Custom-Auth": "custom-auth-value",
 	}
 
-	client := newRemoteClient(server.URL, "streamable", expectedHeaders, NewInMemoryTokenStore(), nil, false, nil)
+	client := newRemoteClient(server.URL, "streamable", expectedHeaders, NewInMemoryTokenStore(), nil, true, nil)
 
 	// Try to initialize
 	_, _ = client.Initialize(t.Context(), nil)
@@ -199,7 +199,7 @@ func TestRemoteClientNoHeaders(t *testing.T) {
 	defer server.Close()
 
 	// Create remote client without custom headers (nil)
-	client := newRemoteClient(server.URL, "sse", nil, NewInMemoryTokenStore(), nil, false, nil)
+	client := newRemoteClient(server.URL, "sse", nil, NewInMemoryTokenStore(), nil, true, nil)
 
 	_, _ = client.Initialize(t.Context(), nil)
 
@@ -235,7 +235,7 @@ func TestRemoteClientEmptyHeaders(t *testing.T) {
 	defer server.Close()
 
 	// Create remote client with empty headers map
-	client := newRemoteClient(server.URL, "sse", map[string]string{}, NewInMemoryTokenStore(), nil, false, nil)
+	client := newRemoteClient(server.URL, "sse", map[string]string{}, NewInMemoryTokenStore(), nil, true, nil)
 
 	_, _ = client.Initialize(t.Context(), nil)
 
@@ -339,7 +339,7 @@ func TestInitialize_SurfacesServerErrorInReturnedError(t *testing.T) {
 	store := NewInMemoryTokenStore()
 	require.NoError(t, store.StoreToken(server.URL, &OAuthToken{AccessToken: "at", TokenType: "Bearer"}))
 
-	client := newRemoteClient(server.URL, "streamable", nil, store, nil, false, nil)
+	client := newRemoteClient(server.URL, "streamable", nil, store, nil, true, nil)
 
 	_, err := client.Initialize(t.Context(), nil)
 	require.Error(t, err, "Initialize should fail against a server that rejects initialize")
@@ -371,7 +371,7 @@ func TestInitialize_NonInteractiveCtxDefersOAuthAndDoesNotBlock(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := newRemoteClient(server.URL, "streamable", nil, NewInMemoryTokenStore(), nil, false, nil)
+	client := newRemoteClient(server.URL, "streamable", nil, NewInMemoryTokenStore(), nil, true, nil)
 
 	ctx, cancel := context.WithTimeout(t.Context(), 2*time.Second)
 	defer cancel()
@@ -446,7 +446,7 @@ func TestInitialize_OAuthDefersWhenElicitationBridgeNotReady(t *testing.T) {
 	// flow runs. That path reaches requestElicitation without needing
 	// dynamic client registration, which keeps the test focused on the
 	// bridge-not-ready behaviour.
-	client := newRemoteClient(srv.URL, "streamable", nil, NewInMemoryTokenStore(), nil, false, nil)
+	client := newRemoteClient(srv.URL, "streamable", nil, NewInMemoryTokenStore(), nil, true, nil)
 
 	// Plain interactive ctx (no WithoutInteractivePrompts marker). The
 	// elicitation handler is intentionally not wired up.
@@ -496,7 +496,7 @@ func TestCreateHTTPClient_PersistsCookies(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := newRemoteClient(server.URL, "streamable", nil, NewInMemoryTokenStore(), nil, false, nil)
+	client := newRemoteClient(server.URL, "streamable", nil, NewInMemoryTokenStore(), nil, true, nil)
 	httpClient, _, err := client.createHTTPClient()
 	require.NoError(t, err)
 	require.NotNil(t, httpClient.Jar, "createHTTPClient must attach a cookie jar so sticky sessions stick")
@@ -514,6 +514,44 @@ func TestCreateHTTPClient_PersistsCookies(t *testing.T) {
 	_ = resp2.Body.Close()
 
 	require.Equal(t, int32(2), requestCount.Load(), "handler should have served both requests")
+}
+
+func TestRemoteClientRejectsPrivateIPsByDefault(t *testing.T) {
+	t.Parallel()
+
+	var hits atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hits.Add(1)
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	client := newRemoteClient(server.URL, "streamable", map[string]string{"X-Test": "value"}, NewInMemoryTokenStore(), nil, false, nil)
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, server.URL, http.NoBody)
+	require.NoError(t, err)
+	resp, err := (&http.Client{Transport: client.headerTransport()}).Do(req)
+	if resp != nil {
+		defer resp.Body.Close()
+	}
+	require.Error(t, err)
+	assert.Zero(t, hits.Load())
+}
+
+func TestRemoteClientAllowsPrivateIPsWhenConfigured(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	client := newRemoteClient(server.URL, "streamable", nil, NewInMemoryTokenStore(), nil, true, nil)
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, server.URL, http.NoBody)
+	require.NoError(t, err)
+	resp, err := (&http.Client{Transport: client.headerTransport()}).Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
 }
 
 func TestNewRemoteToolsetWithAllowPrivateIPsPropagatesToClient(t *testing.T) {
@@ -587,7 +625,7 @@ func TestRemoteClientCallToolAbortsOnContextDeadline(t *testing.T) {
 	httpServer := httptest.NewServer(gomcp.NewStreamableHTTPHandler(func(*http.Request) *gomcp.Server { return server }, nil))
 	defer httpServer.Close()
 
-	client := newRemoteClient(httpServer.URL, "streamable", nil, NewInMemoryTokenStore(), nil, false, nil)
+	client := newRemoteClient(httpServer.URL, "streamable", nil, NewInMemoryTokenStore(), nil, true, nil)
 	_, err := client.Initialize(t.Context(), nil)
 	require.NoError(t, err)
 	defer func() { _ = client.Close(context.WithoutCancel(t.Context())) }()
@@ -663,7 +701,7 @@ func TestRemoteClientCallToolMRTRElicitation(t *testing.T) {
 	))
 	defer httpServer.Close()
 
-	client := newRemoteClient(httpServer.URL, "streamable", nil, NewInMemoryTokenStore(), nil, false, nil)
+	client := newRemoteClient(httpServer.URL, "streamable", nil, NewInMemoryTokenStore(), nil, true, nil)
 
 	var elicitCalls atomic.Int32
 	elicitMessages := make(chan string, 1)
@@ -797,7 +835,7 @@ func TestRemoteClient_ExpandsEnvHeadersPerRequest(t *testing.T) {
 
 	env := &mutableEnvProvider{vals: map[string]string{"TOKEN": "token-1"}}
 	headers := map[string]string{"X-Env-Token": "${env.TOKEN}"}
-	client := newRemoteClient(srv.URL, "streamable", headers, NewInMemoryTokenStore(), nil, false, env)
+	client := newRemoteClient(srv.URL, "streamable", headers, NewInMemoryTokenStore(), nil, true, env)
 
 	_, err := client.Initialize(t.Context(), nil)
 	require.NoError(t, err)
@@ -843,7 +881,7 @@ func TestRemoteClient_ResolvesUpstreamHeaderPlaceholdersPerRequest(t *testing.T)
 		"Authorization": "${headers.Authorization}",
 		"X-Env-Token":   "${env.TOKEN}",
 	}
-	client := newRemoteClient(srv.URL, "streamable", headers, NewInMemoryTokenStore(), nil, false, env)
+	client := newRemoteClient(srv.URL, "streamable", headers, NewInMemoryTokenStore(), nil, true, env)
 
 	_, err := client.Initialize(t.Context(), nil)
 	require.NoError(t, err)
@@ -891,7 +929,7 @@ func TestRemoteClient_ExpandsMixedEnvAndUpstreamPlaceholdersInOneValue(t *testin
 
 	env := &mutableEnvProvider{vals: map[string]string{"SCHEME": "Env"}}
 	headers := map[string]string{"X-Combined": "${env.SCHEME} ${headers.X-Upstream-Token}"}
-	client := newRemoteClient(srv.URL, "streamable", headers, NewInMemoryTokenStore(), nil, false, env)
+	client := newRemoteClient(srv.URL, "streamable", headers, NewInMemoryTokenStore(), nil, true, env)
 
 	_, err := client.Initialize(t.Context(), nil)
 	require.NoError(t, err)
@@ -1080,7 +1118,7 @@ func TestRemoteToolset_SurvivesSubscriptionsListenRejection(t *testing.T) {
 
 	srv := newGitHubStyleMCPServer(t)
 
-	client := newRemoteClient(srv.URL, "streamable", nil, NewInMemoryTokenStore(), nil, false, nil)
+	client := newRemoteClient(srv.URL, "streamable", nil, NewInMemoryTokenStore(), nil, true, nil)
 	ts := &Toolset{
 		name:      "github",
 		mcpClient: client,
@@ -1144,7 +1182,7 @@ func TestEnrichConnectError_RetryableStatusSurfacesAsStatusError(t *testing.T) {
 			store := NewInMemoryTokenStore()
 			require.NoError(t, store.StoreToken(srv.URL, &OAuthToken{AccessToken: "tok", TokenType: "Bearer"}))
 
-			client := newRemoteClient(srv.URL, "streamable", nil, store, nil, false, nil)
+			client := newRemoteClient(srv.URL, "streamable", nil, store, nil, true, nil)
 
 			_, err := client.Initialize(t.Context(), nil)
 			require.Error(t, err)
@@ -1174,7 +1212,7 @@ func TestEnrichConnectError_NonRetryableStatusDoesNotArm(t *testing.T) {
 	store := NewInMemoryTokenStore()
 	require.NoError(t, store.StoreToken(srv.URL, &OAuthToken{AccessToken: "tok", TokenType: "Bearer"}))
 
-	client := newRemoteClient(srv.URL, "streamable", nil, store, nil, false, nil)
+	client := newRemoteClient(srv.URL, "streamable", nil, store, nil, true, nil)
 
 	_, err := client.Initialize(t.Context(), nil)
 	require.Error(t, err)
@@ -1198,7 +1236,7 @@ func TestEnrichConnectError_NoStatusNoStatusError(t *testing.T) {
 	addr := ln.Addr().String()
 	_ = ln.Close()
 
-	client := newRemoteClient("http://"+addr, "streamable", nil, NewInMemoryTokenStore(), nil, false, nil)
+	client := newRemoteClient("http://"+addr, "streamable", nil, NewInMemoryTokenStore(), nil, true, nil)
 
 	_, err = client.Initialize(t.Context(), nil)
 	require.Error(t, err)
@@ -1240,7 +1278,7 @@ func TestEnrichConnectError_EmptyBodyStatusStillArms(t *testing.T) {
 			store := NewInMemoryTokenStore()
 			require.NoError(t, store.StoreToken(srv.URL, &OAuthToken{AccessToken: "tok", TokenType: "Bearer"}))
 
-			client := newRemoteClient(srv.URL, "streamable", nil, store, nil, false, nil)
+			client := newRemoteClient(srv.URL, "streamable", nil, store, nil, true, nil)
 
 			_, err := client.Initialize(t.Context(), nil)
 			require.Error(t, err)
@@ -1271,7 +1309,7 @@ func TestEnrichConnectError_RetryAfterHonoured(t *testing.T) {
 	store := NewInMemoryTokenStore()
 	require.NoError(t, store.StoreToken(srv.URL, &OAuthToken{AccessToken: "tok", TokenType: "Bearer"}))
 
-	client := newRemoteClient(srv.URL, "streamable", nil, store, nil, false, nil)
+	client := newRemoteClient(srv.URL, "streamable", nil, store, nil, true, nil)
 
 	_, err := client.Initialize(t.Context(), nil)
 	require.Error(t, err)
@@ -1297,7 +1335,7 @@ func TestEnrichConnectError_NoRetryAfterHeaderLeavesZero(t *testing.T) {
 	store := NewInMemoryTokenStore()
 	require.NoError(t, store.StoreToken(srv.URL, &OAuthToken{AccessToken: "tok", TokenType: "Bearer"}))
 
-	client := newRemoteClient(srv.URL, "streamable", nil, store, nil, false, nil)
+	client := newRemoteClient(srv.URL, "streamable", nil, store, nil, true, nil)
 
 	_, err := client.Initialize(t.Context(), nil)
 	require.Error(t, err)
@@ -1325,7 +1363,7 @@ func TestBackoffGate_RemoteMCPRetryableStatusPacesReconnect(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	toolset := NewRemoteToolset("test", srv.URL, "streamable", nil, nil)
+	toolset := NewRemoteToolsetWithAllowPrivateIPs("test", srv.URL, "streamable", nil, nil, true)
 
 	now := time.Now()
 	clock := func() time.Time { return now }
@@ -1378,7 +1416,7 @@ func TestBackoffGate_RemoteMCPNonRetryableStatusFailsPromptly(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	toolset := NewRemoteToolset("test", srv.URL, "streamable", nil, nil)
+	toolset := NewRemoteToolsetWithAllowPrivateIPs("test", srv.URL, "streamable", nil, nil, true)
 	s := tools.NewStartable(toolset)
 
 	var prev int32
@@ -1418,7 +1456,7 @@ func TestBackoffGate_RemoteMCPRecoversAfterBackoffWindow(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	toolset := NewRemoteToolset("test", srv.URL, "streamable", nil, nil)
+	toolset := NewRemoteToolsetWithAllowPrivateIPs("test", srv.URL, "streamable", nil, nil, true)
 
 	now := time.Now()
 	clock := func() time.Time { return now }


### PR DESCRIPTION
## Summary

- harden session and ACP concurrency, including event delivery, permissions, model switches, message ownership, and app turn isolation
- close security boundaries around remote MCP access, OCI caches, task file reads, Unix socket reclamation, and remote configuration sizes
- improve background agent/job lifecycle handling and scheduled recall retries
- make task store updates atomic and preserve unreadable stores instead of overwriting them

## Notable fixes

- prevent delayed or blocked session events from panicking or retaining stream locks
- serialize competing session operations without allowing stale updates or deleted-session resurrection
- apply SSRF policy to MCP transports and scope OCI cache entries by registry
- terminate background jobs reliably and enforce background-agent admission limits atomically
- safely reclaim stale Unix sockets while preserving live sockets and non-socket paths
- cap remote agent configurations at 32 MiB across HTTP, cache, and OCI sources

The Unix socket helper tests are isolated in a `!windows` test file so the server test package remains cross-compilable.

## Validation

- `task build`
- `task test`
- `task lint`
- `go test -race ./pkg/server`
- `GOOS=windows GOARCH=amd64 go test -c ./pkg/server`
