### PR TITLE
refactor(api): extract JavaScript-free HTTP client leaf and per-runtime factory options

### DIFF
--- a/docs/guides/go-sdk/index.md
+++ b/docs/guides/go-sdk/index.md
@@ -154,7 +154,7 @@ The RAG toolset (`type: rag`) is included in `NewDefaultToolsetRegistry()` (from
 
 The underlying tree-sitter code parser uses cgo, but build-tag guards in `pkg/rag/treesitter` mean importing the package is safe regardless of `CGO_ENABLED`: with `CGO_ENABLED=0` the parser stub compiles in and returns a runtime error on first use rather than failing at compile time.
 
-If you want to exclude the RAG toolset from your binary entirely — surfacing a load-time warning on the agent rather than a deferred runtime error from the `!cgo` stub — remove it from the registry before passing it to `teamloader.Load`:
+To disable the RAG toolset at runtime — surfacing a load-time warning rather than a deferred error from the `!cgo` stub — remove it from the registry before passing it to `teamloader.Load`. This does not remove its package dependencies; use a hand-picked registry without importing the full defaults for that:
 
 ```go
 import (
@@ -182,7 +182,7 @@ import (
     "github.com/docker/docker-agent/pkg/model/provider"
     "github.com/docker/docker-agent/pkg/model/provider/anthropic"
     "github.com/docker/docker-agent/pkg/teamloader"
-    "github.com/docker/docker-agent/pkg/tools/builtin/api"
+    "github.com/docker/docker-agent/pkg/tools/builtin/api/client"
     "github.com/docker/docker-agent/pkg/tools/builtin/think"
 )
 
@@ -191,7 +191,7 @@ team, err := teamloader.Load(ctx, ocisource.New("myorg/agent:v1"), runConfig,
         "anthropic": provider.Adapt(anthropic.NewClient),
     })),
     teamloader.WithToolsetRegistry(teamloader.NewToolsetRegistry(map[string]teamloader.ToolsetCreator{
-        "api":   api.Creator,
+        "api":   client.Creator(teamloader.NewEnvExpander),
         "think": teamloader.Creator(think.CreateToolSet),
     })),
     // Deny every optional feature; pass e.g. config.FeatureSkills to allow one.
@@ -213,6 +213,65 @@ team, err := teamloader.Load(ctx, ocisource.New("myorg/agent:v1"), runConfig,
 > `config.Resolve`, `config.ResolveSources`, `config.ResolveAlias` and `config.BuiltinAgentNames` are now in `pkg/config/sources`; `config.NewOCISource` is `ocisource.New` in `pkg/config/ocisource`; and `config.Load` no longer auto-detects HCL — wrap the source with `hcl.NewSource` (which `sources.Resolve` does for you). `teamloader.ToolsetRegistry` gained a `Has(toolsetType string) bool` method.
 >
 > If you call `teamloader.Load` without `loaderdefaults.Opts()`, JavaScript expansion, code mode, TOON, deferred tools and harness agents are now off until you enable them (see *Optional loader features* above). Code-built teams that use `harness:` agents must call `runtime.RegisterHarness(codingharness.Factory)`; `codingharness.Label` moved into the runtime.
+
+### Per-runtime feature configuration
+
+Prefer instance options over `runtime.RegisterHarness` and
+`runtime.RegisterCommandEvaluator`, which affect the entire process:
+
+```go
+rt, err := runtime.New(ctx, team,
+    runtime.WithProviderRegistry(providers),
+    runtime.WithHarnessFactory(codingharness.Factory),
+    runtime.WithCommandEvaluatorFactory(jscommands.Factory),
+)
+```
+
+Import `pkg/codingharness` or `pkg/runtime/jscommands` only when needed.
+Passing `nil` to either factory option explicitly disables that feature for
+this runtime, even if another caller registered a global default. Omitting the
+options retains the legacy global fallback, including registrations made after
+runtime construction. Factories are still invoked lazily, at execution time.
+Runtime decorators used with `ResolveCommand` should forward
+`CommandEvaluatorFactory() runtime.CommandEvaluatorFactory` to preserve this
+selection. The `runtime.Runtime` interface itself is unchanged.
+
+These options also work through `embeddedchat.Config.RuntimeOptions`. Loader
+policy remains separate: `teamloader.WithStrict(config.FeatureHarness)` permits
+harness declarations but does not install a driver. Likewise, supplying an
+implementation does not automatically authorize a feature in strict mode.
+
+### HTTP tools without JavaScript
+
+The `pkg/tools/builtin/api/client` package accepts an expander instead of
+importing JavaScript. Register a placeholder-only HTTP tool with:
+
+```go
+"api": client.Creator(teamloader.NewEnvExpander),
+```
+
+This supports `${env.NAME}` and bound `${argument}` placeholders and resolves
+credentials on each request. Unknown placeholders and JavaScript expressions
+remain unchanged. `api.Creator` and `api.New` retain the full JavaScript and
+upstream-header behavior for existing callers. The leaf package does **not**
+automatically expand `${headers.NAME}`; use `client.WithHeaderResolver` to supply
+that policy. Passing `upstream.ResolveHeaders` restores the legacy behavior but
+also imports JavaScript.
+
+A complete placeholder-only example lives in
+[examples/golibrary/leanapi](https://github.com/docker/docker-agent/tree/main/examples/golibrary/leanapi).
+The older `yamlstrict` example intentionally retains JavaScript-capable API and
+fetch tools.
+
+Selecting the leaf removes four external modules from the HTTP tool's import
+closure: Goja, regexp2, go-sourcemap, and pprof. Importing the full defaults and
+then deleting registry entries does **not** remove those package dependencies.
+
+Go package dependencies and module requirements are different: these changes
+reduce the packages compiled and their required source modules. Docker Agent
+still has one `go.mod`, so this does not promise an equally small
+`go list -m all` graph or a small `go mod download all`. Independently versioned
+optional modules would be a separate packaging change.
 
 ## Registering Custom Built-in Themes
 

--- a/e2e/dependencies_test.go
+++ b/e2e/dependencies_test.go
@@ -95,6 +95,8 @@ func TestDependencies(t *testing.T) {
 			"./pkg/config",
 			"./pkg/teamloader",
 			"./pkg/embeddedchat",
+			"./pkg/tools/builtin/api/client",
+			"./examples/golibrary/leanapi",
 			"./pkg/tools/builtin/think",
 			"./pkg/model/provider/anthropic",
 		)

--- a/examples/golibrary/leanapi/agent.yaml
+++ b/examples/golibrary/leanapi/agent.yaml
@@ -1,0 +1,15 @@
+agents:
+  root:
+    description: Queries GitHub repository metadata without JavaScript.
+    model: anthropic/claude-sonnet-4-6
+    instruction: Answer questions about GitHub repositories using the API tool.
+    toolsets:
+      - type: api
+        api_config:
+          name: repository
+          method: GET
+          endpoint: https://api.github.com/repos/${owner}/${repo}
+          args:
+            owner: {type: string}
+            repo: {type: string}
+          required: [owner, repo]

--- a/examples/golibrary/leanapi/main.go
+++ b/examples/golibrary/leanapi/main.go
@@ -1,0 +1,71 @@
+// Example: wire a YAML-loaded agent without JavaScript or global runtime features.
+package main
+
+import (
+	"context"
+	_ "embed"
+	"fmt"
+	"os"
+	"os/signal"
+
+	"github.com/docker/docker-agent/pkg/config"
+	"github.com/docker/docker-agent/pkg/embeddedchat"
+	"github.com/docker/docker-agent/pkg/model/provider"
+	"github.com/docker/docker-agent/pkg/model/provider/anthropic"
+	"github.com/docker/docker-agent/pkg/runtime"
+	"github.com/docker/docker-agent/pkg/teamloader"
+	"github.com/docker/docker-agent/pkg/tools/builtin/api/client"
+)
+
+//go:embed agent.yaml
+var agentYAML []byte
+
+func main() {
+	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt)
+	defer cancel()
+	if err := run(ctx); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+	}
+}
+
+func run(ctx context.Context) error {
+	providers := provider.NewRegistry(map[string]provider.Factory{
+		"anthropic": provider.Adapt(anthropic.NewClient),
+	})
+	chat, err := embeddedchat.New(ctx, embeddedchat.Config{
+		AgentSource: config.NewBytesSource("lean.yaml", agentYAML),
+		LoadOpts: []teamloader.Opt{
+			teamloader.WithProviderRegistry(providers),
+			teamloader.WithToolsetRegistry(teamloader.NewToolsetRegistry(map[string]teamloader.ToolsetCreator{
+				"api": client.Creator(teamloader.NewEnvExpander),
+			})),
+			teamloader.WithStrict(),
+		},
+		RuntimeOptions: []runtime.Opt{
+			runtime.WithProviderRegistry(providers),
+			runtime.WithHarnessFactory(nil),
+			runtime.WithCommandEvaluatorFactory(nil),
+		},
+	})
+	if err != nil {
+		return err
+	}
+	defer chat.Close()
+	events, err := chat.Send(ctx, "What is docker/docker-agent?")
+	if err != nil {
+		return err
+	}
+	for event := range events {
+		if event.Err != nil {
+			return event.Err
+		}
+		if event.Tool != nil && event.Tool.NeedsConfirmation {
+			// This example never grants unreviewed tool calls.
+			if err := chat.Confirm(ctx, runtime.ResumeReject("Approval is not configured in this example.")); err != nil {
+				return err
+			}
+		}
+		fmt.Print(event.Text)
+	}
+	return nil
+}

--- a/pkg/runtime/command_factory_external_test.go
+++ b/pkg/runtime/command_factory_external_test.go
@@ -1,0 +1,47 @@
+package runtime_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/docker/docker-agent/pkg/agent"
+	"github.com/docker/docker-agent/pkg/config/latest"
+	"github.com/docker/docker-agent/pkg/config/types"
+	"github.com/docker/docker-agent/pkg/runtime"
+	"github.com/docker/docker-agent/pkg/runtime/jscommands"
+	"github.com/docker/docker-agent/pkg/team"
+)
+
+type runtimeDecorator struct {
+	runtime.Runtime
+
+	factory func() runtime.CommandEvaluatorFactory
+}
+
+func (r runtimeDecorator) CommandEvaluatorFactory() runtime.CommandEvaluatorFactory {
+	return r.factory()
+}
+
+func TestCommandEvaluatorThroughDecorator(t *testing.T) {
+	t.Parallel()
+	for _, enabled := range []bool{true, false} {
+		t.Run(map[bool]string{true: "enabled", false: "disabled"}[enabled], func(t *testing.T) {
+			t.Parallel()
+			root := agent.New("root", "", agent.WithHarness(&latest.HarnessConfig{Type: "codex"}),
+				agent.WithCommands(types.Commands{"test": {Instruction: "${args[0]}"}}))
+			var factory runtime.CommandEvaluatorFactory
+			expected := "${args[0]}"
+			if enabled {
+				factory = jscommands.Factory
+				expected = "hello"
+			}
+			r, err := runtime.NewLocalRuntime(t.Context(), team.New(team.WithAgents(root)), runtime.WithCommandEvaluatorFactory(factory))
+			require.NoError(t, err)
+			t.Cleanup(func() { require.NoError(t, r.Close()) })
+			wrapped := runtimeDecorator{Runtime: r, factory: r.CommandEvaluatorFactory}
+			assert.Equal(t, expected, runtime.ResolveCommand(t.Context(), wrapped, "/test hello"))
+		})
+	}
+}

--- a/pkg/runtime/command_factory_test.go
+++ b/pkg/runtime/command_factory_test.go
@@ -1,0 +1,82 @@
+package runtime
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/docker/docker-agent/pkg/agent"
+	"github.com/docker/docker-agent/pkg/config/types"
+	"github.com/docker/docker-agent/pkg/team"
+	"github.com/docker/docker-agent/pkg/tools"
+)
+
+type commandEvaluatorFunc func(context.Context, string, []string) string
+
+func (f commandEvaluatorFunc) Evaluate(ctx context.Context, instruction string, args []string) string {
+	return f(ctx, instruction, args)
+}
+
+func commandRuntime(t *testing.T, opts ...Opt) *LocalRuntime {
+	t.Helper()
+	root := agent.New("root", "", agent.WithModel(&mockProvider{id: "test/mock-model"}), agent.WithCommands(types.Commands{
+		"test": {Instruction: "${args[0]}"},
+	}))
+	opts = append([]Opt{WithModelStore(mockModelStore{})}, opts...)
+	r, err := NewLocalRuntime(t.Context(), team.New(team.WithAgents(root)), opts...)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, r.Close()) })
+	return r
+}
+
+func TestWithCommandEvaluatorFactory(t *testing.T) {
+	t.Parallel()
+	for _, name := range []string{"first", "second"} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			calls := 0
+			r := commandRuntime(t, WithCommandEvaluatorFactory(func([]tools.Tool) CommandEvaluator {
+				calls++
+				return commandEvaluatorFunc(func(_ context.Context, instruction string, args []string) string {
+					assert.Equal(t, "${args[0]}", instruction)
+					assert.Equal(t, []string{"hello"}, args)
+					return name
+				})
+			}))
+			require.Zero(t, calls, "factory must remain lazy")
+			assert.Equal(t, name, ResolveCommand(t.Context(), r, "/test hello"))
+			assert.Equal(t, 1, calls)
+		})
+	}
+}
+
+func TestCommandEvaluatorOverridesGlobal(t *testing.T) {
+	original := commandEvaluatorFactory.Load()
+	t.Cleanup(func() { commandEvaluatorFactory.Store(original) })
+
+	r := commandRuntime(t)
+	calls := 0
+	RegisterCommandEvaluator(func([]tools.Tool) CommandEvaluator {
+		calls++
+		return commandEvaluatorFunc(func(context.Context, string, []string) string { return "global" })
+	})
+	assert.Equal(t, "global", ResolveCommand(t.Context(), r, "/test"))
+	assert.Equal(t, 1, calls, "registration after construction remains supported")
+
+	disabled := commandRuntime(t, WithCommandEvaluatorFactory(nil))
+	assert.Equal(t, "${args[0]}", ResolveCommand(t.Context(), disabled, "/test"))
+	assert.Equal(t, 1, calls)
+
+	local := commandRuntime(t, WithCommandEvaluatorFactory(func([]tools.Tool) CommandEvaluator {
+		return commandEvaluatorFunc(func(context.Context, string, []string) string { return "local" })
+	}))
+	assert.Equal(t, "local", ResolveCommand(t.Context(), local, "/test"))
+	assert.Equal(t, 1, calls)
+
+	// Third-party Runtime implementations keep the global fallback.
+	mock := &mockRuntime{commands: types.Commands{"test": {Instruction: "${args[0]}"}}}
+	assert.Equal(t, "global", ResolveCommand(t.Context(), mock, "/test"))
+	assert.Equal(t, 2, calls)
+}

--- a/pkg/runtime/commands.go
+++ b/pkg/runtime/commands.go
@@ -27,12 +27,42 @@ type CommandEvaluator interface {
 // embeddedchat/defaults) wires in the goja-backed evaluator from pkg/js.
 // The indirection keeps the JS engine out of pkg/runtime's import graph for
 // embedders that build teams in code and never use JS command expressions.
-var commandEvaluatorFactory atomic.Pointer[func(agentTools []tools.Tool) CommandEvaluator]
+var commandEvaluatorFactory atomic.Pointer[CommandEvaluatorFactory]
 
 // RegisterCommandEvaluator installs the factory ResolveCommand uses to
 // expand ${...} expressions. See pkg/runtime/jscommands.
-func RegisterCommandEvaluator(factory func(agentTools []tools.Tool) CommandEvaluator) {
+// Prefer [WithCommandEvaluatorFactory] to configure independent runtimes.
+func RegisterCommandEvaluator(factory CommandEvaluatorFactory) {
 	commandEvaluatorFactory.Store(&factory)
+}
+
+// CommandEvaluatorFactory builds an evaluator with the current agent's tools.
+type CommandEvaluatorFactory = func(agentTools []tools.Tool) CommandEvaluator
+
+// WithCommandEvaluatorFactory selects the slash-command evaluator for this runtime.
+// Passing nil leaves JavaScript expressions unexpanded, even when a global
+// evaluator is registered. Without this option, the global evaluator is used.
+func WithCommandEvaluatorFactory(factory CommandEvaluatorFactory) Opt {
+	return func(r *LocalRuntime) {
+		r.commandEvaluator = &factory
+	}
+}
+
+// CommandEvaluatorFactory returns the effective slash-command evaluator factory.
+// Runtime decorators passed to ResolveCommand should forward this method to
+// preserve instance configuration, including an explicitly disabled evaluator.
+func (r *LocalRuntime) CommandEvaluatorFactory() CommandEvaluatorFactory {
+	if r.commandEvaluator != nil {
+		return *r.commandEvaluator
+	}
+	return globalCommandFactory()
+}
+
+func globalCommandFactory() CommandEvaluatorFactory {
+	if factory := commandEvaluatorFactory.Load(); factory != nil {
+		return *factory
+	}
+	return nil
 }
 
 // argsPlaceholderRegex matches ${args...} patterns to check if args are used.
@@ -93,14 +123,20 @@ func ResolveCommand(ctx context.Context, rt Runtime, userInput string) string {
 	// Execute JavaScript expressions (${...} syntax) with args array
 	// We execute JS first to prevent tool output (from !tool commands) from being evaluated as JS,
 	// which would be a security vulnerability (injection).
-	if factory := commandEvaluatorFactory.Load(); factory == nil {
+	factory := globalCommandFactory()
+	if local, ok := rt.(interface {
+		CommandEvaluatorFactory() CommandEvaluatorFactory
+	}); ok {
+		factory = local.CommandEvaluatorFactory()
+	}
+	if factory == nil {
 		if strings.Contains(instruction, "${") {
 			slog.WarnContext(ctx, "No JavaScript evaluator registered; ${...} expressions left unexpanded (call jscommands.Register to enable them)")
 		}
 	} else if agentTools, err := rt.CurrentAgentTools(ctx); err != nil {
 		slog.WarnContext(ctx, "Failed to get agent tools for JS expression execution", "error", err)
 	} else {
-		instruction = (*factory)(agentTools).Evaluate(ctx, instruction, args)
+		instruction = factory(agentTools).Evaluate(ctx, instruction, args)
 	}
 
 	// Execute tool commands and substitute their output (legacy !tool() syntax)

--- a/pkg/runtime/harness.go
+++ b/pkg/runtime/harness.go
@@ -24,7 +24,7 @@ func (r *LocalRuntime) runHarnessAgent(ctx context.Context, sess *session.Sessio
 	ctx, span := r.startSpan(ctx, "runtime.harness", trace.WithAttributes(traceAttributesForHarness(sess, a)...))
 	defer span.End()
 
-	provider, err := newHarnessProvider(a.Harness())
+	provider, err := r.newHarnessProvider(a.Harness())
 	if err != nil {
 		msg := fmt.Sprintf("failed to configure harness: %v", err)
 		events.Emit(ErrorWithCodeForSession(sess.ID, ErrorCodeModelError, msg))

--- a/pkg/runtime/harness_provider.go
+++ b/pkg/runtime/harness_provider.go
@@ -18,6 +18,8 @@ var harnessFactory atomic.Pointer[harness.Factory]
 // RegisterHarness installs the factory used to run `harness:` agents:
 //
 //	runtime.RegisterHarness(codingharness.Factory)
+//
+// Prefer [WithHarnessFactory] to configure independent runtimes.
 func RegisterHarness(factory harness.Factory) {
 	harnessFactory.Store(&factory)
 }
@@ -26,9 +28,21 @@ func RegisterHarness(factory harness.Factory) {
 // driver was registered with RegisterHarness.
 var ErrHarnessNotRegistered = errors.New("harness agents need a driver: call runtime.RegisterHarness(codingharness.Factory)")
 
-func newHarnessProvider(cfg *latest.HarnessConfig) (harness.Provider, error) {
-	factory := harnessFactory.Load()
+// WithHarnessFactory selects the harness driver for this runtime only.
+// Passing nil disables harnesses, even when a global driver is registered.
+// Without this option, the runtime uses [RegisterHarness]'s global driver.
+func WithHarnessFactory(factory harness.Factory) Opt {
+	return func(r *LocalRuntime) {
+		r.harnessFactory = &factory
+	}
+}
+
+func (r *LocalRuntime) newHarnessProvider(cfg *latest.HarnessConfig) (harness.Provider, error) {
+	factory := r.harnessFactory
 	if factory == nil {
+		factory = harnessFactory.Load()
+	}
+	if factory == nil || *factory == nil {
 		return nil, ErrHarnessNotRegistered
 	}
 	return (*factory)(cfg)

--- a/pkg/runtime/harness_provider_test.go
+++ b/pkg/runtime/harness_provider_test.go
@@ -16,7 +16,7 @@ func TestNewHarnessProvider_RequiresRegistration(t *testing.T) {
 	harnessFactory.Store(nil)
 	t.Cleanup(func() { harnessFactory.Store(original) })
 
-	_, err := newHarnessProvider(&latest.HarnessConfig{Type: "codex"})
+	_, err := (&LocalRuntime{}).newHarnessProvider(&latest.HarnessConfig{Type: "codex"})
 	require.ErrorIs(t, err, ErrHarnessNotRegistered)
 
 	var called *latest.HarnessConfig
@@ -24,7 +24,7 @@ func TestNewHarnessProvider_RequiresRegistration(t *testing.T) {
 		called = cfg
 		return nil, nil
 	})
-	_, err = newHarnessProvider(&latest.HarnessConfig{Type: "codex"})
+	_, err = (&LocalRuntime{}).newHarnessProvider(&latest.HarnessConfig{Type: "codex"})
 	require.NoError(t, err)
 	assert.Equal(t, "codex", called.Type)
 }
@@ -34,4 +34,54 @@ func TestHarnessLabel(t *testing.T) {
 	assert.Empty(t, harnessLabel(nil))
 	assert.Equal(t, "codex", harnessLabel(&latest.HarnessConfig{Type: "codex"}))
 	assert.Equal(t, "claude-code/opus", harnessLabel(&latest.HarnessConfig{Type: "claude-code", Model: " opus "}))
+}
+
+func TestWithHarnessFactory(t *testing.T) {
+	t.Parallel()
+	for _, name := range []string{"first", "second"} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			var called *latest.HarnessConfig
+			r := &LocalRuntime{}
+			WithHarnessFactory(func(cfg *latest.HarnessConfig) (harness.Provider, error) {
+				called = cfg
+				return nil, nil
+			})(r)
+			require.Nil(t, called, "factory must remain lazy")
+			cfg := &latest.HarnessConfig{Type: name}
+			_, err := r.newHarnessProvider(cfg)
+			require.NoError(t, err)
+			assert.Same(t, cfg, called)
+		})
+	}
+}
+
+func TestHarnessFactoryOverridesGlobal(t *testing.T) {
+	original := harnessFactory.Load()
+	t.Cleanup(func() { harnessFactory.Store(original) })
+
+	r := &LocalRuntime{}
+	globalCalls := 0
+	RegisterHarness(func(*latest.HarnessConfig) (harness.Provider, error) {
+		globalCalls++
+		return nil, nil
+	})
+	_, err := r.newHarnessProvider(nil)
+	require.NoError(t, err)
+	assert.Equal(t, 1, globalCalls, "registration after construction remains supported")
+
+	WithHarnessFactory(nil)(r)
+	_, err = r.newHarnessProvider(nil)
+	require.ErrorIs(t, err, ErrHarnessNotRegistered)
+	assert.Equal(t, 1, globalCalls)
+
+	localCalls := 0
+	WithHarnessFactory(func(*latest.HarnessConfig) (harness.Provider, error) {
+		localCalls++
+		return nil, nil
+	})(r)
+	_, err = r.newHarnessProvider(nil)
+	require.NoError(t, err)
+	assert.Equal(t, 1, localCalls)
+	assert.Equal(t, 1, globalCalls)
 }

--- a/pkg/runtime/jscommands/jscommands.go
+++ b/pkg/runtime/jscommands/jscommands.go
@@ -17,7 +17,11 @@ import (
 // Register installs the goja-backed evaluator as the runtime's command
 // evaluator. It is idempotent and safe to call from multiple goroutines.
 func Register() {
-	runtime.RegisterCommandEvaluator(func(agentTools []tools.Tool) runtime.CommandEvaluator {
-		return js.NewEvaluator(agentTools)
-	})
+	runtime.RegisterCommandEvaluator(Factory)
+}
+
+// Factory builds the JavaScript evaluator without changing global registration.
+// Pass it to runtime.WithCommandEvaluatorFactory for instance-scoped wiring.
+func Factory(agentTools []tools.Tool) runtime.CommandEvaluator {
+	return js.NewEvaluator(agentTools)
 }

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -23,6 +23,7 @@ import (
 	"github.com/docker/docker-agent/pkg/config/latest"
 	"github.com/docker/docker-agent/pkg/config/types"
 	"github.com/docker/docker-agent/pkg/effort"
+	"github.com/docker/docker-agent/pkg/harness"
 	"github.com/docker/docker-agent/pkg/hooks"
 	"github.com/docker/docker-agent/pkg/hooks/builtins"
 	"github.com/docker/docker-agent/pkg/httpclient"
@@ -230,6 +231,8 @@ type ModelStore interface {
 
 // LocalRuntime manages the execution of agents
 type LocalRuntime struct {
+	harnessFactory *harness.Factory
+
 	ctx                       func() context.Context
 	toolMap                   map[string]ToolHandlerFunc
 	toolDeferrals             tools.DeferralTracker

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -231,7 +231,8 @@ type ModelStore interface {
 
 // LocalRuntime manages the execution of agents
 type LocalRuntime struct {
-	harnessFactory *harness.Factory
+	harnessFactory   *harness.Factory
+	commandEvaluator *CommandEvaluatorFactory
 
 	ctx                       func() context.Context
 	toolMap                   map[string]ToolHandlerFunc

--- a/pkg/teamloader/expander.go
+++ b/pkg/teamloader/expander.go
@@ -36,18 +36,18 @@ func WithExpander[E Expander](newExpander func(environment.Provider) E) Opt {
 // envRef matches ${env.NAME} and ${NAME} where NAME is a plain identifier.
 var envRef = regexp.MustCompile(`\$\{\s*(env\.)?([A-Za-z_][A-Za-z0-9_]*)\s*\}`)
 
-// envExpander is the default Expander: it resolves ${env.NAME} from the
+// EnvExpander is the default Expander: it resolves ${env.NAME} from the
 // environment and ${name} from the bound values, and leaves any other
 // expression untouched so it stays visible rather than silently vanishing.
-type envExpander struct {
+type EnvExpander struct {
 	env environment.Provider
 }
 
 func newEnvExpander(env environment.Provider) Expander {
-	return envExpander{env: env}
+	return NewEnvExpander(env)
 }
 
-func (e envExpander) Expand(ctx context.Context, text string, values map[string]string) string {
+func (e EnvExpander) Expand(ctx context.Context, text string, values map[string]string) string {
 	if !strings.Contains(text, "${") {
 		return text
 	}
@@ -69,7 +69,7 @@ func (e envExpander) Expand(ctx context.Context, text string, values map[string]
 	})
 }
 
-func (e envExpander) ExpandCommands(ctx context.Context, cmds types.Commands) types.Commands {
+func (e EnvExpander) ExpandCommands(ctx context.Context, cmds types.Commands) types.Commands {
 	if cmds == nil {
 		return nil
 	}
@@ -79,6 +79,21 @@ func (e envExpander) ExpandCommands(ctx context.Context, cmds types.Commands) ty
 		cmd.Instruction = e.Expand(ctx, cmd.Instruction, nil)
 		cmd.URL = e.Expand(ctx, cmd.URL, nil)
 		expanded[k] = cmd
+	}
+	return expanded
+}
+
+// NewEnvExpander resolves ${env.NAME} and bound ${name} placeholders without
+// evaluating JavaScript. Unknown placeholders are left untouched.
+func NewEnvExpander(env environment.Provider) *EnvExpander {
+	return &EnvExpander{env: env}
+}
+
+// ExpandMap expands each value without modifying the input map.
+func (e EnvExpander) ExpandMap(ctx context.Context, values map[string]string) map[string]string {
+	expanded := make(map[string]string, len(values))
+	for key, value := range values {
+		expanded[key] = e.Expand(ctx, value, nil)
 	}
 	return expanded
 }

--- a/pkg/teamloader/expander_test.go
+++ b/pkg/teamloader/expander_test.go
@@ -27,3 +27,19 @@ func TestEnvExpander(t *testing.T) {
 	assert.Equal(t, "root", cmds["c"].Agent)
 	assert.Nil(t, exp.ExpandCommands(t.Context(), nil))
 }
+
+func TestEnvExpanderMap(t *testing.T) {
+	t.Parallel()
+	exp := NewEnvExpander(environment.NewMapEnvProvider(map[string]string{"TOKEN": "secret"}))
+	input := map[string]string{
+		"Authorization": "Bearer ${env.TOKEN}",
+		"Unknown":       "${env.MISSING}",
+		"JavaScript":    "${1 + 1}",
+	}
+	got := exp.ExpandMap(t.Context(), input)
+	assert.Equal(t, "Bearer secret", got["Authorization"])
+	assert.Equal(t, "Bearer ${env.TOKEN}", input["Authorization"])
+	assert.Equal(t, "${env.MISSING}", got["Unknown"])
+	assert.Equal(t, "${1 + 1}", got["JavaScript"])
+	assert.Empty(t, exp.ExpandMap(t.Context(), nil))
+}

--- a/pkg/tools/builtin/api/api.go
+++ b/pkg/tools/builtin/api/api.go
@@ -1,203 +1,31 @@
+// Package api provides HTTP API tools with JavaScript template expansion.
+// Import api/client instead to supply an expander without linking JavaScript.
 package api
 
 import (
-	"bytes"
-	"cmp"
-	"context"
-	"encoding/json"
-	"errors"
-	"fmt"
-	"io"
-	"net/http"
-	"net/url"
 	"time"
 
 	"github.com/docker/docker-agent/pkg/config"
 	"github.com/docker/docker-agent/pkg/config/latest"
-	"github.com/docker/docker-agent/pkg/httpclient"
 	"github.com/docker/docker-agent/pkg/js"
 	"github.com/docker/docker-agent/pkg/tools"
+	"github.com/docker/docker-agent/pkg/tools/builtin/api/client"
 	"github.com/docker/docker-agent/pkg/upstream"
-	"github.com/docker/docker-agent/pkg/useragent"
 )
 
-type ToolSet struct {
-	config   latest.APIToolConfig
-	expander *js.Expander
-
-	timeout         time.Duration
-	allowPrivateIPs bool
-}
-
-// Verify interface compliance
-var (
-	_ tools.ToolSet      = (*ToolSet)(nil)
-	_ tools.Instructable = (*ToolSet)(nil)
+type (
+	ToolSet = client.ToolSet
+	Option  = client.Option
 )
-
-func (t *ToolSet) callTool(ctx context.Context, toolCall tools.ToolCall, _ tools.Runtime) (*tools.ToolCallResult, error) {
-	endpoint := t.expander.Expand(ctx, t.config.Endpoint, nil)
-	headers := t.expander.ExpandMap(ctx, t.config.Headers)
-
-	client := httpclient.ClientForAllowPrivateIPs(t.timeout, t.allowPrivateIPs)
-
-	var reqBody io.Reader = http.NoBody
-	switch t.config.Method {
-	case http.MethodGet:
-		if toolCall.Function.Arguments != "" {
-			var params map[string]string
-			if err := json.Unmarshal([]byte(toolCall.Function.Arguments), &params); err != nil {
-				return nil, fmt.Errorf("invalid arguments: %w", err)
-			}
-
-			endpoint = t.expander.Expand(ctx, endpoint, params)
-		}
-	case http.MethodPost:
-		var params map[string]any
-		if err := json.Unmarshal([]byte(toolCall.Function.Arguments), &params); err != nil {
-			return nil, fmt.Errorf("invalid arguments: %w", err)
-		}
-
-		jsonData, err := json.Marshal(params)
-		if err != nil {
-			return nil, fmt.Errorf("failed to marshal request body: %w", err)
-		}
-
-		reqBody = bytes.NewReader(jsonData)
-	}
-
-	req, err := http.NewRequestWithContext(ctx, t.config.Method, endpoint, reqBody)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create request: %w", err)
-	}
-
-	setHeaders(req, headers)
-	if t.config.Method == http.MethodPost {
-		req.Header.Set("Content-Type", "application/json")
-	}
-
-	resp, err := client.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("request failed: %w", err)
-	}
-	defer resp.Body.Close()
-
-	maxSize := int64(1 << 20)
-	body, err := io.ReadAll(io.LimitReader(resp.Body, maxSize))
-	if err != nil {
-		return nil, fmt.Errorf("failed to read response body: %w", err)
-	}
-
-	if resp.StatusCode >= 400 {
-		return tools.ResultError(fmt.Sprintf("API request failed with status %d %s: %s", resp.StatusCode, http.StatusText(resp.StatusCode), limitOutput(string(body)))), nil
-	}
-
-	return tools.ResultSuccess(limitOutput(string(body))), nil
-}
 
 // CreateToolSet is used by the tools registry.
 func CreateToolSet(toolset latest.Toolset, runConfig *config.RuntimeConfig) (tools.ToolSet, error) {
-	if toolset.APIConfig.Endpoint == "" {
-		return nil, errors.New("api tool requires an endpoint in api_config")
-	}
-
-	expander := js.NewJsExpander(runConfig.EnvProvider())
-
-	var opts []Option
-	if toolset.Timeout > 0 {
-		opts = append(opts, WithTimeout(time.Duration(toolset.Timeout)*time.Second))
-	}
-	if toolset.AllowPrivateIPsEnabled() {
-		opts = append(opts, WithAllowPrivateIPs(true))
-	}
-
-	return New(toolset.APIConfig, expander, opts...), nil
+	return client.CreateToolSet(toolset, runConfig, js.NewJsExpander, client.WithHeaderResolver(upstream.ResolveHeaders))
 }
 
-// Option configures an api ToolSet.
-type Option func(*ToolSet)
-
-// WithTimeout overrides the default HTTP client timeout (see
-// [httpclient.DefaultToolHTTPTimeout]).
-func WithTimeout(d time.Duration) Option {
-	return func(t *ToolSet) { t.timeout = d }
-}
-
-// WithAllowPrivateIPs disables SSRF dial-time protection so the api tool
-// may dial loopback / RFC1918 / link-local addresses. Operators opt in via
-// `allow_private_ips: true` when the configured endpoint legitimately
-// targets internal services. Tests use this to talk to httptest.NewServer.
-func WithAllowPrivateIPs(allow bool) Option {
-	return func(t *ToolSet) { t.allowPrivateIPs = allow }
-}
+func WithTimeout(d time.Duration) Option    { return client.WithTimeout(d) }
+func WithAllowPrivateIPs(allow bool) Option { return client.WithAllowPrivateIPs(allow) }
 
 func New(apiConfig latest.APIToolConfig, expander *js.Expander, opts ...Option) *ToolSet {
-	t := &ToolSet{
-		config:   apiConfig,
-		expander: expander,
-		timeout:  httpclient.DefaultToolHTTPTimeout,
-	}
-	for _, opt := range opts {
-		opt(t)
-	}
-	return t
-}
-
-func (t *ToolSet) Instructions() string {
-	return t.config.Instruction
-}
-
-func (t *ToolSet) Tools(context.Context) ([]tools.Tool, error) {
-	inputSchema, err := tools.SchemaToMap(map[string]any{
-		"type":       "object",
-		"properties": t.config.Args,
-		"required":   t.config.Required,
-	})
-	if err != nil {
-		return nil, fmt.Errorf("invalid schema: %w", err)
-	}
-
-	parsedURL, err := url.Parse(t.config.Endpoint)
-	if err != nil {
-		return nil, fmt.Errorf("invalid URL: %w", err)
-	}
-
-	if parsedURL.Scheme == "" || parsedURL.Host == "" {
-		return nil, errors.New("invalid URL: missing scheme or host")
-	}
-
-	if parsedURL.Scheme != "http" && parsedURL.Scheme != "https" {
-		return nil, errors.New("only HTTP and HTTPS URLs are supported")
-	}
-
-	outputSchema := tools.MustSchemaFor[string]()
-	if t.config.OutputSchema != nil {
-		var err error
-		outputSchema, err = tools.SchemaToMap(t.config.OutputSchema)
-		if err != nil {
-			return nil, fmt.Errorf("invalid output_schema: %w", err)
-		}
-	}
-
-	return []tools.Tool{
-		{
-			Name:         t.config.Name,
-			Category:     "api",
-			Description:  t.config.Instruction,
-			Parameters:   inputSchema,
-			OutputSchema: outputSchema,
-			Handler:      t.callTool,
-			Annotations: tools.ToolAnnotations{
-				ReadOnlyHint: true,
-				Title:        cmp.Or(t.config.Name, "Query API"),
-			},
-		},
-	}, nil
-}
-
-func setHeaders(req *http.Request, headers map[string]string) {
-	useragent.SetIdentity(req)
-	for k, v := range upstream.ResolveHeaders(req.Context(), headers) {
-		req.Header.Set(k, v)
-	}
+	return client.New(apiConfig, expander, append(opts, client.WithHeaderResolver(upstream.ResolveHeaders))...)
 }

--- a/pkg/tools/builtin/api/api_test.go
+++ b/pkg/tools/builtin/api/api_test.go
@@ -2,12 +2,9 @@ package api
 
 import (
 	"context"
-	"encoding/json"
-	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -16,261 +13,17 @@ import (
 	"github.com/docker/docker-agent/pkg/config/latest"
 	"github.com/docker/docker-agent/pkg/js"
 	"github.com/docker/docker-agent/pkg/tools"
-	"github.com/docker/docker-agent/pkg/useragent"
-	"github.com/docker/docker-agent/pkg/version"
+	"github.com/docker/docker-agent/pkg/upstream"
 )
-
-// newAPIToolForTest constructs an APITool that bypasses SSRF dial-time
-// protection so tests can talk to httptest.NewServer (which binds to
-// 127.0.0.1). It is defined in a *_test.go file so it is not compiled
-// into release binaries. Production callers must use [New].
-func newAPIToolForTest(apiConfig latest.APIToolConfig, expander *js.Expander) *ToolSet {
-	return New(apiConfig, expander, WithAllowPrivateIPs(true))
-}
-
-type testServer struct {
-	serverURL       string
-	receivedURL     string
-	receivedHeaders http.Header
-	receivedMethod  string
-	receivedBody    []byte
-}
-
-func getTestServer(t *testing.T) *testServer {
-	t.Helper()
-
-	ts := &testServer{}
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		ts.receivedHeaders = r.Header.Clone()
-		ts.receivedURL = r.URL.String()
-		ts.receivedMethod = r.Method
-
-		var err error
-		ts.receivedBody, err = io.ReadAll(r.Body)
-		if err != nil {
-			w.WriteHeader(http.StatusInternalServerError)
-			return
-		}
-		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write([]byte(`{"status":"ok"}`))
-	}))
-
-	ts.serverURL = server.URL
-
-	t.Cleanup(func() {
-		server.Close()
-	})
-
-	return ts
-}
-
-func TestAPITool_GET(t *testing.T) {
-	t.Parallel()
-	ts := getTestServer(t)
-
-	tool := newAPIToolForTest(latest.APIToolConfig{
-		Method:   http.MethodGet,
-		Endpoint: ts.serverURL + "/api?key=${key}&value=${value}",
-	}, testExpander())
-
-	result, err := tool.callTool(t.Context(), tools.ToolCall{
-		Function: tools.FunctionCall{
-			Arguments: `{"key": "mykey", "value": "myvalue"}`,
-		},
-	}, tools.NopRuntime{})
-
-	require.NoError(t, err)
-	assert.JSONEq(t, `{"status":"ok"}`, result.Output)
-	assert.Equal(t, http.MethodGet, ts.receivedMethod)
-	assert.Equal(t, "/api?key=mykey&value=myvalue", ts.receivedURL)
-}
-
-func TestAPITool_POST(t *testing.T) {
-	t.Parallel()
-	ts := getTestServer(t)
-
-	tool := newAPIToolForTest(latest.APIToolConfig{
-		Method:   http.MethodPost,
-		Endpoint: ts.serverURL,
-	}, testExpander())
-
-	result, err := tool.callTool(t.Context(), tools.ToolCall{
-		Function: tools.FunctionCall{
-			Arguments: `{"name":"John Doe","age":30}`,
-		},
-	}, tools.NopRuntime{})
-
-	require.NoError(t, err)
-	assert.JSONEq(t, `{"status":"ok"}`, result.Output)
-	assert.Equal(t, http.MethodPost, ts.receivedMethod)
-	assert.Equal(t, "application/json", ts.receivedHeaders.Get("Content-Type"))
-
-	var receivedData map[string]any
-	err = json.Unmarshal(ts.receivedBody, &receivedData)
-	require.NoError(t, err)
-	assert.Equal(t, "John Doe", receivedData["name"])
-	assert.InEpsilon(t, 30.0, receivedData["age"], 0.01)
-}
-
-func TestAPITool_Headers(t *testing.T) {
-	t.Parallel()
-	ts := getTestServer(t)
-
-	tool := newAPIToolForTest(latest.APIToolConfig{
-		Method:   http.MethodGet,
-		Endpoint: ts.serverURL,
-		Headers: map[string]string{
-			"X-Custom-Header":  "custom-value",
-			"X-API-Key":        "secret-key",
-			"X-Another-Header": "another-value",
-		},
-	}, testExpander())
-
-	result, err := tool.callTool(t.Context(), tools.ToolCall{}, tools.NopRuntime{})
-
-	require.NoError(t, err)
-	assert.JSONEq(t, `{"status":"ok"}`, result.Output)
-	assert.Equal(t, "custom-value", ts.receivedHeaders.Get("X-Custom-Header"))
-	assert.Equal(t, "secret-key", ts.receivedHeaders.Get("X-API-Key"))
-	assert.Equal(t, "another-value", ts.receivedHeaders.Get("X-Another-Header"))
-}
-
-// TestAPITool_IdentityHeaders pins the docker-agent identity headers that
-// every built-in tool sends so backends can attribute traffic to a specific
-// docker-agent install. X-Docker-Desktop-Version is only present when
-// Docker Desktop is reachable, so we accept its absence.
-func TestAPITool_IdentityHeaders(t *testing.T) {
-	t.Parallel()
-	ts := getTestServer(t)
-
-	tool := newAPIToolForTest(latest.APIToolConfig{
-		Method:   http.MethodGet,
-		Endpoint: ts.serverURL,
-	}, testExpander())
-
-	_, err := tool.callTool(t.Context(), tools.ToolCall{}, tools.NopRuntime{})
-	require.NoError(t, err)
-
-	assert.Equal(t, useragent.Header, ts.receivedHeaders.Get("User-Agent"))
-	assert.Equal(t, version.Version, ts.receivedHeaders.Get(useragent.HeaderAgentVersion))
-}
-
-func TestAPITool_DefaultOutputSchema(t *testing.T) {
-	t.Parallel()
-
-	tool := New(latest.APIToolConfig{
-		Name:     "default-schema",
-		Method:   http.MethodGet,
-		Endpoint: "https://example.com/api",
-	}, testExpander())
-
-	toolsList, err := tool.Tools(t.Context())
-	require.NoError(t, err)
-	require.Len(t, toolsList, 1)
-
-	assert.Equal(t, tools.MustSchemaFor[string](), toolsList[0].OutputSchema)
-}
-
-func TestAPITool_CustomOutputSchema(t *testing.T) {
-	t.Parallel()
-
-	customSchema := map[string]any{
-		"type": "object",
-		"properties": map[string]any{
-			"first_name": map[string]any{"type": "string"},
-			"last_name":  map[string]any{"type": "string"},
-			"age":        map[string]any{"type": "number"},
-		},
-		"required": []string{"first_name", "last_name"},
-	}
-
-	tool := New(latest.APIToolConfig{
-		Name:         "user-info",
-		Method:       http.MethodGet,
-		Endpoint:     "https://example.com/api/users/${id}",
-		Required:     []string{"id"},
-		Args:         map[string]any{"id": map[string]any{"type": "number"}},
-		OutputSchema: customSchema,
-	}, testExpander())
-
-	toolsList, err := tool.Tools(t.Context())
-	require.NoError(t, err)
-	require.Len(t, toolsList, 1)
-
-	schema, ok := toolsList[0].OutputSchema.(map[string]any)
-	require.True(t, ok)
-	assert.Equal(t, "object", schema["type"])
-
-	props, ok := schema["properties"].(map[string]any)
-	require.True(t, ok)
-	assert.Contains(t, props, "first_name")
-	assert.Contains(t, props, "age")
-}
-
-func TestAPITool_RejectsLocalAddresses(t *testing.T) {
-	t.Parallel()
-
-	// Production constructor — must refuse loopback at dial time so a
-	// crafted endpoint cannot be used to probe internal services or the
-	// cloud metadata endpoint at 169.254.169.254.
-	tests := []string{
-		"http://127.0.0.1/api",
-		"http://[::1]/api",
-		"http://10.0.0.1/api",
-		"http://169.254.169.254/latest/meta-data/",
-		"http://0.0.0.0/api",
-	}
-	for _, target := range tests {
-		t.Run(target, func(t *testing.T) {
-			t.Parallel()
-			tool := New(latest.APIToolConfig{
-				Method:   http.MethodGet,
-				Endpoint: target,
-			}, testExpander())
-
-			_, err := tool.callTool(t.Context(), tools.ToolCall{}, tools.NopRuntime{})
-			require.Error(t, err)
-			assert.Contains(t, err.Error(), "non-public address")
-		})
-	}
-}
-
-// TestAPITool_AllowPrivateIPsRestoresLegacyBehaviour verifies that the
-// allow_private_ips opt-in actually disables the SSRF dial filter.
-func TestAPITool_AllowPrivateIPsRestoresLegacyBehaviour(t *testing.T) {
-	t.Parallel()
-	ts := getTestServer(t)
-
-	tool := New(latest.APIToolConfig{
-		Method:   http.MethodGet,
-		Endpoint: ts.serverURL,
-	}, testExpander(), WithAllowPrivateIPs(true))
-
-	_, err := tool.callTool(t.Context(), tools.ToolCall{}, tools.NopRuntime{})
-	require.NoError(t, err, "WithAllowPrivateIPs(true) must permit dialling 127.0.0.1")
-}
-
-// TestAPITool_TimeoutHonoured confirms WithTimeout caps the request.
-func TestAPITool_TimeoutHonoured(t *testing.T) {
-	t.Parallel()
-
-	slow := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
-		<-r.Context().Done()
-	}))
-	t.Cleanup(slow.Close)
-
-	tool := New(latest.APIToolConfig{
-		Method:   http.MethodGet,
-		Endpoint: slow.URL,
-	}, testExpander(), WithAllowPrivateIPs(true), WithTimeout(50*time.Millisecond))
-
-	_, err := tool.callTool(t.Context(), tools.ToolCall{}, tools.NopRuntime{})
-	require.Error(t, err)
-}
 
 func TestAPITool_LazyReplaceHeaders(t *testing.T) {
 	t.Parallel()
-	ts := getTestServer(t)
+	var receivedURL string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedURL = r.URL.String()
+		_, _ = w.Write([]byte(`{"status":"ok"}`))
+	}))
+	t.Cleanup(server.Close)
 
 	envVariables := map[string]string{
 		"DOCKER_TOKEN": "INITIAL",
@@ -281,7 +34,7 @@ func TestAPITool_LazyReplaceHeaders(t *testing.T) {
 		AllowPrivateIPs: new(true),
 		APIConfig: latest.APIToolConfig{
 			Method:   http.MethodGet,
-			Endpoint: ts.serverURL + "/api?token=${env.DOCKER_TOKEN}&value=${value}",
+			Endpoint: server.URL + "/api?token=${env.DOCKER_TOKEN}&value=${value}",
 		},
 	}, &config.RuntimeConfig{
 		EnvProviderForTests: &env,
@@ -302,13 +55,8 @@ func TestAPITool_LazyReplaceHeaders(t *testing.T) {
 
 	require.NoError(t, err)
 	assert.JSONEq(t, `{"status":"ok"}`, result.Output)
-	assert.Equal(t, http.MethodGet, ts.receivedMethod)
-	assert.Equal(t, "/api?token=REFRESHED&value=myvalue", ts.receivedURL)
+	assert.Equal(t, "/api?token=REFRESHED&value=myvalue", receivedURL)
 }
-
-type noopEnvProvider struct{}
-
-func (noopEnvProvider) Get(context.Context, string) (string, bool) { return "", false }
 
 type testEnvProvider map[string]string
 
@@ -317,30 +65,38 @@ func (p *testEnvProvider) Get(_ context.Context, name string) (string, bool) {
 	return val, found
 }
 
-func testExpander() *js.Expander {
-	return js.NewJsExpander(noopEnvProvider{})
-}
-
-func TestAPITool_ErrorStatusCode(t *testing.T) {
+func TestLegacyUpstreamHeaders(t *testing.T) {
 	t.Parallel()
-
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusInternalServerError)
-		_, _ = w.Write([]byte(`{"error":"internal server error"}`))
-	}))
-	t.Cleanup(func() {
-		server.Close()
-	})
-
-	tool := newAPIToolForTest(latest.APIToolConfig{
-		Method:   http.MethodGet,
-		Endpoint: server.URL,
-	}, testExpander())
-
-	result, err := tool.callTool(t.Context(), tools.ToolCall{}, tools.NopRuntime{})
-	require.NoError(t, err)
-
-	assert.True(t, result.IsError)
-	assert.Contains(t, result.Output, "API request failed with status 500")
-	assert.Contains(t, result.Output, "internal server error")
+	for _, constructor := range []string{"New", "Creator"} {
+		t.Run(constructor, func(t *testing.T) {
+			t.Parallel()
+			var authorization string
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				authorization = r.Header.Get("Authorization")
+				w.WriteHeader(http.StatusOK)
+			}))
+			t.Cleanup(server.Close)
+			env := testEnvProvider{}
+			cfg := latest.APIToolConfig{
+				Method:   http.MethodGet,
+				Endpoint: server.URL,
+				Headers:  map[string]string{"Authorization": "${headers.Authorization}"},
+			}
+			var set tools.ToolSet
+			if constructor == "New" {
+				set = New(cfg, js.NewJsExpander(&env), WithAllowPrivateIPs(true))
+			} else {
+				var err error
+				set, err = Creator(t.Context(), latest.Toolset{APIConfig: cfg, AllowPrivateIPs: new(true)}, "", &config.RuntimeConfig{EnvProviderForTests: &env}, "")
+				require.NoError(t, err)
+			}
+			defs, err := set.Tools(t.Context())
+			require.NoError(t, err)
+			headers := http.Header{"Authorization": {"Bearer upstream"}}
+			ctx := upstream.WithHeaders(t.Context(), headers)
+			_, err = defs[0].Handler(ctx, tools.ToolCall{}, tools.NopRuntime{})
+			require.NoError(t, err)
+			assert.Equal(t, "Bearer upstream", authorization)
+		})
+	}
 }

--- a/pkg/tools/builtin/api/client/client.go
+++ b/pkg/tools/builtin/api/client/client.go
@@ -1,0 +1,199 @@
+// Package client implements HTTP API tools with a caller-supplied template expander.
+package client
+
+import (
+	"bytes"
+	"cmp"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"time"
+
+	"github.com/docker/docker-agent/pkg/config/latest"
+	"github.com/docker/docker-agent/pkg/httpclient"
+	"github.com/docker/docker-agent/pkg/tools"
+	"github.com/docker/docker-agent/pkg/useragent"
+)
+
+// Expander resolves endpoint and header templates at request time.
+// Both js.Expander and teamloader.NewEnvExpander satisfy this interface.
+type Expander interface {
+	Expand(ctx context.Context, text string, values map[string]string) string
+	ExpandMap(ctx context.Context, values map[string]string) map[string]string
+}
+
+type ToolSet struct {
+	config   latest.APIToolConfig
+	expander Expander
+
+	timeout         time.Duration
+	allowPrivateIPs bool
+	headerResolver  func(context.Context, map[string]string) map[string]string
+}
+
+// Verify interface compliance
+var (
+	_ tools.ToolSet      = (*ToolSet)(nil)
+	_ tools.Instructable = (*ToolSet)(nil)
+)
+
+func (t *ToolSet) callTool(ctx context.Context, toolCall tools.ToolCall, _ tools.Runtime) (*tools.ToolCallResult, error) {
+	endpoint := t.expander.Expand(ctx, t.config.Endpoint, nil)
+	headers := t.expander.ExpandMap(ctx, t.config.Headers)
+
+	client := httpclient.ClientForAllowPrivateIPs(t.timeout, t.allowPrivateIPs)
+
+	var reqBody io.Reader = http.NoBody
+	switch t.config.Method {
+	case http.MethodGet:
+		if toolCall.Function.Arguments != "" {
+			var params map[string]string
+			if err := json.Unmarshal([]byte(toolCall.Function.Arguments), &params); err != nil {
+				return nil, fmt.Errorf("invalid arguments: %w", err)
+			}
+
+			endpoint = t.expander.Expand(ctx, endpoint, params)
+		}
+	case http.MethodPost:
+		var params map[string]any
+		if err := json.Unmarshal([]byte(toolCall.Function.Arguments), &params); err != nil {
+			return nil, fmt.Errorf("invalid arguments: %w", err)
+		}
+
+		jsonData, err := json.Marshal(params)
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal request body: %w", err)
+		}
+
+		reqBody = bytes.NewReader(jsonData)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, t.config.Method, endpoint, reqBody)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	t.setHeaders(req, headers)
+	if t.config.Method == http.MethodPost {
+		req.Header.Set("Content-Type", "application/json")
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	maxSize := int64(1 << 20)
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxSize))
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response body: %w", err)
+	}
+
+	if resp.StatusCode >= 400 {
+		return tools.ResultError(fmt.Sprintf("API request failed with status %d %s: %s", resp.StatusCode, http.StatusText(resp.StatusCode), limitOutput(string(body)))), nil
+	}
+
+	return tools.ResultSuccess(limitOutput(string(body))), nil
+}
+
+// Option configures an api ToolSet.
+type Option func(*ToolSet)
+
+// WithTimeout overrides the default HTTP client timeout (see
+// [httpclient.DefaultToolHTTPTimeout]).
+func WithTimeout(d time.Duration) Option {
+	return func(t *ToolSet) { t.timeout = d }
+}
+
+// WithAllowPrivateIPs disables SSRF dial-time protection so the api tool
+// may dial loopback / RFC1918 / link-local addresses. Operators opt in via
+// `allow_private_ips: true` when the configured endpoint legitimately
+// targets internal services. Tests use this to talk to httptest.NewServer.
+func WithAllowPrivateIPs(allow bool) Option {
+	return func(t *ToolSet) { t.allowPrivateIPs = allow }
+}
+
+// WithHeaderResolver resolves headers after template expansion on every request.
+// Pass upstream.ResolveHeaders to enable upstream JavaScript header templates.
+func WithHeaderResolver(resolve func(context.Context, map[string]string) map[string]string) Option {
+	return func(t *ToolSet) { t.headerResolver = resolve }
+}
+
+func New(apiConfig latest.APIToolConfig, expander Expander, opts ...Option) *ToolSet {
+	t := &ToolSet{
+		config:   apiConfig,
+		expander: expander,
+		timeout:  httpclient.DefaultToolHTTPTimeout,
+	}
+	for _, opt := range opts {
+		opt(t)
+	}
+	return t
+}
+
+func (t *ToolSet) Instructions() string {
+	return t.config.Instruction
+}
+
+func (t *ToolSet) Tools(context.Context) ([]tools.Tool, error) {
+	inputSchema, err := tools.SchemaToMap(map[string]any{
+		"type":       "object",
+		"properties": t.config.Args,
+		"required":   t.config.Required,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("invalid schema: %w", err)
+	}
+
+	parsedURL, err := url.Parse(t.config.Endpoint)
+	if err != nil {
+		return nil, fmt.Errorf("invalid URL: %w", err)
+	}
+
+	if parsedURL.Scheme == "" || parsedURL.Host == "" {
+		return nil, errors.New("invalid URL: missing scheme or host")
+	}
+
+	if parsedURL.Scheme != "http" && parsedURL.Scheme != "https" {
+		return nil, errors.New("only HTTP and HTTPS URLs are supported")
+	}
+
+	outputSchema := tools.MustSchemaFor[string]()
+	if t.config.OutputSchema != nil {
+		var err error
+		outputSchema, err = tools.SchemaToMap(t.config.OutputSchema)
+		if err != nil {
+			return nil, fmt.Errorf("invalid output_schema: %w", err)
+		}
+	}
+
+	return []tools.Tool{
+		{
+			Name:         t.config.Name,
+			Category:     "api",
+			Description:  t.config.Instruction,
+			Parameters:   inputSchema,
+			OutputSchema: outputSchema,
+			Handler:      t.callTool,
+			Annotations: tools.ToolAnnotations{
+				ReadOnlyHint: true,
+				Title:        cmp.Or(t.config.Name, "Query API"),
+			},
+		},
+	}, nil
+}
+
+func (t *ToolSet) setHeaders(req *http.Request, headers map[string]string) {
+	useragent.SetIdentity(req)
+	if t.headerResolver != nil {
+		headers = t.headerResolver(req.Context(), headers)
+	}
+	for k, v := range headers {
+		req.Header.Set(k, v)
+	}
+}

--- a/pkg/tools/builtin/api/client/client_test.go
+++ b/pkg/tools/builtin/api/client/client_test.go
@@ -1,0 +1,300 @@
+package client
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/docker/docker-agent/pkg/config/latest"
+	"github.com/docker/docker-agent/pkg/js"
+	"github.com/docker/docker-agent/pkg/tools"
+	"github.com/docker/docker-agent/pkg/useragent"
+	"github.com/docker/docker-agent/pkg/version"
+)
+
+// newAPIToolForTest constructs an APITool that bypasses SSRF dial-time
+// protection so tests can talk to httptest.NewServer (which binds to
+// 127.0.0.1). It is defined in a *_test.go file so it is not compiled
+// into release binaries. Production callers must use [New].
+func newAPIToolForTest(apiConfig latest.APIToolConfig, expander *js.Expander) *ToolSet {
+	return New(apiConfig, expander, WithAllowPrivateIPs(true))
+}
+
+type testServer struct {
+	serverURL       string
+	receivedURL     string
+	receivedHeaders http.Header
+	receivedMethod  string
+	receivedBody    []byte
+}
+
+func getTestServer(t *testing.T) *testServer {
+	t.Helper()
+
+	ts := &testServer{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ts.receivedHeaders = r.Header.Clone()
+		ts.receivedURL = r.URL.String()
+		ts.receivedMethod = r.Method
+
+		var err error
+		ts.receivedBody, err = io.ReadAll(r.Body)
+		if err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"status":"ok"}`))
+	}))
+
+	ts.serverURL = server.URL
+
+	t.Cleanup(func() {
+		server.Close()
+	})
+
+	return ts
+}
+
+func TestAPITool_GET(t *testing.T) {
+	t.Parallel()
+	ts := getTestServer(t)
+
+	tool := newAPIToolForTest(latest.APIToolConfig{
+		Method:   http.MethodGet,
+		Endpoint: ts.serverURL + "/api?key=${key}&value=${value}",
+	}, testExpander())
+
+	result, err := tool.callTool(t.Context(), tools.ToolCall{
+		Function: tools.FunctionCall{
+			Arguments: `{"key": "mykey", "value": "myvalue"}`,
+		},
+	}, tools.NopRuntime{})
+
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"status":"ok"}`, result.Output)
+	assert.Equal(t, http.MethodGet, ts.receivedMethod)
+	assert.Equal(t, "/api?key=mykey&value=myvalue", ts.receivedURL)
+}
+
+func TestAPITool_POST(t *testing.T) {
+	t.Parallel()
+	ts := getTestServer(t)
+
+	tool := newAPIToolForTest(latest.APIToolConfig{
+		Method:   http.MethodPost,
+		Endpoint: ts.serverURL,
+	}, testExpander())
+
+	result, err := tool.callTool(t.Context(), tools.ToolCall{
+		Function: tools.FunctionCall{
+			Arguments: `{"name":"John Doe","age":30}`,
+		},
+	}, tools.NopRuntime{})
+
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"status":"ok"}`, result.Output)
+	assert.Equal(t, http.MethodPost, ts.receivedMethod)
+	assert.Equal(t, "application/json", ts.receivedHeaders.Get("Content-Type"))
+
+	var receivedData map[string]any
+	err = json.Unmarshal(ts.receivedBody, &receivedData)
+	require.NoError(t, err)
+	assert.Equal(t, "John Doe", receivedData["name"])
+	assert.InEpsilon(t, 30.0, receivedData["age"], 0.01)
+}
+
+func TestAPITool_Headers(t *testing.T) {
+	t.Parallel()
+	ts := getTestServer(t)
+
+	tool := newAPIToolForTest(latest.APIToolConfig{
+		Method:   http.MethodGet,
+		Endpoint: ts.serverURL,
+		Headers: map[string]string{
+			"X-Custom-Header":  "custom-value",
+			"X-API-Key":        "secret-key",
+			"X-Another-Header": "another-value",
+		},
+	}, testExpander())
+
+	result, err := tool.callTool(t.Context(), tools.ToolCall{}, tools.NopRuntime{})
+
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"status":"ok"}`, result.Output)
+	assert.Equal(t, "custom-value", ts.receivedHeaders.Get("X-Custom-Header"))
+	assert.Equal(t, "secret-key", ts.receivedHeaders.Get("X-API-Key"))
+	assert.Equal(t, "another-value", ts.receivedHeaders.Get("X-Another-Header"))
+}
+
+// TestAPITool_IdentityHeaders pins the docker-agent identity headers that
+// every built-in tool sends so backends can attribute traffic to a specific
+// docker-agent install. X-Docker-Desktop-Version is only present when
+// Docker Desktop is reachable, so we accept its absence.
+func TestAPITool_IdentityHeaders(t *testing.T) {
+	t.Parallel()
+	ts := getTestServer(t)
+
+	tool := newAPIToolForTest(latest.APIToolConfig{
+		Method:   http.MethodGet,
+		Endpoint: ts.serverURL,
+	}, testExpander())
+
+	_, err := tool.callTool(t.Context(), tools.ToolCall{}, tools.NopRuntime{})
+	require.NoError(t, err)
+
+	assert.Equal(t, useragent.Header, ts.receivedHeaders.Get("User-Agent"))
+	assert.Equal(t, version.Version, ts.receivedHeaders.Get(useragent.HeaderAgentVersion))
+}
+
+func TestAPITool_DefaultOutputSchema(t *testing.T) {
+	t.Parallel()
+
+	tool := New(latest.APIToolConfig{
+		Name:     "default-schema",
+		Method:   http.MethodGet,
+		Endpoint: "https://example.com/api",
+	}, testExpander())
+
+	toolsList, err := tool.Tools(t.Context())
+	require.NoError(t, err)
+	require.Len(t, toolsList, 1)
+
+	assert.Equal(t, tools.MustSchemaFor[string](), toolsList[0].OutputSchema)
+}
+
+func TestAPITool_CustomOutputSchema(t *testing.T) {
+	t.Parallel()
+
+	customSchema := map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"first_name": map[string]any{"type": "string"},
+			"last_name":  map[string]any{"type": "string"},
+			"age":        map[string]any{"type": "number"},
+		},
+		"required": []string{"first_name", "last_name"},
+	}
+
+	tool := New(latest.APIToolConfig{
+		Name:         "user-info",
+		Method:       http.MethodGet,
+		Endpoint:     "https://example.com/api/users/${id}",
+		Required:     []string{"id"},
+		Args:         map[string]any{"id": map[string]any{"type": "number"}},
+		OutputSchema: customSchema,
+	}, testExpander())
+
+	toolsList, err := tool.Tools(t.Context())
+	require.NoError(t, err)
+	require.Len(t, toolsList, 1)
+
+	schema, ok := toolsList[0].OutputSchema.(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "object", schema["type"])
+
+	props, ok := schema["properties"].(map[string]any)
+	require.True(t, ok)
+	assert.Contains(t, props, "first_name")
+	assert.Contains(t, props, "age")
+}
+
+func TestAPITool_RejectsLocalAddresses(t *testing.T) {
+	t.Parallel()
+
+	// Production constructor — must refuse loopback at dial time so a
+	// crafted endpoint cannot be used to probe internal services or the
+	// cloud metadata endpoint at 169.254.169.254.
+	tests := []string{
+		"http://127.0.0.1/api",
+		"http://[::1]/api",
+		"http://10.0.0.1/api",
+		"http://169.254.169.254/latest/meta-data/",
+		"http://0.0.0.0/api",
+	}
+	for _, target := range tests {
+		t.Run(target, func(t *testing.T) {
+			t.Parallel()
+			tool := New(latest.APIToolConfig{
+				Method:   http.MethodGet,
+				Endpoint: target,
+			}, testExpander())
+
+			_, err := tool.callTool(t.Context(), tools.ToolCall{}, tools.NopRuntime{})
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "non-public address")
+		})
+	}
+}
+
+// TestAPITool_AllowPrivateIPsRestoresLegacyBehaviour verifies that the
+// allow_private_ips opt-in actually disables the SSRF dial filter.
+func TestAPITool_AllowPrivateIPsRestoresLegacyBehaviour(t *testing.T) {
+	t.Parallel()
+	ts := getTestServer(t)
+
+	tool := New(latest.APIToolConfig{
+		Method:   http.MethodGet,
+		Endpoint: ts.serverURL,
+	}, testExpander(), WithAllowPrivateIPs(true))
+
+	_, err := tool.callTool(t.Context(), tools.ToolCall{}, tools.NopRuntime{})
+	require.NoError(t, err, "WithAllowPrivateIPs(true) must permit dialling 127.0.0.1")
+}
+
+// TestAPITool_TimeoutHonoured confirms WithTimeout caps the request.
+func TestAPITool_TimeoutHonoured(t *testing.T) {
+	t.Parallel()
+
+	slow := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		<-r.Context().Done()
+	}))
+	t.Cleanup(slow.Close)
+
+	tool := New(latest.APIToolConfig{
+		Method:   http.MethodGet,
+		Endpoint: slow.URL,
+	}, testExpander(), WithAllowPrivateIPs(true), WithTimeout(50*time.Millisecond))
+
+	_, err := tool.callTool(t.Context(), tools.ToolCall{}, tools.NopRuntime{})
+	require.Error(t, err)
+}
+
+type noopEnvProvider struct{}
+
+func (noopEnvProvider) Get(context.Context, string) (string, bool) { return "", false }
+
+func testExpander() *js.Expander {
+	return js.NewJsExpander(noopEnvProvider{})
+}
+
+func TestAPITool_ErrorStatusCode(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"error":"internal server error"}`))
+	}))
+	t.Cleanup(func() {
+		server.Close()
+	})
+
+	tool := newAPIToolForTest(latest.APIToolConfig{
+		Method:   http.MethodGet,
+		Endpoint: server.URL,
+	}, testExpander())
+
+	result, err := tool.callTool(t.Context(), tools.ToolCall{}, tools.NopRuntime{})
+	require.NoError(t, err)
+
+	assert.True(t, result.IsError)
+	assert.Contains(t, result.Output, "API request failed with status 500")
+	assert.Contains(t, result.Output, "internal server error")
+}

