### PR TITLE
docs: add CLAUDE.md pointing at AGENTS.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,4 @@
+# CLAUDE.md
+
+See [AGENTS.md](AGENTS.md). It applies to Claude Code as written, and this
+file exists only so it is loaded automatically.


### PR DESCRIPTION
Claude Code loads `CLAUDE.md` automatically. It does not load `AGENTS.md`, so the guidance already written there is invisible to it unless a contributor happens to open the file by hand. I hit this working on #4190: the rules I needed were in `AGENTS.md` all along and never reached the tool.

This adds a pointer and nothing else. No guidance is copied, so there is nothing to drift.

Separate from #4197, which edits `AGENTS.md` itself, so the two can be taken independently or one dropped.

I have read access only, so treat this as a suggestion rather than a decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qyjba1txhq3QsrpcGUt3FM
