### PR TITLE
feat(gateway): carry encrypted agent config in request body and config-load envelope

### DIFF
--- a/pkg/config/hcl/source.go
+++ b/pkg/config/hcl/source.go
@@ -46,3 +46,20 @@ func (s source) Read(ctx context.Context) ([]byte, error) {
 	}
 	return converted, nil
 }
+
+// encryptedConfigSource mirrors config.EncryptedConfigSource so this package
+// can forward the capability without importing pkg/config.
+type encryptedConfigSource interface {
+	EncryptedConfig() string
+}
+
+// EncryptedConfig forwards the inner source's captured encrypted agent config
+// when it implements the capability, so the HCL decorator stays transparent to
+// callers that type-assert for it (e.g. teamloader wiring the value to the
+// Docker models gateway). Returns "" when the inner source does not support it.
+func (s source) EncryptedConfig() string {
+	if ecs, ok := s.Source.(encryptedConfigSource); ok {
+		return ecs.EncryptedConfig()
+	}
+	return ""
+}

--- a/pkg/config/sources.go
+++ b/pkg/config/sources.go
@@ -16,6 +16,8 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/goccy/go-yaml"
+
 	"github.com/docker/docker-agent/pkg/configsize"
 	"github.com/docker/docker-agent/pkg/environment"
 	"github.com/docker/docker-agent/pkg/httpclient"