--- a/pkg/tools/builtin/api/client/creator.go
+++ b/pkg/tools/builtin/api/client/creator.go
@@ -1,0 +1,36 @@
+package client
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/docker/docker-agent/pkg/config"
+	"github.com/docker/docker-agent/pkg/config/latest"
+	"github.com/docker/docker-agent/pkg/environment"
+	"github.com/docker/docker-agent/pkg/tools"
+)
+
+// Creator returns a teamloader.ToolsetCreator using the supplied expander.
+// Pass teamloader.NewEnvExpander to support placeholders without JavaScript.
+func Creator[E Expander](newExpander func(environment.Provider) E, options ...Option) func(context.Context, latest.Toolset, string, *config.RuntimeConfig, string) (tools.ToolSet, error) {
+	return func(_ context.Context, toolset latest.Toolset, _ string, runConfig *config.RuntimeConfig, _ string) (tools.ToolSet, error) {
+		return CreateToolSet(toolset, runConfig, newExpander, options...)
+	}
+}
+
+// CreateToolSet builds a configured HTTP tool with the supplied expander.
+func CreateToolSet[E Expander](toolset latest.Toolset, runConfig *config.RuntimeConfig, newExpander func(environment.Provider) E, options ...Option) (tools.ToolSet, error) {
+	if toolset.APIConfig.Endpoint == "" {
+		return nil, errors.New("api tool requires an endpoint in api_config")
+	}
+	expander := newExpander(runConfig.EnvProvider())
+	var opts []Option
+	if toolset.Timeout > 0 {
+		opts = append(opts, WithTimeout(time.Duration(toolset.Timeout)*time.Second))
+	}
+	if toolset.AllowPrivateIPsEnabled() {
+		opts = append(opts, WithAllowPrivateIPs(true))
+	}
+	return New(toolset.APIConfig, expander, append(opts, options...)...), nil
+}

