### PR TITLE
fix: drop Gemini keepalive SSE events before SDK parsing

### DIFF
--- a/pkg/httpclient/sse_filter.go
+++ b/pkg/httpclient/sse_filter.go
@@ -10,7 +10,7 @@ import (
 
 // sseFilterTransport wraps a base RoundTripper and, when the response is a
 // `text/event-stream`, replaces the body with one that strips SSE events
-// containing no `data:` lines.
+// containing no `data:` lines or named `keepalive`.
 //
 // Why this exists: some upstreams (notably OpenRouter) inject comment-only
 // keep-alive frames into their streams:
@@ -28,8 +28,10 @@ import (
 //
 // The filter normalises the byte stream so events with no `data:` lines
 // (comment-only events, or events bearing only `event:` / `id:` headers)
-// never reach the SDK. Well-formed events pass through verbatim, and the
-// filter is a no-op on non-SSE responses.
+// never reach the SDK. Named `keepalive` events are also dropped, even when
+// they carry `data: {}`, because Gemini's SDK rejects their `event:` header.
+// Other data-bearing events pass through, and the filter is a no-op on
+// non-SSE responses.
 type sseFilterTransport struct {
 	base http.RoundTripper
 }
@@ -49,15 +51,16 @@ func (t *sseFilterTransport) RoundTrip(req *http.Request) (*http.Response, error
 
 // sseFilterReader buffers the lines of a single SSE event and only emits
 // them once it has seen the trailing blank line AND the event contained at
-// least one `data:` line. A half-built event still pending at EOF is
-// dropped silently — without the terminating blank line a downstream parser
-// would not have dispatched it anyway.
+// least one `data:` line and was not a keepalive. A half-built event still
+// pending at EOF is dropped silently — without the terminating blank line a
+// downstream parser would not have dispatched it anyway.
 type sseFilterReader struct {
-	src     io.ReadCloser
-	scn     *bufio.Scanner
-	out     bytes.Buffer // bytes ready to hand back to the caller
-	pending bytes.Buffer // accumulated lines for the current event
-	hasData bool         // saw at least one `data:` line in `pending`
+	src       io.ReadCloser
+	scn       *bufio.Scanner
+	out       bytes.Buffer // bytes ready to hand back to the caller
+	pending   bytes.Buffer // accumulated lines for the current event
+	hasData   bool         // saw at least one `data:` line in `pending`
+	keepalive bool         // the last `event:` field names a keepalive
 }
 
 func newSSEFilterReader(src io.ReadCloser) *sseFilterReader {
@@ -85,13 +88,14 @@ func (r *sseFilterReader) Read(p []byte) (int, error) {
 func (r *sseFilterReader) consumeLine(line []byte) {
 	switch {
 	case len(line) == 0:
-		// Event boundary: emit the buffered event iff it had data.
-		if r.hasData {
+		// Event boundary: emit data-bearing events except keepalives.
+		if r.hasData && !r.keepalive {
 			r.out.Write(r.pending.Bytes())
 			r.out.WriteByte('\n')
 		}
 		r.pending.Reset()
 		r.hasData = false
+		r.keepalive = false
 	case line[0] == ':':
 		// SSE comment — drop entirely.
 	default:
@@ -99,6 +103,9 @@ func (r *sseFilterReader) consumeLine(line []byte) {
 		r.pending.WriteByte('\n')
 		if bytes.HasPrefix(line, []byte("data:")) {
 			r.hasData = true
+		}
+		if field, value, _ := bytes.Cut(line, []byte(":")); bytes.Equal(field, []byte("event")) {
+			r.keepalive = bytes.Equal(bytes.TrimPrefix(value, []byte(" ")), []byte("keepalive"))
 		}
 	}
 }

--- a/pkg/httpclient/sse_filter_test.go
+++ b/pkg/httpclient/sse_filter_test.go
@@ -36,6 +36,60 @@ func TestSSEFilter_FiltersStream(t *testing.T) {
 			want: "data: {\"id\":\"1\"}\n\n",
 		},
 		{
+			name: "drops keepalive events with data",
+			in:   "event: keepalive\ndata: {}\n\ndata: ok\n\n",
+			want: "data: ok\n\n",
+		},
+		{
+			name: "drops interleaved and trailing keepalives",
+			in: "data: first\n\n" +
+				"event: keepalive\ndata: {}\n\n" +
+				"event: keepalive\ndata: {}\n\n" +
+				"data: last\n\n" +
+				"event: keepalive\ndata: {}\n\n",
+			want: "data: first\n\ndata: last\n\n",
+		},
+		{
+			name: "drops keepalive with data before event header",
+			in:   "data: {}\nevent: keepalive\n\ndata: ok\n\n",
+			want: "data: ok\n\n",
+		},
+		{
+			name: "drops keepalive without optional space and with CRLF",
+			in:   "event:keepalive\r\ndata:{}\r\n\r\ndata: ok\r\n\r\n",
+			want: "data: ok\n\n",
+		},
+		{
+			name: "only keepalives",
+			in:   "event: keepalive\ndata: {}\n\nevent: keepalive\ndata: {}\n\n",
+			want: "",
+		},
+		{
+			name: "uses last event header",
+			in:   "event: chunk\nevent: keepalive\ndata: {}\n\n",
+			want: "",
+		},
+		{
+			name: "later event header overrides keepalive",
+			in:   "event: keepalive\nevent: chunk\ndata: {}\n\n",
+			want: "event: keepalive\nevent: chunk\ndata: {}\n\n",
+		},
+		{
+			name: "empty event header overrides keepalive",
+			in:   "event: keepalive\nevent\ndata: {}\n\n",
+			want: "event: keepalive\nevent\ndata: {}\n\n",
+		},
+		{
+			name: "preserves unnamed empty JSON payload",
+			in:   "data: {}\n\n",
+			want: "data: {}\n\n",
+		},
+		{
+			name: "preserves other named events and errors",
+			in:   "event: keepalive-extra\ndata: {}\n\nevent: error\ndata: {\"error\":\"failed\"}\n\n",
+			want: "event: keepalive-extra\ndata: {}\n\nevent: error\ndata: {\"error\":\"failed\"}\n\n",
+		},
+		{
 			// Guard against the filter breaking ordinary streams that
 			// don't contain comments.
 			name: "passes through well-formed events",

--- a/pkg/model/provider/gemini/streaming_test.go
+++ b/pkg/model/provider/gemini/streaming_test.go
@@ -1,0 +1,85 @@
+package gemini
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/docker/docker-agent/pkg/chat"
+	"github.com/docker/docker-agent/pkg/config/latest"
+	"github.com/docker/docker-agent/pkg/environment"
+	"github.com/docker/docker-agent/pkg/model/provider/options"
+)
+
+func TestCreateChatCompletionStream_Keepalive(t *testing.T) {
+	t.Parallel()
+
+	for _, gateway := range []bool{false, true} {
+		t.Run(fmt.Sprintf("gateway=%t", gateway), func(t *testing.T) {
+			t.Parallel()
+
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "text/event-stream")
+				for _, event := range []string{
+					"event: keepalive\ndata: {}\n\n",
+					"data: {\"candidates\":[{\"content\":{\"parts\":[{\"text\":\"hello\"}],\"role\":\"model\"}}]}\n\n",
+					"event: keepalive\ndata: {}\n\n",
+					"event: keepalive\ndata: {}\n\n",
+					"data: {\"candidates\":[{\"content\":{\"parts\":[{\"text\":\" world\"}],\"role\":\"model\"},\"finishReason\":\"STOP\"}],\"usageMetadata\":{\"promptTokenCount\":2,\"candidatesTokenCount\":3,\"totalTokenCount\":5}}\n\n",
+					"event: keepalive\ndata: {}\n\n",
+				} {
+					_, _ = io.WriteString(w, event)
+					w.(http.Flusher).Flush()
+				}
+			}))
+			t.Cleanup(server.Close)
+
+			cfg := &latest.ModelConfig{
+				Provider: "google",
+				Model:    "gemini-3.8-flash",
+				BaseURL:  server.URL,
+			}
+			env := environment.NewMapEnvProvider(map[string]string{
+				"GOOGLE_API_KEY":                  "test-key",
+				environment.DockerDesktopTokenEnv: "test-dd-token",
+			})
+			var opts []options.Opt
+			if gateway {
+				cfg.BaseURL = ""
+				opts = append(opts, options.WithGateway(server.URL))
+			}
+			client, err := NewClient(t.Context(), cfg, env, opts...)
+			require.NoError(t, err)
+
+			stream, err := client.CreateChatCompletionStream(t.Context(), []chat.Message{
+				{Role: chat.MessageRoleUser, Content: "hello"},
+			}, nil)
+			require.NoError(t, err)
+			t.Cleanup(stream.Close)
+
+			for _, text := range []string{"hello", " world"} {
+				response, err := stream.Recv()
+				require.NoError(t, err)
+				require.Len(t, response.Choices, 1)
+				assert.Equal(t, text, response.Choices[0].Delta.Content)
+				assert.Empty(t, response.Choices[0].FinishReason)
+			}
+
+			response, err := stream.Recv()
+			require.NoError(t, err)
+			require.Len(t, response.Choices, 1)
+			assert.Equal(t, chat.FinishReasonStop, response.Choices[0].FinishReason)
+			require.NotNil(t, response.Usage)
+			assert.Equal(t, int64(2), response.Usage.InputTokens)
+			assert.Equal(t, int64(3), response.Usage.OutputTokens)
+
+			_, err = stream.Recv()
+			require.ErrorIs(t, err, io.EOF)
+		})
+	}
+}


### PR DESCRIPTION
The Gemini SDK rejects upstream SSE heartbeat events that arrive as `event: keepalive` with `data: {}`. These frames are valid at the transport layer but cause the SDK to fail parsing when it encounters them unexpectedly.

The fix sits in the shared SSE transport layer: `sseFilter` now drops any event whose SSE `event:` field is exactly `keepalive` before the bytes reach the SDK. All other named and unnamed events pass through unchanged, so no existing behavior is affected beyond silencing those heartbeats.

New unit tests cover the filter directly (named keepalive events are dropped, anonymous data events are preserved), and new Gemini integration tests reproduce the original parse failure on both the direct and gateway paths, then confirm that content, usage metadata, and normal stream completion are correct after the fix.