### PR TITLE
feat: add copy command to lean TUI

### DIFF
--- a/pkg/leantui/commands.go
+++ b/pkg/leantui/commands.go
@@ -10,6 +10,7 @@ func builtinCommands() []ui.Command {
 		{Name: "compact", Desc: "Summarize and compact the conversation", Kind: ui.CmdBuiltin},
 		{Name: "model", Desc: "Change the model for the current agent", Kind: ui.CmdBuiltin},
 		{Name: "effort", Desc: "Set the model's reasoning effort (usage: /effort <level>)", Kind: ui.CmdBuiltin},
+		{Name: "copy", Desc: "Copy the last assistant response", Kind: ui.CmdBuiltin},
 		{Name: "clear", Desc: "Clear the screen", Kind: ui.CmdBuiltin},
 		{Name: "help", Desc: "Show keyboard shortcuts and commands", Kind: ui.CmdBuiltin},
 		{Name: "exit", Desc: "Exit", Kind: ui.CmdBuiltin},

--- a/pkg/leantui/ui/terminal.go
+++ b/pkg/leantui/ui/terminal.go
@@ -145,6 +145,11 @@ func (t *Terminal) Writer() *bufio.Writer {
 	return t.writer
 }
 
+func (t *Terminal) SetClipboard(text string) {
+	t.writeString(ansi.SetSystemClipboard(text))
+	t.flush()
+}
+
 func (t *Terminal) writeString(s string) {
 	_, _ = t.writer.WriteString(s)
 }

--- a/pkg/leantui/update.go
+++ b/pkg/leantui/update.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"charm.land/lipgloss/v2"
+	"github.com/atotto/clipboard"
 
 	"github.com/docker/docker-agent/pkg/chat"
 	"github.com/docker/docker-agent/pkg/effort"
@@ -276,6 +277,9 @@ func (m *model) handleSlash(ctx context.Context, text string, mode busySubmitMod
 	case "clear":
 		m.clearScreen()
 		return true
+	case "copy":
+		m.copyLastResponse()
+		return true
 	case "help":
 		m.commitHelp()
 		return true
@@ -312,6 +316,25 @@ func (m *model) handleSlash(ctx context.Context, text string, mode busySubmitMod
 
 	return false
 }
+
+func (m *model) copyLastResponse() {
+	if m.app == nil || m.app.Session() == nil {
+		m.addNotice("", "No active session.", ui.StMuted())
+		return
+	}
+	lastResponse := m.app.Session().GetLastAssistantMessageContent()
+	if lastResponse == "" {
+		m.addNotice("", "No assistant response to copy.", ui.StMuted())
+		return
+	}
+	if m.term != nil {
+		m.term.SetClipboard(lastResponse)
+	}
+	_ = writeClipboard(lastResponse)
+	m.addNotice("", "Last response copied to clipboard.", ui.StMuted())
+}
+
+var writeClipboard = clipboard.WriteAll
 
 func (m *model) handleSessionsCommand(ctx context.Context, sessionID string) {
 	if m.busy {
@@ -739,6 +762,7 @@ func (m *model) commitHelp() {
 			ui.StMuted().Render("  /compact   summarize and compact the conversation"),
 			ui.StMuted().Render("  /model     change the model for the current agent"),
 			ui.StMuted().Render("  /effort    set the model's reasoning effort (e.g. /effort high)"),
+			ui.StMuted().Render("  /copy      copy the last assistant response"),
 			ui.StMuted().Render("  /clear     clear the screen"),
 			ui.StMuted().Render("  /help      show this help"),
 			ui.StMuted().Render("  /exit      quit"),

--- a/pkg/leantui/update_test.go
+++ b/pkg/leantui/update_test.go
@@ -533,3 +533,45 @@ func TestSteeredUserEventConfirmsPendingAfterAssistant(t *testing.T) {
 	assert.NotEqual(t, -1, steerAt)
 	assert.Less(t, assistantAt, steerAt)
 }
+
+func TestCopyCommandCopiesLastAssistantResponse(t *testing.T) {
+	sess := session.New()
+	sess.AddMessage(session.UserMessage("question"))
+	sess.AddMessage(session.NewAgentMessage("coder", &chat.Message{
+		Role:    chat.MessageRoleAssistant,
+		Content: "the last response",
+	}))
+	m := bareModel(80)
+	m.app = app.New(t.Context(), &cycleThinkingRuntime{}, sess)
+
+	originalWriteClipboard := writeClipboard
+	t.Cleanup(func() { writeClipboard = originalWriteClipboard })
+	var copied string
+	writeClipboard = func(text string) error {
+		copied = text
+		return nil
+	}
+
+	assert.True(t, m.handleSlash(t.Context(), "/copy", busySubmitSteer))
+	assert.Equal(t, "the last response", copied)
+	transcript := strings.Join(m.screen.Transcript.Lines(80, 0, false, m.sessionState, nil), "\n")
+	assert.Contains(t, transcript, "Last response copied to clipboard.")
+}
+
+func TestCopyCommandReportsMissingAssistantResponse(t *testing.T) {
+	m := bareModel(80)
+	m.app = app.New(t.Context(), &cycleThinkingRuntime{}, session.New())
+
+	originalWriteClipboard := writeClipboard
+	t.Cleanup(func() { writeClipboard = originalWriteClipboard })
+	called := false
+	writeClipboard = func(string) error {
+		called = true
+		return nil
+	}
+
+	assert.True(t, m.handleSlash(t.Context(), "/copy", busySubmitSteer))
+	assert.False(t, called)
+	transcript := strings.Join(m.screen.Transcript.Lines(80, 0, false, m.sessionState, nil), "\n")
+	assert.Contains(t, transcript, "No assistant response to copy.")
+}


### PR DESCRIPTION
## Summary

- add a `/copy` built-in command to the lean TUI
- copy the last assistant response through OSC 52 and the native clipboard API
- show feedback when the copy succeeds or no assistant response exists
- expose the command in autocomplete and help

## Testing

- `task build`
- `task test`
- `task lint`