--- a/pkg/tools/builtin/api/client/creator_test.go
+++ b/pkg/tools/builtin/api/client/creator_test.go
@@ -1,0 +1,72 @@
+package client_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/docker/docker-agent/pkg/config"
+	"github.com/docker/docker-agent/pkg/config/latest"
+	"github.com/docker/docker-agent/pkg/environment"
+	"github.com/docker/docker-agent/pkg/teamloader"
+	"github.com/docker/docker-agent/pkg/tools"
+	"github.com/docker/docker-agent/pkg/tools/builtin/api/client"
+)
+
+type envValues map[string]string
+
+func (e envValues) Get(_ context.Context, name string) (string, bool) {
+	value, found := e[name]
+	return value, found
+}
+
+func TestCreatorWithoutJavaScript(t *testing.T) {
+	t.Parallel()
+	var receivedURL, authorization string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedURL = r.URL.String()
+		authorization = r.Header.Get("Authorization")
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	t.Cleanup(server.Close)
+
+	env := envValues{"TOKEN": "initial"}
+	creator := client.Creator(teamloader.NewEnvExpander)
+	var _ teamloader.ToolsetCreator = creator
+	set, err := creator(t.Context(), latest.Toolset{
+		AllowPrivateIPs: new(true),
+		Timeout:         1,
+		APIConfig: latest.APIToolConfig{
+			Name:     "lookup",
+			Method:   http.MethodGet,
+			Endpoint: server.URL + "/lookup?q=${query}",
+			Headers:  map[string]string{"Authorization": "Bearer ${env.TOKEN}"},
+		},
+	}, "", &config.RuntimeConfig{EnvProviderForTests: env}, "")
+	require.NoError(t, err)
+	env["TOKEN"] = "refreshed"
+	definitions, err := set.Tools(t.Context())
+	require.NoError(t, err)
+	require.Len(t, definitions, 1)
+	result, err := definitions[0].Handler(t.Context(), tools.ToolCall{
+		Function: tools.FunctionCall{Arguments: `{"query":"hello"}`},
+	}, tools.NopRuntime{})
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"ok":true}`, result.Output)
+	assert.Equal(t, "/lookup?q=hello", receivedURL)
+	assert.Equal(t, "Bearer refreshed", authorization)
+}
+
+func TestCreatorValidatesBeforeBuildingExpander(t *testing.T) {
+	t.Parallel()
+	creator := client.Creator(func(_ environment.Provider) *teamloader.EnvExpander {
+		t.Fatal("invalid configuration must not construct an expander")
+		return nil
+	})
+	_, err := creator(t.Context(), latest.Toolset{}, "", &config.RuntimeConfig{}, "")
+	require.ErrorContains(t, err, "requires an endpoint")
+}

--- a/pkg/tools/builtin/api/client/limit.go
+++ b/pkg/tools/builtin/api/client/limit.go
@@ -1,4 +1,4 @@
-package api
+package client
 
 const maxOutputSize = 30000
 


### PR DESCRIPTION
The HTTP API tool (`pkg/tools/builtin/api`) previously dragged four external
modules — `goja`, `regexp2/v2`, `go-sourcemap`, and `google/pprof` — into the
closure of any binary that imported it, because template expansion was wired
directly to the JavaScript engine. This made the package unusable for embedders
that build teams in Go without the JS runtime.

This change extracts the transport layer into a new `pkg/tools/builtin/api/client`
leaf package. `client.ToolSet` accepts a caller-supplied `Expander` interface
and an optional header resolver, so it never imports `pkg/js` or any JS engine.
`client.Creator` and `client.CreateToolSet` provide drop-in replacements for the
existing toolset-factory signature; passing `teamloader.NewEnvExpander` gives
placeholder expansion without JavaScript. The original `pkg/tools/builtin/api`
constructors are preserved and still wire in the JS expander by default, so all
existing configurations are unaffected.

The same principle is applied to two runtime extension points. `WithHarnessFactory`
lets an individual `LocalRuntime` select its own harness driver instead of relying
on the process-wide `RegisterHarness` global; passing `nil` explicitly disables
harnesses even when a global driver is registered. `WithCommandEvaluatorFactory`
does the same for slash-command evaluation: `nil` suppresses JS expansion for that
instance, while the global factory remains the fallback for runtimes that do not
opt in. Both options are useful when building multi-agent systems in code where
different runtime instances need different capability sets.

A new `examples/golibrary/leanapi` example demonstrates constructing an HTTP API
tool programmatically with no JS dependency. The dependency-regression tests in
`e2e/dependencies_test.go` now cover the `api/client` leaf and the `leanapi`
example, asserting that `goja` and related modules are absent from their transitive
closure. SDK documentation is updated to cover both extension points. This PR is
complementary to https://github.com/docker/docker-agent/pull/4192 and shares no
code with it.