### PR TITLE
chore: update docker-agent-action to v2.0.6

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -18,7 +18,7 @@ jobs:
     if: |
       github.event_name == 'issue_comment' ||
       github.event.workflow_run.conclusion == 'success'
-    uses: docker/docker-agent-action/.github/workflows/review-pr.yml@06e1767af06263c93d712449cbf859778d9392ee # v2.0.5
+    uses: docker/docker-agent-action/.github/workflows/review-pr.yml@4dcb32aa716addc5ce33f8b4d33cb635ae174d7e # v2.0.6
     # Scoped to the job so other jobs in this workflow aren't over-permissioned
     permissions:
       contents: read # Read repository files and PR diffs


### PR DESCRIPTION
## Summary
Updates `docker-agent-action` reference in `.github/workflows/pr-review.yml` to [v2.0.6](https://github.com/docker/docker-agent-action/releases/tag/v2.0.6).
- **Commit**: `4dcb32aa716addc5ce33f8b4d33cb635ae174d7e`
- **Version**: `v2.0.6`
> Auto-generated by the [release](https://github.com/docker/docker-agent-action/actions/runs/34202530909) workflow.