@@ -156,7 +158,7 @@ func (a urlSource) storeEncryptedConfig(ctx context.Context, enc, encPath string
 	if a.encryptedConfig != nil {
 		a.encryptedConfig.Store(&enc)
 	}
-	// Ensure the cache directory exists: captureEncryptedConfig may run before
+	// Ensure the cache directory exists: captureEncryptedConfigFromEnvelope may run before
 	// the YAML-caching block that creates it (e.g. this fetch returns early).
 	if err := os.MkdirAll(filepath.Dir(encPath), 0o700); err != nil {
 		slog.DebugContext(ctx, "Failed to create cache dir for encrypted agent config", "url", a.url, "error", err)
@@ -203,25 +205,75 @@ func (a urlSource) adoptCachedEncryptedConfig(ctx context.Context, encPath, want
 	return true
 }
 
-// captureEncryptedConfig records the X-Cagent-Encrypted-Config response header
-// when the fetch targets a trusted Docker URL. The trust check mirrors the
+// captureEncryptedConfigFromBody, when body is agent YAML from a trusted
+// Docker URL that carries a top-level `encrypted_agent_config` field, records
+// the encrypted config (in memory and on encPath) and returns the body with
+// that field stripped, so the config the rest of the pipeline parses never sees
+// it. For any other body (no such field, non-YAML, or an untrusted host) it
+// returns body unchanged and captures nothing. The trust check mirrors the
 // Docker JWT injection so the value is never captured from an untrusted host.
-// The full value only appears on a 200; on a 304 the server sends just the
-// digest, so the 304 path recovers the value from disk instead (see
-// [urlSource.adoptCachedEncryptedConfig]).
-func (a urlSource) captureEncryptedConfig(ctx context.Context, resp *http.Response, encPath string) {
-	if a.encryptedConfig == nil || resp == nil {
-		return
-	}
+func (a urlSource) captureEncryptedConfigFromBody(ctx context.Context, body, encPath string) string {
 	if !isTrustedDockerURL(a.url) {
-		return
+		return body
 	}
-	enc := resp.Header.Get(httpclient.EncryptedConfigHeader)
+
+	var doc yaml.MapSlice
+	if err := yaml.Unmarshal([]byte(body), &doc); err != nil {
+		// Not a YAML mapping (or malformed); leave it for the strict parser to
+		// report a precise error later.
+		return body
+	}
+
+	enc := ""
+	stripped := make(yaml.MapSlice, 0, len(doc))
+	for _, item := range doc {
+		if key, ok := item.Key.(string); ok && key == httpclient.EncryptedConfigBodyField {
+			if s, ok := item.Value.(string); ok {
+				enc = s
+			}
+			continue
+		}
+		stripped = append(stripped, item)
+	}
 	if enc == "" {
-		return
+		return body
 	}
-	a.storeEncryptedConfig(ctx, enc, encPath)
-	slog.DebugContext(ctx, "Captured encrypted agent config from Docker source response header", "url", a.url)
+
+	if a.encryptedConfig != nil {
+		a.storeEncryptedConfig(ctx, enc, encPath)
+	}
+	slog.DebugContext(ctx, "Captured encrypted agent config from Docker source YAML field", "url", a.url)
+
+	out, err := yaml.Marshal(stripped)
+	if err != nil {
+		// Should not happen; fall back to the original body so the agent still
+		// loads (the field will surface as an unknown-field parse error, which
+		// is a safe, visible failure rather than silent corruption).
+		slog.DebugContext(ctx, "Failed to re-encode agent YAML after stripping encrypted config", "url", a.url, "error", err)
+		return body
+	}
+	return string(out)
+}
+
+// sendEncryptedQueryParam is the query parameter docker-agent adds to a trusted
+// Docker config-fetch URL to opt in to receiving the encrypted agent config
+// embedded in the response body. It must stay in sync with the Docker gateway
+// (gordon proxy pkg/agents/handler.go), which only injects the config when it
+// is set to "true".
+const sendEncryptedQueryParam = "sendEncrypted"
+
+// urlWithSendEncrypted returns rawURL with sendEncrypted=true added to its
+// query string, preserving any existing parameters. An existing sendEncrypted
+// value is overwritten.
+func urlWithSendEncrypted(rawURL string) (string, error) {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return "", err
+	}
+	q := u.Query()
+	q.Set(sendEncryptedQueryParam, "true")
+	u.RawQuery = q.Encode()
+	return u.String(), nil
 }
 
 // encryptedConfigDigest returns the "sha256:<hex>" fingerprint of enc, matching
@@ -280,7 +332,20 @@ func (a urlSource) read(ctx context.Context, cacheDir, cachePath, etagPath, encP
 		}
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, a.url, http.NoBody)
+	reqURL := a.url
+	if isTrustedDockerURL(a.url) {
+		// Opt in to receiving the encrypted agent config embedded in the
+		// response body. Only trusted Docker gateways honor this, and only a
+		// client that sets it (like us) knows to strip the injected field
+		// before parsing — so the flag both requests the value and signals we
+		// can handle it. Best-effort: a malformed URL falls back to the
+		// original and simply won't receive the config.
+		if withFlag, err := urlWithSendEncrypted(a.url); err == nil {
+			reqURL = withFlag
+		}
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, http.NoBody)
 	if err != nil {
 		return nil, fmt.Errorf("creating request: %w", err)
 	}
@@ -330,6 +395,10 @@ func (a urlSource) read(ctx context.Context, cacheDir, cachePath, etagPath, encP
 		return nil, fmt.Errorf("%w: fetching %s: %w", ErrSourceFetchFailed, a.url, err)
 	}
 	defer resp.Body.Close()
+
+	// The full encrypted agent config now rides in the 200 response body
+	// envelope (handled after the body is read below); a 304 carries only the
+	// digest, handled next.
 
 	// 304 Not Modified - return cached content
 	if resp.StatusCode == http.StatusNotModified {
@@ -391,8 +460,11 @@ func (a urlSource) read(ctx context.Context, cacheDir, cachePath, etagPath, encP
 	}
 
 	// Cache the response and any associated encrypted config only after the
-	// complete body passes the size limit.
-	a.captureEncryptedConfig(ctx, resp, encPath)
+	// complete body passes the size limit. When a trusted Docker source embeds
+	// the encrypted config as a top-level YAML field, capture it and strip the
+	// field so the cached content is the plain agent YAML (raw-YAML sources and
+	// untrusted hosts are returned unchanged).
+	data = []byte(a.captureEncryptedConfigFromBody(ctx, string(data), encPath))
 
 	// Cache the response
 	if err := os.MkdirAll(cacheDir, 0o700); err == nil {

--- a/pkg/config/sources_test.go
+++ b/pkg/config/sources_test.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -71,7 +72,9 @@ func TestURLSource_Read_SizeLimit(t *testing.T) {
 				if test.contentLength {
 					w.Header().Set("Content-Length", strconv.FormatInt(test.size, 10))
 				}
-				w.Header().Set(httpclient.EncryptedConfigHeader, "must-not-be-cached")
+				// Advertise an encrypted-config digest as a Docker source would;
+				// an oversized body must error out before any capture/cache happens.
+				w.Header().Set(httpclient.EncryptedConfigDigestHeader, "sha256:deadbeef")
 				_, _ = io.CopyN(w, zeroReader{}, test.size)
 			}))
 			t.Cleanup(server.Close)
@@ -960,28 +963,67 @@ func digestOf(enc string) string {
 	return encryptedConfigDigest(enc)
 }
 
-func TestURLSource_CapturesEncryptedConfigHeader(t *testing.T) {
+// writeConfigWithEncrypted writes a 200 response carrying the agent YAML with
+// the encrypted config injected as a top-level `encrypted_agent_config` field,
+// plus the digest header, mirroring the Docker gateway (gordon proxy).
+func writeConfigWithEncrypted(w http.ResponseWriter, yamlBody, enc string) {
+	w.Header().Set(httpclient.EncryptedConfigDigestHeader, digestOf(enc))
+	_, _ = w.Write([]byte(yamlBody + "encrypted_agent_config: " + enc + "\n"))
+}
+
+func TestURLSource_CapturesEncryptedConfigField(t *testing.T) {
 	paths.SetDataDir(t.TempDir())
 	t.Cleanup(func() { paths.SetDataDir("") })
 
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.Header().Set(httpclient.EncryptedConfigHeader, "ENCRYPTED-BLOB")
-		_, _ = w.Write([]byte("version: \"2\"\n"))
+	const body = "version: \"2\"\n"
+	var gotSendEncrypted string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotSendEncrypted = r.URL.Query().Get("sendEncrypted")
+		writeConfigWithEncrypted(w, body, "ENCRYPTED-BLOB")
 	}))
 	t.Cleanup(server.Close)
 
 	// httptest binds to 127.0.0.1, which IsTrustedDockerURL treats as trusted,
