### PR TITLE
fix(http): bound the SSRF pre-check DNS lookup in desktopAwareTransport

### DIFF
--- a/pkg/httpclient/desktop_transport.go
+++ b/pkg/httpclient/desktop_transport.go
@@ -2,6 +2,7 @@ package httpclient
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net"
@@ -10,6 +11,7 @@ import (
 	"os"
 	"strings"
 	"sync"
+	"time"
 
 	"golang.org/x/net/http/httpproxy"
 
@@ -18,6 +20,12 @@ import (
 
 const disableDesktopProxyEnv = "DOCKER_AGENT_DISABLE_DESKTOP_PROXY"
 
+// defaultProxySafeLookupTimeout caps the SSRF pre-check DNS lookup on the
+// Desktop-routing path. A stalled client-side resolver on a network where
+// the target is only reachable through the operator-configured Desktop
+// egress would otherwise block the request indefinitely; see proxySafe.
+const defaultProxySafeLookupTimeout = 2 * time.Second
+
 var invalidDesktopProxySetting struct {
 	sync.Mutex
 
@@ -25,10 +33,11 @@ var invalidDesktopProxySetting struct {
 }
 
 type desktopAwareTransport struct {
-	direct              *http.Transport
-	guarded             bool
-	resolver            func(context.Context, string) ([]net.IP, error)
-	newDesktopTransport func(context.Context, http.RoundTripper) http.RoundTripper
+	direct                 *http.Transport
+	guarded                bool
+	resolver               func(context.Context, string) ([]net.IP, error)
+	newDesktopTransport    func(context.Context, http.RoundTripper) http.RoundTripper
+	proxySafeLookupTimeout time.Duration
 
 	mu                 sync.Mutex
 	desktopTransport   http.RoundTripper
@@ -52,6 +61,7 @@ func newDesktopAwareTransport(guarded bool) http.RoundTripper {
 		newDesktopTransport: func(_ context.Context, direct http.RoundTripper) http.RoundTripper {
 			return desktoptransport.NewDesktopTransport(direct)
 		},
+		proxySafeLookupTimeout: defaultProxySafeLookupTimeout,
 	}
 }
 
@@ -128,10 +138,25 @@ func (t *desktopAwareTransport) proxySafe(ctx context.Context, host string) bool
 	if ip := net.ParseIP(host); ip != nil {
 		return IsPublicIP(ip)
 	}
-	ips, err := t.resolver(ctx, host)
+	// Cap the lookup: on networks where Docker-owned hostnames are
+	// reachable only through the operator-configured Desktop egress,
+	// the client-side resolver may hang or take tens of seconds to
+	// answer. Without a bound here, a request that would have
+	// succeeded through Desktop is trapped in the SSRF pre-check.
+	lookupCtx, cancel := context.WithTimeout(ctx, t.proxySafeLookupTimeout)
+	defer cancel()
+	ips, err := t.resolver(lookupCtx, host)
 	if err != nil {
-		// Fail closed: Docker-owned hostnames resolve publicly; NXDOMAIN
-		// suggests a broken resolver rather than a PAC-only network.
+		// Fall open only when *our* lookup budget expired and the
+		// parent context is still live: the operator has already
+		// opted this host in for Desktop routing (isDockerHost gate
+		// in RoundTrip), and Desktop applies its own egress policy
+		// and resolution against the upstream. NXDOMAIN and other
+		// resolver errors still fail closed — a broken resolver
+		// isn't a routing hint.
+		if errors.Is(err, context.DeadlineExceeded) && ctx.Err() == nil {
+			return true
+		}
 		return false
 	}
 	if len(ips) == 0 {

--- a/pkg/httpclient/desktop_transport_test.go
+++ b/pkg/httpclient/desktop_transport_test.go
@@ -11,6 +11,7 @@ import (
 	"net/url"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -92,18 +93,47 @@ func TestDesktopAwareTransportProxySafe(t *testing.T) {
 			},
 			want: false,
 		},
+		{
+			name: "resolver stalled beyond lookup budget falls open",
+			host: "stalled-resolver.example",
+			resolver: func(ctx context.Context, _ string) ([]net.IP, error) {
+				<-ctx.Done()
+				return nil, ctx.Err()
+			},
+			want: true,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			transport := newDesktopAwareTransport(true).(*desktopAwareTransport)
+			transport.proxySafeLookupTimeout = 20 * time.Millisecond
 			if tt.resolver != nil {
 				transport.resolver = tt.resolver
 			}
 			assert.Equal(t, tt.want, transport.proxySafe(t.Context(), tt.host))
 		})
 	}
+}
+
+// TestDesktopAwareTransportProxySafeParentCancellationStaysClosed asserts
+// that if the caller's context expires while our lookup is in flight, we
+// treat that as the request being torn down — not as a signal to fall open.
+func TestDesktopAwareTransportProxySafeParentCancellationStaysClosed(t *testing.T) {
+	t.Parallel()
+
+	transport := newDesktopAwareTransport(true).(*desktopAwareTransport)
+	transport.proxySafeLookupTimeout = time.Second
+	transport.resolver = func(ctx context.Context, _ string) ([]net.IP, error) {
+		<-ctx.Done()
+		return nil, ctx.Err()
+	}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	assert.False(t, transport.proxySafe(ctx, "cancelled.example"))
 }
 
 func TestDesktopAwareTransportLoopbackIsNeverProxied(t *testing.T) {


### PR DESCRIPTION
## The one-liner

Before sending a request to a docker.com address through the Docker Desktop transport, `desktopAwareTransport` does a quick DNS safety check. On some corporate networks that check hangs forever, freezing the whole request. This PR puts a short cap on the check — if it's still stuck after 2 seconds, the request goes through the Desktop transport anyway.

## Why the safety check exists

The transport has two ways of sending a request out:

- **Direct**: straight to the internet, with strict SSRF guards (it refuses to connect to private IPs, so a malicious DNS answer can't trick it into hitting the internal network).
- **Via Docker Desktop**: hands the request to Desktop, which knows about corporate proxies (PAC files) and routes it properly.

Only docker.com / docker.io addresses are allowed to take the Desktop route. Before taking it, the transport double-checks: *"does this hostname resolve to normal public internet addresses?"* (`proxySafe`). If DNS says the name points somewhere private — suspicious — it falls back to the guarded direct path. Fail closed, safe by default.

## The problem

That double-check asks *the local machine's* DNS. On locked-down corporate networks, machines often can't resolve internet names at all — only the corporate proxy can. So the check doesn't get a "no", it gets **silence**:

```
request to a docker.com host
        │
        ▼
 "is this host safe?" ── asks local DNS ──▶ ⏳ ...no answer, ever...
        │
        ▼
 entire request frozen — even though the Desktop route
 it was about to take works perfectly on this network
```

The irony: the check was guarding a route that exists *precisely for* networks where local DNS doesn't work.

## The fix

Give the DNS check a 2-second budget, then decide based on *how* it failed:

| DNS check outcome | Decision |
|---|---|
| answers with public IPs | Desktop route (unchanged) |
| answers with private IPs | direct, guarded (unchanged) |
| answers "no such host" | direct, guarded (unchanged) |
| still silent after 2 seconds | Desktop route (**new: fall open**) |
| caller already gave up | direct, guarded (unchanged) |

Falling open on silence is safe because the host was already vetted as a docker.com name, and Desktop does its own name resolution and policy on its side — the local DNS answer was never load-bearing for the Desktop route, only a courtesy check.

## Why it matters

Without the cap, the hang can be fatal: when embedded in a host application, a startup request frozen in the check can outlive the host's health-check budget and get the process killed. With the cap, the worst case on such a network is a 2-second pause before the request proceeds down the working route.