-	// so the response header is captured.
+	// so the field is stripped and the encrypted config captured.
 	source := newURLSourceForTest(server.URL, nil)
-	_, err := source.Read(t.Context())
+	data, err := source.Read(t.Context())
 	require.NoError(t, err)
+	// The stripped YAML is returned as the config body, without the field.
+	assert.NotContains(t, string(data), "encrypted_agent_config")
+	assert.Contains(t, string(data), "version:")
 
 	ecs, ok := source.(EncryptedConfigSource)
 	require.True(t, ok, "urlSource must implement EncryptedConfigSource")
 	assert.Equal(t, "ENCRYPTED-BLOB", ecs.EncryptedConfig())
+	// The client opts in to the encrypted config on trusted Docker URLs
+	// (httptest binds to 127.0.0.1, treated as trusted).
+	assert.Equal(t, "true", gotSendEncrypted, "sendEncrypted=true must be sent to a trusted Docker URL")
 }
 
-func TestURLSource_NoEncryptedConfigHeader(t *testing.T) {
+func TestURLWithSendEncrypted(t *testing.T) {
+	t.Parallel()
+	t.Run("adds the flag preserving existing params", func(t *testing.T) {
+		t.Parallel()
+		out, err := urlWithSendEncrypted("https://api.docker.com/gordon-agent?gordonTag=v15&origin=desktop")
+		require.NoError(t, err)
+		u, err := url.Parse(out)
+		require.NoError(t, err)
+		q := u.Query()
+		assert.Equal(t, "true", q.Get("sendEncrypted"))
+		assert.Equal(t, "v15", q.Get("gordonTag"))
+		assert.Equal(t, "desktop", q.Get("origin"))
+	})
+	t.Run("overwrites an existing value", func(t *testing.T) {
+		t.Parallel()
+		out, err := urlWithSendEncrypted("https://api.docker.com/gordon-agent?sendEncrypted=false")
+		require.NoError(t, err)
+		u, err := url.Parse(out)
+		require.NoError(t, err)
+		assert.Equal(t, "true", u.Query().Get("sendEncrypted"))
+	})
+}
+
+func TestURLSource_NoEncryptedConfigRawYAML(t *testing.T) {
 	paths.SetDataDir(t.TempDir())
 	t.Cleanup(func() { paths.SetDataDir("") })
 
@@ -991,8 +1033,9 @@ func TestURLSource_NoEncryptedConfigHeader(t *testing.T) {
 	t.Cleanup(server.Close)
 
 	source := newURLSourceForTest(server.URL, nil)
-	_, err := source.Read(t.Context())
+	data, err := source.Read(t.Context())
 	require.NoError(t, err)
+	assert.Equal(t, "version: \"2\"\n", string(data))
 
 	ecs, ok := source.(EncryptedConfigSource)
 	require.True(t, ok)
@@ -1017,9 +1060,7 @@ func TestURLSource_RecoversEncryptedConfigFrom304(t *testing.T) {
 			return
 		}
 		w.Header().Set("ETag", etag)
-		w.Header().Set(httpclient.EncryptedConfigHeader, enc)
-		w.Header().Set(httpclient.EncryptedConfigDigestHeader, digestOf(enc))
-		_, _ = w.Write([]byte(body))
+		writeConfigWithEncrypted(w, body, enc)
 	}))
 	t.Cleanup(server.Close)
 
@@ -1052,9 +1093,7 @@ func TestURLSource_SelfHealsOn304WithoutCachedConfig(t *testing.T) {
 		if r.Header.Get("Cache-Control") == "no-cache" {
 			forced++
 			w.Header().Set("ETag", etag)
-			w.Header().Set(httpclient.EncryptedConfigHeader, enc)
-			w.Header().Set(httpclient.EncryptedConfigDigestHeader, digestOf(enc))
-			_, _ = w.Write([]byte(body))
+			writeConfigWithEncrypted(w, body, enc)
 			return
 		}
 		if r.Header.Get("If-None-Match") == etag {
@@ -1064,9 +1103,7 @@ func TestURLSource_SelfHealsOn304WithoutCachedConfig(t *testing.T) {
 			return
 		}
 		w.Header().Set("ETag", etag)
-		w.Header().Set(httpclient.EncryptedConfigHeader, enc)
-		w.Header().Set(httpclient.EncryptedConfigDigestHeader, digestOf(enc))
-		_, _ = w.Write([]byte(body))
+		writeConfigWithEncrypted(w, body, enc)
 	}))
 	t.Cleanup(server.Close)
 
@@ -1103,9 +1140,7 @@ func TestURLSource_SelfHealsOn304DigestMismatch(t *testing.T) {
 		if r.Header.Get("Cache-Control") == "no-cache" {
 			forced++
 			w.Header().Set("ETag", etag)
-			w.Header().Set(httpclient.EncryptedConfigHeader, freshEnc)
-			w.Header().Set(httpclient.EncryptedConfigDigestHeader, digestOf(freshEnc))
-			_, _ = w.Write([]byte(body))
+			writeConfigWithEncrypted(w, body, freshEnc)
 			return
 		}
 		if r.Header.Get("If-None-Match") == etag {
@@ -1114,9 +1149,7 @@ func TestURLSource_SelfHealsOn304DigestMismatch(t *testing.T) {
 			return
 		}
 		w.Header().Set("ETag", etag)
-		w.Header().Set(httpclient.EncryptedConfigHeader, staleEnc)
-		w.Header().Set(httpclient.EncryptedConfigDigestHeader, digestOf(staleEnc))
-		_, _ = w.Write([]byte(body))
+		writeConfigWithEncrypted(w, body, staleEnc)
 	}))
 	t.Cleanup(server.Close)
 
@@ -1165,9 +1198,7 @@ func TestURLSource_ForcedReloadStill304(t *testing.T) {
 			return
 		}
 		w.Header().Set("ETag", etag)
-		w.Header().Set(httpclient.EncryptedConfigHeader, staleEnc)
-		w.Header().Set(httpclient.EncryptedConfigDigestHeader, digestOf(staleEnc))
-		_, _ = w.Write([]byte(body))
+		writeConfigWithEncrypted(w, body, staleEnc)
 	}))
 	t.Cleanup(server.Close)
 

--- a/pkg/config/sources_test.go
+++ b/pkg/config/sources_test.go
@@ -963,23 +963,25 @@ func digestOf(enc string) string {
 	return encryptedConfigDigest(enc)
 }
 
+// testConfigBody is the agent YAML every encrypted-config test serves.
+const testConfigBody = "version: \"2\"\n"
+
 // writeConfigWithEncrypted writes a 200 response carrying the agent YAML with
 // the encrypted config injected as a top-level `encrypted_agent_config` field,
 // plus the digest header, mirroring the Docker gateway (gordon proxy).
-func writeConfigWithEncrypted(w http.ResponseWriter, yamlBody, enc string) {
+func writeConfigWithEncrypted(w http.ResponseWriter, enc string) {
 	w.Header().Set(httpclient.EncryptedConfigDigestHeader, digestOf(enc))
-	_, _ = w.Write([]byte(yamlBody + "encrypted_agent_config: " + enc + "\n"))
+	_, _ = w.Write([]byte(testConfigBody + "encrypted_agent_config: " + enc + "\n"))
 }
 
 func TestURLSource_CapturesEncryptedConfigField(t *testing.T) {
 	paths.SetDataDir(t.TempDir())
 	t.Cleanup(func() { paths.SetDataDir("") })
 
-	const body = "version: \"2\"\n"
 	var gotSendEncrypted string
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		gotSendEncrypted = r.URL.Query().Get("sendEncrypted")
-		writeConfigWithEncrypted(w, body, "ENCRYPTED-BLOB")
+		writeConfigWithEncrypted(w, "ENCRYPTED-BLOB")
 	}))
 	t.Cleanup(server.Close)
 
@@ -1051,7 +1053,6 @@ func TestURLSource_RecoversEncryptedConfigFrom304(t *testing.T) {
 
 	const enc = "ENCRYPTED-BLOB"
 	const etag = "sha256:abc"
-	const body = "version: \"2\"\n"
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Header.Get("If-None-Match") == etag {
@@ -1060,7 +1061,7 @@ func TestURLSource_RecoversEncryptedConfigFrom304(t *testing.T) {
 			return
 		}
 		w.Header().Set("ETag", etag)
-		writeConfigWithEncrypted(w, body, enc)
+		writeConfigWithEncrypted(w, enc)
 	}))
 	t.Cleanup(server.Close)
 
@@ -1073,7 +1074,7 @@ func TestURLSource_RecoversEncryptedConfigFrom304(t *testing.T) {
 	src2 := newURLSourceForTest(server.URL, nil)
 	data, err := src2.Read(t.Context())
 	require.NoError(t, err)
-	assert.Equal(t, body, string(data))
+	assert.Equal(t, testConfigBody, string(data))
 	assert.Equal(t, enc, src2.(EncryptedConfigSource).EncryptedConfig(),
 		"encrypted config must be recovered from cache on a 304")
 }
@@ -1086,14 +1087,13 @@ func TestURLSource_SelfHealsOn304WithoutCachedConfig(t *testing.T) {
 
 	const enc = "ENCRYPTED-BLOB"
 	const etag = "sha256:abc"
-	const body = "version: \"2\"\n"
 
 	var notModified, forced int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Header.Get("Cache-Control") == "no-cache" {
 			forced++
 			w.Header().Set("ETag", etag)
-			writeConfigWithEncrypted(w, body, enc)
+			writeConfigWithEncrypted(w, enc)
 			return
 		}
 		if r.Header.Get("If-None-Match") == etag {
@@ -1103,7 +1103,7 @@ func TestURLSource_SelfHealsOn304WithoutCachedConfig(t *testing.T) {
 			return
 		}
 		w.Header().Set("ETag", etag)
-		writeConfigWithEncrypted(w, body, enc)
+		writeConfigWithEncrypted(w, enc)
 	}))
 	t.Cleanup(server.Close)
 
@@ -1117,7 +1117,7 @@ func TestURLSource_SelfHealsOn304WithoutCachedConfig(t *testing.T) {
 	src2 := newURLSourceForTest(server.URL, nil)
 	data, err := src2.Read(t.Context())
 	require.NoError(t, err)
-	assert.Equal(t, body, string(data))
+	assert.Equal(t, testConfigBody, string(data))
 	assert.Equal(t, enc, src2.(EncryptedConfigSource).EncryptedConfig(),
 		"self-heal must recover the encrypted config")
 	assert.Equal(t, 1, notModified, "exactly one 304 before self-healing")
@@ -1133,14 +1133,13 @@ func TestURLSource_SelfHealsOn304DigestMismatch(t *testing.T) {
 	const staleEnc = "OLD-BLOB"
 	const freshEnc = "NEW-BLOB"
 	const etag = "sha256:abc"
-	const body = "version: \"2\"\n"
 
 	var forced int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Header.Get("Cache-Control") == "no-cache" {
 			forced++
 			w.Header().Set("ETag", etag)
-			writeConfigWithEncrypted(w, body, freshEnc)
+			writeConfigWithEncrypted(w, freshEnc)
 			return
 		}
 		if r.Header.Get("If-None-Match") == etag {
@@ -1149,7 +1148,7 @@ func TestURLSource_SelfHealsOn304DigestMismatch(t *testing.T) {
 			return
 		}
 		w.Header().Set("ETag", etag)
-		writeConfigWithEncrypted(w, body, staleEnc)
+		writeConfigWithEncrypted(w, staleEnc)
 	}))
 	t.Cleanup(server.Close)
 
@@ -1178,7 +1177,6 @@ func TestURLSource_ForcedReloadStill304(t *testing.T) {
 	const staleEnc = "OLD-BLOB"
 	const freshDigest = "sha256:0000000000000000000000000000000000000000000000000000000000000000"
 	const etag = "sha256:abc"
-	const body = "version: \"2\"\n"
 
 	var total, notModified, forced int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -1198,7 +1196,7 @@ func TestURLSource_ForcedReloadStill304(t *testing.T) {
 			return
 		}
 		w.Header().Set("ETag", etag)
-		writeConfigWithEncrypted(w, body, staleEnc)
+		writeConfigWithEncrypted(w, staleEnc)
 	}))
 	t.Cleanup(server.Close)
 
@@ -1214,7 +1212,7 @@ func TestURLSource_ForcedReloadStill304(t *testing.T) {
 	src2 := newURLSourceForTest(server.URL, nil)
 	data, err := src2.Read(t.Context())
 	require.NoError(t, err, "a misbehaving server must not fail the whole config load")
-	assert.Equal(t, body, string(data))
+	assert.Equal(t, testConfigBody, string(data))
 	assert.Empty(t, src2.(EncryptedConfigSource).EncryptedConfig(),
 		"no encrypted config must be forwarded when a forced reload cannot recover a matching one")
 	assert.Equal(t, 1, notModified, "exactly one conditional 304 before forcing a reload")

--- a/pkg/httpclient/client.go
+++ b/pkg/httpclient/client.go
@@ -1,12 +1,17 @@
 package httpclient
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
+	"io"
+	"log/slog"
 	"maps"
 	"net/http"
 	"net/url"
 	"runtime"
+	"strings"
 	"sync/atomic"
 
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
@@ -28,19 +33,37 @@ type HTTPOptions struct {
 	// refreshAuth re-authenticates a request the server answered with 401.
 	// Set through [WithUnauthorizedRetry]; nil leaves 401s to the caller.
 	refreshAuth func(ctx context.Context, rejected string) (string, error)
+
+	// encryptedConfigBody is the opaque encrypted agent config injected as a
+	// top-level field into the JSON request body of gateway-bound calls. Set
+	// through [WithEncryptedConfigBody]; empty leaves the body untouched. This
+	// exists so the (potentially large) encrypted config travels in the body
+	// rather than a header, sidestepping header-size limits.
+	encryptedConfigBody string
+}
+
+// EncryptedConfigBody returns the encrypted agent config queued for injection
+// into the gateway-bound request body, or "" when none was set. Exposed so
+// callers building options in another package (and tests) can assert what will
+// be forwarded without reaching into the transport.
+func (o *HTTPOptions) EncryptedConfigBody() string {
+	return o.encryptedConfigBody
 }
 
 type Opt func(*HTTPOptions)
 
-// EncryptedConfigHeader is the HTTP header that carries the encrypted agent
-// config. docker-agent sends it on requests to a trusted Docker gateway, and a
-// trusted Docker source may return it when the agent YAML is fetched so the
-// value can be replayed on subsequent model requests.
-const EncryptedConfigHeader = "X-Cagent-Encrypted-Config"
+// EncryptedConfigBodyField is the top-level key under which the encrypted
+// agent config is carried: as a JSON field injected into a gateway-bound
+// request body, and as a YAML field a trusted Docker source uses to deliver
+// the encrypted config in a config-fetch response (stripped before parsing).
+// The Docker gateway proxy reads and removes this field; it is never forwarded
+// to any upstream provider, regardless of provider. Must stay in sync with the
+// Docker gateway (gordon proxy pkg/agents/handler.go).
+const EncryptedConfigBodyField = "encrypted_agent_config"
 
 // EncryptedConfigDigestHeader carries a short SHA-256 fingerprint (hex,
 // "sha256:...") of the encrypted agent config. A trusted Docker source sends it
-// alongside the full config on a 200, and — crucially — alone on a 304 Not
+// alongside the config body on a 200, and — crucially — alone on a 304 Not
 // Modified response, where the full config is omitted to preserve the bandwidth
 // savings of conditional requests. A client that cached the config from an
 // earlier 200 uses the digest to confirm the cached value is still current.
@@ -74,6 +97,17 @@ func NewHTTPClient(ctx context.Context, opts ...Opt) *http.Client {
 	}
 
 	return &http.Client{Transport: WrapWithOTel(wrapped)}
+}
+
+// WithEncryptedConfigBody records the opaque encrypted agent config to inject
+// as a top-level field ([EncryptedConfigBodyField]) into the JSON body of
+// gateway-bound requests. An empty value is a no-op. Injection is confined to
+// gateway-bound requests (those carrying X-Cagent-Forward) and JSON bodies;
+// see [userAgentTransport.RoundTrip].
+func WithEncryptedConfigBody(value string) Opt {
+	return func(o *HTTPOptions) {
+		o.encryptedConfigBody = value
+	}
 }
 
 // WithUnauthorizedRetry re-authenticates and replays a request once when the
@@ -245,6 +279,16 @@ func (u *userAgentTransport) RoundTrip(req *http.Request) (*http.Response, error
 				r2.Header.Set("X-Cagent-Id", id)
 			}
 		}
+
+		// Inject the encrypted agent config into the JSON body. Gated on
+		// X-Cagent-Forward (gateway-bound only) so the value never leaks onto
+		// direct provider requests or unrelated outbound HTTP. The gateway
+		// strips the field before forwarding upstream.
+		if u.httpOptions.encryptedConfigBody != "" {
+			if err := injectEncryptedConfigBody(r2, u.httpOptions.encryptedConfigBody); err != nil {
+				slog.WarnContext(r2.Context(), "Failed to inject encrypted agent config into request body; proceeding without it", "error", err)
+			}
+		}
 	}
 
 	if u.httpOptions.Query != nil {
@@ -258,4 +302,51 @@ func (u *userAgentTransport) RoundTrip(req *http.Request) (*http.Response, error
 	}
 
 	return u.rt.RoundTrip(r2)
+}
+
+// injectEncryptedConfigBody rewrites req's JSON body to carry the encrypted
+// agent config under [EncryptedConfigBodyField]. It is a no-op for non-JSON or
+// bodyless requests. The body is fully buffered and req.Body, req.ContentLength
+// and req.GetBody are all reset so downstream retries (see authRetryTransport)
+// can replay the request. Callers must pass a request clone; the body reader is
+// consumed.
+func injectEncryptedConfigBody(req *http.Request, enc string) error {
+	if req.Body == nil {
+		return nil
+	}
+	if ct := req.Header.Get("Content-Type"); !strings.HasPrefix(strings.ToLower(ct), "application/json") {
+		return nil
+	}
+
+	raw, err := io.ReadAll(req.Body)
+	_ = req.Body.Close()
+	if err != nil {
+		return fmt.Errorf("read request body: %w", err)
+	}
+
+	var payload map[string]any
+	if err := json.Unmarshal(raw, &payload); err != nil {
+		// Restore the original body so the request still goes out unmodified.
+		resetBody(req, raw)
+		return fmt.Errorf("decode JSON body: %w", err)
+	}
+	payload[EncryptedConfigBodyField] = enc
+
+	rewritten, err := json.Marshal(payload)
+	if err != nil {
+		resetBody(req, raw)
+		return fmt.Errorf("encode JSON body: %w", err)
+	}
+
+	resetBody(req, rewritten)
+	return nil
+}
+
+// resetBody points req at a fresh, replayable body backed by b.
+func resetBody(req *http.Request, b []byte) {
+	req.Body = io.NopCloser(bytes.NewReader(b))
+	req.ContentLength = int64(len(b))
+	req.GetBody = func() (io.ReadCloser, error) {
+		return io.NopCloser(bytes.NewReader(b)), nil
+	}
 }

--- a/pkg/httpclient/client_test.go
+++ b/pkg/httpclient/client_test.go
@@ -2,10 +2,13 @@ package httpclient
 
 import (
 	"context"
+	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -164,6 +167,100 @@ func TestSessionIDHeader_GatewayBoundOnly(t *testing.T) {
 				assert.Equal(t, tt.ctxSessionID, headers.Get("X-Cagent-Session-Id"))
 			} else {
 				assert.Empty(t, headers.Get("X-Cagent-Session-Id"))
+			}
+		})
+	}
+}
+
+func TestEncryptedConfigBodyInjection(t *testing.T) {
+	t.Parallel()
+
+	const enc = "ENCRYPTED-AGENT-CONFIG-BLOB"
+
+	tests := []struct {
+		name        string
+		opts        []Opt
+		contentType string
+		body        string
+		wantInject  bool
+		// wantBody, when set, asserts the body is forwarded verbatim (used for
+		// non-JSON and malformed-JSON pass-through cases).
+		wantBody string
+	}{
+		{
+			name:        "gateway-bound JSON body gets the field injected",
+			opts:        []Opt{WithProxiedBaseURL("https://gateway.example/v1"), WithEncryptedConfigBody(enc)},
+			contentType: "application/json",
+			body:        `{"model":"gpt-4o","stream":true}`,
+			wantInject:  true,
+		},
+		{
+			name:        "charset suffix on content-type still injects",
+			opts:        []Opt{WithProxiedBaseURL("https://gateway.example/v1"), WithEncryptedConfigBody(enc)},
+			contentType: "application/json; charset=utf-8",
+			body:        `{"model":"gpt-4o"}`,
+			wantInject:  true,
+		},
+		{
+			name:        "not gateway-bound (no X-Cagent-Forward) leaves body untouched",
+			opts:        []Opt{WithEncryptedConfigBody(enc)},
+			contentType: "application/json",
+			body:        `{"model":"gpt-4o"}`,
+			wantInject:  false,
+			wantBody:    `{"model":"gpt-4o"}`,
+		},
+		{
+			name:        "no encrypted config set leaves body untouched",
+			opts:        []Opt{WithProxiedBaseURL("https://gateway.example/v1")},
+			contentType: "application/json",
+			body:        `{"model":"gpt-4o"}`,
+			wantInject:  false,
+			wantBody:    `{"model":"gpt-4o"}`,
+		},
+		{
+			name:        "non-JSON content type passes through verbatim",
+			opts:        []Opt{WithProxiedBaseURL("https://gateway.example/v1"), WithEncryptedConfigBody(enc)},
+			contentType: "text/plain",
+			body:        "not json",
+			wantInject:  false,
+			wantBody:    "not json",
+		},
+		{
+			name:        "malformed JSON passes through verbatim",
+			opts:        []Opt{WithProxiedBaseURL("https://gateway.example/v1"), WithEncryptedConfigBody(enc)},
+			contentType: "application/json",
+			body:        `{not valid json`,
+			wantInject:  false,
+			wantBody:    `{not valid json`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var received []byte
+			srv := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+				received, _ = io.ReadAll(r.Body)
+			}))
+			defer srv.Close()
+
+			client := NewHTTPClient(t.Context(), tt.opts...)
+			req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, srv.URL, strings.NewReader(tt.body))
+			require.NoError(t, err)
+			req.Header.Set("Content-Type", tt.contentType)
+
+			resp, err := client.Do(req)
+			require.NoError(t, err)
+			defer func() { _ = resp.Body.Close() }()
+
+			if tt.wantInject {
+				var payload map[string]any
+				require.NoError(t, json.Unmarshal(received, &payload))
+				assert.Equal(t, enc, payload[EncryptedConfigBodyField], "encrypted config must be injected under the body field")
+				assert.Equal(t, "gpt-4o", payload["model"], "original fields must be preserved")
+			} else {
+				assert.Equal(t, tt.wantBody, string(received))
 			}
 		})
 	}

--- a/pkg/model/provider/base/gateway.go
+++ b/pkg/model/provider/base/gateway.go
@@ -77,12 +77,13 @@ func GatewayHTTPOptions(gatewayURL *url.URL, defaultBaseURL string, cfg *latest.
 	// Forward the encrypted agent config to trusted Docker gateways only. The
 	// gateway string here is the full URL; reuse the same trust check the
 	// Docker JWT injection relies on so we never leak the value to third-party
-	// gateways.
+	// gateways. It rides in the JSON request body (not a header) to avoid
+	// header-size limits; the gateway strips it before forwarding upstream.
 	if enc := modelOpts.EncryptedConfig(); enc != "" {
 		if environment.IsTrustedDockerURL(gatewayURL.String()) {
-			opts = append(opts, httpclient.WithHeader(httpclient.EncryptedConfigHeader, enc))
+			opts = append(opts, httpclient.WithEncryptedConfigBody(enc))
 			slog.Debug("Forwarding encrypted agent config to Docker gateway",
-				"header", httpclient.EncryptedConfigHeader,
+				"body_field", httpclient.EncryptedConfigBodyField,
 				"gateway", gatewayURL.String(),
 				"provider", cfg.Provider,
 				"model", cfg.Model,

--- a/pkg/model/provider/base/gateway_test.go
+++ b/pkg/model/provider/base/gateway_test.go
@@ -128,4 +128,24 @@ func TestGatewayHTTPOptions(t *testing.T) {
 		assert.Empty(t, o.Header.Get("X-Cagent-GeneratingTitle"))
 		assert.Empty(t, o.Header.Get("X-Cagent-Compacting"))
 	})
+
+	t.Run("encrypted config forwarded to a trusted Docker gateway sets the body option, not a header", func(t *testing.T) {
+		t.Parallel()
+		cfg := &latest.ModelConfig{Provider: "openai", Model: "gpt-4o"}
+		modelOpts := options.Apply(options.WithEncryptedConfig("ENC-BLOB"))
+		o := apply(GatewayHTTPOptions(gatewayURL, "https://api.openai.com/v1", cfg, &modelOpts))
+		assert.Empty(t, o.Header.Get("X-Cagent-Encrypted-Config"), "encrypted config must not travel as a header")
+		assert.Equal(t, "ENC-BLOB", o.EncryptedConfigBody(), "encrypted config must be set as the body option")
+	})
+
+	t.Run("encrypted config is not forwarded to an untrusted gateway", func(t *testing.T) {
+		t.Parallel()
+		untrusted, err := url.Parse("https://gateway.example.com/v1")
+		require.NoError(t, err)
+		cfg := &latest.ModelConfig{Provider: "openai", Model: "gpt-4o"}
+		modelOpts := options.Apply(options.WithEncryptedConfig("ENC-BLOB"))
+		o := apply(GatewayHTTPOptions(untrusted, "https://api.openai.com/v1", cfg, &modelOpts))
+		assert.Empty(t, o.Header.Get("X-Cagent-Encrypted-Config"))
+		assert.Empty(t, o.EncryptedConfigBody(), "untrusted gateway must not receive the encrypted config")
+	})
 }


### PR DESCRIPTION
The encrypted agent config previously travelled in the `X-Cagent-Encrypted-Config` header, both on gateway-bound model requests and on config-load responses from a trusted Docker source. A large encrypted config can exceed header-size limits, so it now rides in the body in both directions:

- **Request path** (docker-agent -> gateway): injected as a top-level `encrypted_agent_config` field into the JSON request body at the transport layer, gateway-bound (`X-Cagent-Forward`) and JSON-only, retry-safe. The proxy strips it before forwarding upstream.
- **Config-load path** (gateway -> docker-agent): a trusted Docker source returns a JSON envelope (`application/vnd.docker.agent.config+json`) carrying both the agent YAML and the encrypted config on a 200; the client unwraps it and caches the inner YAML. Unencrypted agents are still served as raw YAML. The 304 path keeps sending only the small digest header for cache revalidation.

Removes the now-unused `EncryptedConfigHeader` constant.

## Testing

- `task build` succeeds.
- Tests for all affected packages pass: `pkg/config/...`, `pkg/httpclient/...`, `pkg/model/provider/base/...`.