### PR TITLE
fix: snapshot caller agent before parallel tool dispatch to eliminate transfer_task race

### DIFF
--- a/pkg/runtime/agent_delegation.go
+++ b/pkg/runtime/agent_delegation.go
@@ -192,6 +192,14 @@ type SubSessionConfig struct {
 type delegationRequest struct {
 	SubSessionConfig
 
+	// Caller, when non-nil, is used as the calling agent instead of
+	// re-resolving via resolveSessionAgent inside runForwarding. Callers
+	// that have already resolved the agent (e.g. handleTaskTransfer,
+	// which validates it before calling runForwarding) must set this to
+	// prevent a concurrent swapCurrentAgent from corrupting the identity
+	// read for a second, parallel tool call from the same LLM response.
+	Caller *agent.Agent
+
 	// SwitchCurrentAgent, when true, swaps r.currentAgent to AgentName
 	// for the lifetime of the call and emits AgentSwitching/AgentInfo
 	// events on entry and exit. Used by transfer_task. Mutually
@@ -340,11 +348,18 @@ func (r *LocalRuntime) swapCurrentAgent(ctx context.Context, sessionID string, f
 func (r *LocalRuntime) runForwarding(ctx context.Context, parent *session.Session, evts EventSink, req delegationRequest) (*tools.ToolCallResult, error) {
 	span := trace.SpanFromContext(ctx)
 
-	// The caller resolves from the parent session, not the shared current
-	// agent: a nested transfer from a pinned background session must
-	// attribute events, hooks, and completion to the pinned agent, no
-	// matter where the concurrent foreground loop points (#3886).
-	callerAgent := r.resolveSessionAgent(parent)
+	// Use the pre-resolved caller when provided: handleTaskTransfer already
+	// resolved and validated it before calling runForwarding, so re-reading
+	// the shared current-agent field here would race a concurrent
+	// swapCurrentAgent from a parallel tool call in the same LLM response.
+	// For callers that haven't pre-resolved, fall back to the session-aware
+	// resolver (pinned background sessions return their pinned agent; the
+	// foreground root session returns the shared current agent — safe here
+	// because those callers don't race their own swapCurrentAgent).
+	callerAgent := req.Caller
+	if callerAgent == nil {
+		callerAgent = r.resolveSessionAgent(parent)
+	}
 	if callerAgent == nil {
 		return nil, errors.New("no agent resolved for the parent session")
 	}
@@ -665,7 +680,7 @@ func (r *LocalRuntime) RunAgent(ctx context.Context, params agenttool.RunParams)
 	}, params.OnContent)
 }
 
-func (r *LocalRuntime) handleTaskTransfer(ctx context.Context, sess *session.Session, toolCall tools.ToolCall, evts EventSink, _ tools.Runtime) (*tools.ToolCallResult, error) {
+func (r *LocalRuntime) handleTaskTransfer(ctx context.Context, a *agent.Agent, sess *session.Session, toolCall tools.ToolCall, evts EventSink, _ tools.Runtime) (*tools.ToolCallResult, error) {
 	var params struct {
 		Agent          string `json:"agent"`
 		Task           string `json:"task"`
@@ -675,13 +690,11 @@ func (r *LocalRuntime) handleTaskTransfer(ctx context.Context, sess *session.Ses
 		return nil, fmt.Errorf("invalid arguments: %w", err)
 	}
 
-	// Resolve the caller session-aware: nested transfer_task from a pinned
-	// background session must attribute the call to the pinned agent, not
-	// the shared current agent (#3886).
-	a := r.resolveSessionAgent(sess)
-	if a == nil {
-		return nil, errors.New("no agent resolved for the calling session")
-	}
+	// a is the calling agent, pre-resolved by the dispatcher before the
+	// parallel tool-call loop. Using it directly avoids a race with a
+	// concurrent swapCurrentAgent from another transfer_task goroutine in
+	// the same LLM response batch (which would corrupt a re-read of the
+	// shared current-agent field via resolveSessionAgent).
 	if errResult := validateAgentInList(a.Name(), params.Agent, "transfer task to", "sub-agents list", a.SubAgents()); errResult != nil {
 		return errResult, nil
 	}
@@ -724,6 +737,7 @@ func (r *LocalRuntime) handleTaskTransfer(ctx context.Context, sess *session.Ses
 	defer span.End()
 
 	return r.runForwarding(ctx, sess, evts, delegationRequest{
+		Caller: a,
 		SubSessionConfig: SubSessionConfig{
 			Task:              params.Task,
 			ExpectedOutput:    params.ExpectedOutput,
@@ -739,7 +753,7 @@ func (r *LocalRuntime) handleTaskTransfer(ctx context.Context, sess *session.Ses
 	})
 }
 
-func (r *LocalRuntime) handleHandoff(ctx context.Context, sess *session.Session, toolCall tools.ToolCall, _ EventSink, _ tools.Runtime) (*tools.ToolCallResult, error) {
+func (r *LocalRuntime) handleHandoff(ctx context.Context, _ *agent.Agent, sess *session.Session, toolCall tools.ToolCall, _ EventSink, _ tools.Runtime) (*tools.ToolCallResult, error) {
 	var params handoff.Args
 	if err := json.Unmarshal([]byte(toolCall.Function.Arguments), &params); err != nil {
 		return nil, fmt.Errorf("invalid arguments: %w", err)

--- a/pkg/runtime/agent_delegation_test.go
+++ b/pkg/runtime/agent_delegation_test.go
@@ -636,7 +636,7 @@ func TestTransferTask_PropagatesPermissions(t *testing.T) {
 		},
 	}
 
-	result, err := rt.handleTaskTransfer(t.Context(), sess, toolCall, NewChannelSink(evts), tools.NopRuntime{})
+	result, err := rt.handleTaskTransfer(t.Context(), rt.resolveSessionAgent(sess), sess, toolCall, NewChannelSink(evts), tools.NopRuntime{})
 	require.NoError(t, err)
 	require.NotNil(t, result)
 	assert.False(t, result.IsError, "transfer to valid sub-agent should succeed")
@@ -819,7 +819,7 @@ func TestTransferTask_RejectsDirectCycle(t *testing.T) {
 	sess := session.New(session.WithUserMessage("Test"))
 	evts := make(chan Event, 128)
 
-	result, err := rt.handleTaskTransfer(t.Context(), sess, transferToolCall("root"), NewChannelSink(evts), tools.NopRuntime{})
+	result, err := rt.handleTaskTransfer(t.Context(), rt.resolveSessionAgent(sess), sess, transferToolCall("root"), NewChannelSink(evts), tools.NopRuntime{})
 	require.NoError(t, err)
 	require.NotNil(t, result)
 	assert.True(t, result.IsError)
@@ -869,7 +869,7 @@ func TestTransferTask_NestedFromPinnedBackgroundSession(t *testing.T) {
 	evts := make(chan Event, 128)
 
 	// Delegating back to an ancestor from the pinned child is an indirect cycle.
-	result, err := rt.handleTaskTransfer(t.Context(), child, transferToolCall("root"), NewChannelSink(evts), tools.NopRuntime{})
+	result, err := rt.handleTaskTransfer(t.Context(), rt.resolveSessionAgent(child), child, transferToolCall("root"), NewChannelSink(evts), tools.NopRuntime{})
 	require.NoError(t, err)
 	require.NotNil(t, result)
 	assert.True(t, result.IsError)
@@ -879,7 +879,7 @@ func TestTransferTask_NestedFromPinnedBackgroundSession(t *testing.T) {
 	// Acyclic delegation from the same pinned child is allowed. helper is
 	// not in root's sub-agents, so success also proves the caller resolved
 	// from the pinned session (worker), not the shared current agent (root).
-	result, err = rt.handleTaskTransfer(t.Context(), child, transferToolCall("helper"), NewChannelSink(evts), tools.NopRuntime{})
+	result, err = rt.handleTaskTransfer(t.Context(), rt.resolveSessionAgent(child), child, transferToolCall("helper"), NewChannelSink(evts), tools.NopRuntime{})
 	require.NoError(t, err)
 	require.NotNil(t, result)
 	assert.False(t, result.IsError, "acyclic multi-level delegation must stay supported: %s", result.Output)
@@ -994,7 +994,7 @@ func TestTransferTask_PinnedParentDoesNotMutateSharedCurrentAgent(t *testing.T) 
 	require.Equal(t, "worker", child.AgentName, "background child session must be pinned")
 
 	evts := make(chan Event, 128)
-	result, err := rt.handleTaskTransfer(t.Context(), child, transferToolCall("helper"), NewChannelSink(evts), tools.NopRuntime{})
+	result, err := rt.handleTaskTransfer(t.Context(), rt.resolveSessionAgent(child), child, transferToolCall("helper"), NewChannelSink(evts), tools.NopRuntime{})
 	require.NoError(t, err)
 	require.NotNil(t, result)
 	require.False(t, result.IsError, "nested transfer must succeed: %s", result.Output)
@@ -1056,7 +1056,7 @@ func TestTransferTask_ForegroundSwitchesAndRestoresCurrentAgent(t *testing.T) {
 	sess := session.New(session.WithUserMessage("Test"), session.WithToolsApproved(true))
 	evts := make(chan Event, 128)
 
-	result, err := rt.handleTaskTransfer(t.Context(), sess, transferToolCall("librarian"), NewChannelSink(evts), tools.NopRuntime{})
+	result, err := rt.handleTaskTransfer(t.Context(), rt.resolveSessionAgent(sess), sess, transferToolCall("librarian"), NewChannelSink(evts), tools.NopRuntime{})
 	require.NoError(t, err)
 	require.NotNil(t, result)
 	require.False(t, result.IsError, "transfer must succeed: %s", result.Output)
@@ -1147,7 +1147,7 @@ func TestTransferTask_ConcurrentPinnedNestedTransfersStayIsolated(t *testing.T) 
 		out := make(chan transferOutcome, 1)
 		go func() {
 			evts := make(chan Event, 128)
-			result, err := rt.handleTaskTransfer(t.Context(), child, transferToolCall(target), NewChannelSink(evts), tools.NopRuntime{})
+			result, err := rt.handleTaskTransfer(t.Context(), rt.resolveSessionAgent(child), child, transferToolCall(target), NewChannelSink(evts), tools.NopRuntime{})
 			out <- transferOutcome{result: result, err: err, evts: evts}
 		}()
 		return out
@@ -1211,7 +1211,7 @@ func TestTransferTask_DepthBoundary(t *testing.T) {
 		)
 		evts := make(chan Event, 128)
 
-		result, err := rt.handleTaskTransfer(t.Context(), sess, transferToolCall("librarian"), NewChannelSink(evts), tools.NopRuntime{})
+		result, err := rt.handleTaskTransfer(t.Context(), rt.resolveSessionAgent(sess), sess, transferToolCall("librarian"), NewChannelSink(evts), tools.NopRuntime{})
 		require.NoError(t, err)
 		require.NotNil(t, result)
 		assert.False(t, result.IsError, "delegation at the maximum depth must be allowed: %s", result.Output)
@@ -1228,7 +1228,7 @@ func TestTransferTask_DepthBoundary(t *testing.T) {
 		)
 		evts := make(chan Event, 128)
 
-		result, err := rt.handleTaskTransfer(t.Context(), sess, transferToolCall("librarian"), NewChannelSink(evts), tools.NopRuntime{})
+		result, err := rt.handleTaskTransfer(t.Context(), rt.resolveSessionAgent(sess), sess, transferToolCall("librarian"), NewChannelSink(evts), tools.NopRuntime{})
 		require.NoError(t, err)
 		require.NotNil(t, result)
 		assert.True(t, result.IsError)
@@ -1633,7 +1633,7 @@ func TestRunStream_NestedBackgroundAgents_EndToEnd(t *testing.T) {
 	}
 	var listOut string
 	require.Eventually(t, func() bool {
-		res, err := listHandler(t.Context(), sess, listCall, NewChannelSink(make(chan Event, 4)), tools.NopRuntime{})
+		res, err := listHandler(t.Context(), rt.resolveSessionAgent(sess), sess, listCall, NewChannelSink(make(chan Event, 4)), tools.NopRuntime{})
 		if err != nil {
 			return false
 		}
@@ -1698,4 +1698,103 @@ func TestRunStream_NestedBackgroundAgents_EndToEnd(t *testing.T) {
 
 	assert.Equal(t, "root", rt.CurrentAgent().Name(),
 		"the shared current agent must still be root after the whole chain")
+}
+
+// TestTransferTask_ConcurrentFromUnpinnedForegroundSession is the core
+// regression test for the parallel-dispatch race: when the root (foreground,
+// unpinned) session emits two transfer_task calls in a single LLM response,
+// the dispatcher runs them in parallel via concurrent.MapSlice. Before the
+// fix, the second goroutine called resolveSessionAgent after the first had
+// already invoked swapCurrentAgent, so it resolved to the target agent
+// ("drafter") instead of the caller ("root"), and then failed validation
+// with "Agent drafter cannot transfer task to drafter".
+//
+// After the fix, the dispatcher pre-resolves the caller agent before the
+// parallel loop and passes it as a *agent.Agent parameter to the handler,
+// which never re-reads the shared mutable current-agent field.
+func TestTransferTask_ConcurrentFromUnpinnedForegroundSession(t *testing.T) {
+	t.Parallel()
+
+	// Each call to the drafter agent gets its own stream via a queueProvider
+	// so concurrent RunStream invocations don't fight over a single mock.
+	drafterProv := &queueProvider{id: "test/mock-model", streams: []chat.MessageStream{
+		newStreamBuilder().AddContent("draft chunk 1 done").AddStopWithUsage(10, 5).Build(),
+		newStreamBuilder().AddContent("draft chunk 2 done").AddStopWithUsage(10, 5).Build(),
+	}}
+
+	root := agent.New("root", "Root agent",
+		agent.WithModel(&mockProvider{id: "test/mock-model", stream: &mockStream{}}),
+	)
+	drafter := agent.New("drafter", "Drafter agent",
+		agent.WithModel(drafterProv),
+	)
+	agent.WithSubAgents(drafter)(root)
+
+	tm := team.New(team.WithAgents(root, drafter))
+	rt, err := NewLocalRuntime(t.Context(), tm,
+		WithSessionCompaction(false),
+		WithModelStore(mockModelStore{}),
+	)
+	require.NoError(t, err)
+
+	// The root session is unpinned (AgentName == ""), exactly like the
+	// foreground user session. resolveSessionAgent falls back to
+	// r.Current() for it, which is the field swapCurrentAgent mutates.
+	sess := session.New(session.WithUserMessage("Test"), session.WithToolsApproved(true))
+	require.Empty(t, sess.AgentName, "root session must be unpinned to reproduce the race")
+
+	// Snapshot the caller agent once, before spawning goroutines — exactly
+	// what Dispatcher.Process does (a := d.AgentFor(sess)) before its
+	// concurrent.MapSlice loop. Before the fix, handlers re-resolved inside
+	// each goroutine and could read a post-swap value from r.current.
+	caller := rt.resolveSessionAgent(sess)
+	require.Equal(t, "root", caller.Name(), "pre-dispatch caller must be root")
+
+	// Simulate the parallel-dispatch pattern: two transfer_task calls for
+	// the same drafter agent (two diff chunks), exactly as the root
+	// pr-review agent would emit in a single LLM response.
+	type outcome struct {
+		result *tools.ToolCallResult
+		err    error
+	}
+	transfer := func(id, task string) chan outcome {
+		out := make(chan outcome, 1)
+		go func() {
+			evts := make(chan Event, 128)
+			tc := tools.ToolCall{
+				ID:   id,
+				Type: "function",
+				Function: tools.FunctionCall{
+					Name:      "transfer_task",
+					Arguments: fmt.Sprintf(`{"agent":"drafter","task":%q}`, task),
+				},
+			}
+			// Pass the pre-resolved caller (mirrors what the fixed dispatcher does).
+			result, err := rt.handleTaskTransfer(t.Context(), caller, sess, tc, NewChannelSink(evts), tools.NopRuntime{})
+			out <- outcome{result, err}
+		}()
+		return out
+	}
+
+	outA := transfer("call_chunk1", "review chunk 1")
+	outB := transfer("call_chunk2", "review chunk 2")
+	a := <-outA
+	b := <-outB
+
+	// Both must pass validation. The pre-fix failure was "Agent drafter
+	// cannot transfer task to drafter": the second goroutine mis-resolved
+	// the caller as "drafter" (post-swap) and then validated against the
+	// drafter's empty sub-agent list.
+	require.NoError(t, a.err)
+	require.NotNil(t, a.result)
+	assert.False(t, a.result.IsError,
+		"first concurrent transfer must pass validation, not: %s", a.result.Output)
+
+	require.NoError(t, b.err)
+	require.NotNil(t, b.result)
+	assert.False(t, b.result.IsError,
+		"second concurrent transfer must pass validation, not: %s", b.result.Output)
+
+	assert.Equal(t, "root", rt.CurrentAgent().Name(),
+		"shared current agent must be restored to root after both concurrent transfers complete")
 }

--- a/pkg/runtime/loop.go
+++ b/pkg/runtime/loop.go
@@ -54,7 +54,7 @@ func (r *LocalRuntime) registerDefaultTools() {
 	r.toolMap[sessioncontext.ToolNameReadSession] = r.handleReadSession
 
 	r.bgAgents.RegisterHandlers(func(name string, fn func(context.Context, *session.Session, tools.ToolCall) (*tools.ToolCallResult, error)) {
-		r.toolMap[name] = func(ctx context.Context, sess *session.Session, tc tools.ToolCall, _ EventSink, _ tools.Runtime) (*tools.ToolCallResult, error) {
+		r.toolMap[name] = func(ctx context.Context, _ *agent.Agent, sess *session.Session, tc tools.ToolCall, _ EventSink, _ tools.Runtime) (*tools.ToolCallResult, error) {
 			return fn(ctx, sess, tc)
 		}
 	})

--- a/pkg/runtime/model_picker.go
+++ b/pkg/runtime/model_picker.go
@@ -8,6 +8,7 @@ import (
 	"slices"
 	"strings"
 
+	"github.com/docker/docker-agent/pkg/agent"
 	"github.com/docker/docker-agent/pkg/session"
 	"github.com/docker/docker-agent/pkg/tools"
 	"github.com/docker/docker-agent/pkg/tools/builtin/modelpicker"
@@ -30,7 +31,7 @@ func (r *LocalRuntime) findModelPickerTool() *modelpicker.ToolSet {
 }
 
 // handleChangeModel handles the change_model tool call by switching the current agent's model.
-func (r *LocalRuntime) handleChangeModel(ctx context.Context, _ *session.Session, toolCall tools.ToolCall, events EventSink, _ tools.Runtime) (*tools.ToolCallResult, error) {
+func (r *LocalRuntime) handleChangeModel(ctx context.Context, _ *agent.Agent, _ *session.Session, toolCall tools.ToolCall, events EventSink, _ tools.Runtime) (*tools.ToolCallResult, error) {
 	var params modelpicker.ChangeModelArgs
 	if err := json.Unmarshal([]byte(toolCall.Function.Arguments), &params); err != nil {
 		return nil, fmt.Errorf("invalid arguments: %w", err)
@@ -57,7 +58,7 @@ func (r *LocalRuntime) handleChangeModel(ctx context.Context, _ *session.Session
 }
 
 // handleRevertModel handles the revert_model tool call by reverting the current agent to its default model.
-func (r *LocalRuntime) handleRevertModel(ctx context.Context, _ *session.Session, _ tools.ToolCall, events EventSink, _ tools.Runtime) (*tools.ToolCallResult, error) {
+func (r *LocalRuntime) handleRevertModel(ctx context.Context, _ *agent.Agent, _ *session.Session, _ tools.ToolCall, events EventSink, _ tools.Runtime) (*tools.ToolCallResult, error) {
 	return r.setModelAndEmitInfo(ctx, "", events)
 }
 

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -39,10 +39,12 @@ import (
 	"github.com/docker/docker-agent/pkg/tools/lifecycle"
 )
 
-// ToolHandlerFunc handles a runtime-managed tool call. rt is the dispatcher's
+// ToolHandlerFunc handles a runtime-managed tool call. a is the calling agent,
+// already resolved by the dispatcher before the parallel dispatch loop so
+// concurrent handlers don't race shared mutable state. rt is the dispatcher's
 // per-call handle, used by handlers that need to talk back to the in-flight
 // call (streaming output, asking the user to approve an action).
-type ToolHandlerFunc func(ctx context.Context, sess *session.Session, toolCall tools.ToolCall, events EventSink, rt tools.Runtime) (*tools.ToolCallResult, error)
+type ToolHandlerFunc func(ctx context.Context, a *agent.Agent, sess *session.Session, toolCall tools.ToolCall, events EventSink, rt tools.Runtime) (*tools.ToolCallResult, error)
 
 // Runtime defines the contract for runtime execution
 type Runtime interface {

--- a/pkg/runtime/runtime_test.go
+++ b/pkg/runtime/runtime_test.go
@@ -2716,7 +2716,7 @@ func TestTransferTaskRejectsNonSubAgent(t *testing.T) {
 		},
 	}
 
-	result, err := rt.handleTaskTransfer(t.Context(), sess, toolCall, NewChannelSink(evts), tools.NopRuntime{})
+	result, err := rt.handleTaskTransfer(t.Context(), rt.resolveSessionAgent(sess), sess, toolCall, NewChannelSink(evts), tools.NopRuntime{})
 	require.NoError(t, err)
 	require.NotNil(t, result)
 	assert.True(t, result.IsError, "transfer to non-sub-agent should return an error result")
@@ -2756,7 +2756,7 @@ func TestTransferTaskAllowsSubAgent(t *testing.T) {
 		},
 	}
 
-	result, err := rt.handleTaskTransfer(t.Context(), sess, toolCall, NewChannelSink(evts), tools.NopRuntime{})
+	result, err := rt.handleTaskTransfer(t.Context(), rt.resolveSessionAgent(sess), sess, toolCall, NewChannelSink(evts), tools.NopRuntime{})
 	require.NoError(t, err)
 	require.NotNil(t, result)
 	assert.False(t, result.IsError, "transfer to valid sub-agent should succeed")
@@ -2804,7 +2804,7 @@ func TestTransferTaskPersistsSubSessionOnError(t *testing.T) {
 
 	// runForwarding returns an error because the child emitted an ErrorEvent,
 	// but only *after* persisting the sub-session.
-	_, err = rt.handleTaskTransfer(t.Context(), sess, toolCall, NewChannelSink(evts), tools.NopRuntime{})
+	_, err = rt.handleTaskTransfer(t.Context(), rt.resolveSessionAgent(sess), sess, toolCall, NewChannelSink(evts), tools.NopRuntime{})
 	require.Error(t, err, "transfer should surface the sub-session error to the caller")
 
 	// The parent session must now hold a sub-session item — without the fix

--- a/pkg/runtime/sessioncontext_handlers.go
+++ b/pkg/runtime/sessioncontext_handlers.go
@@ -8,13 +8,14 @@ import (
 	"strings"
 	"time"
 
+	"github.com/docker/docker-agent/pkg/agent"
 	"github.com/docker/docker-agent/pkg/chat"
 	"github.com/docker/docker-agent/pkg/session"
 	"github.com/docker/docker-agent/pkg/tools"
 	"github.com/docker/docker-agent/pkg/tools/builtin/sessioncontext"
 )
 
-func (r *LocalRuntime) handleListSessions(ctx context.Context, sess *session.Session, toolCall tools.ToolCall, _ EventSink, _ tools.Runtime) (*tools.ToolCallResult, error) {
+func (r *LocalRuntime) handleListSessions(ctx context.Context, _ *agent.Agent, sess *session.Session, toolCall tools.ToolCall, _ EventSink, _ tools.Runtime) (*tools.ToolCallResult, error) {
 	if r.sessionStore == nil {
 		return tools.ResultError("session history is not available in this runtime"), nil
 	}
@@ -52,7 +53,7 @@ func (r *LocalRuntime) handleListSessions(ctx context.Context, sess *session.Ses
 	return tools.ResultJSON(infos), nil
 }
 
-func (r *LocalRuntime) handleReadSession(ctx context.Context, sess *session.Session, toolCall tools.ToolCall, _ EventSink, _ tools.Runtime) (*tools.ToolCallResult, error) {
+func (r *LocalRuntime) handleReadSession(ctx context.Context, _ *agent.Agent, sess *session.Session, toolCall tools.ToolCall, _ EventSink, _ tools.Runtime) (*tools.ToolCallResult, error) {
 	if r.sessionStore == nil {
 		return tools.ResultError("session history is not available in this runtime"), nil
 	}

--- a/pkg/runtime/sessionplan_handlers.go
+++ b/pkg/runtime/sessionplan_handlers.go
@@ -7,12 +7,13 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/docker/docker-agent/pkg/agent"
 	"github.com/docker/docker-agent/pkg/session"
 	"github.com/docker/docker-agent/pkg/tools"
 	"github.com/docker/docker-agent/pkg/tools/builtin/sessionplan"
 )
 
-func (r *LocalRuntime) handleWriteSessionPlan(ctx context.Context, sess *session.Session, toolCall tools.ToolCall, events EventSink, _ tools.Runtime) (*tools.ToolCallResult, error) {
+func (r *LocalRuntime) handleWriteSessionPlan(ctx context.Context, _ *agent.Agent, sess *session.Session, toolCall tools.ToolCall, events EventSink, _ tools.Runtime) (*tools.ToolCallResult, error) {
 	var args sessionplan.WriteSessionPlanArgs
 	if err := json.Unmarshal([]byte(toolCall.Function.Arguments), &args); err != nil {
 		return nil, fmt.Errorf("invalid arguments: %w", err)
@@ -33,7 +34,7 @@ func (r *LocalRuntime) handleWriteSessionPlan(ctx context.Context, sess *session
 	return tools.ResultSuccess("Plan saved to " + path), nil
 }
 
-func (r *LocalRuntime) handleReadSessionPlan(_ context.Context, sess *session.Session, _ tools.ToolCall, _ EventSink, _ tools.Runtime) (*tools.ToolCallResult, error) {
+func (r *LocalRuntime) handleReadSessionPlan(_ context.Context, _ *agent.Agent, sess *session.Session, _ tools.ToolCall, _ EventSink, _ tools.Runtime) (*tools.ToolCallResult, error) {
 	content, _, err := sessionplan.ReadContent(sessionplan.DefaultDir(), sess.ID)
 	if errors.Is(err, sessionplan.ErrPlanNotFound) {
 		return tools.ResultError("no plan written yet for this session; call write_session_plan first"), nil
@@ -52,7 +53,7 @@ func (r *LocalRuntime) handleReadSessionPlan(_ context.Context, sess *session.Se
 // call setCurrentAgent here so a CLI that prints results inline, a chat UI
 // with a mode toggle, and a server with a configured handoff can all consume
 // the same marker without one stepping on the other.
-func (r *LocalRuntime) handleExitPlanMode(_ context.Context, sess *session.Session, _ tools.ToolCall, _ EventSink, _ tools.Runtime) (*tools.ToolCallResult, error) {
+func (r *LocalRuntime) handleExitPlanMode(_ context.Context, _ *agent.Agent, sess *session.Session, _ tools.ToolCall, _ EventSink, _ tools.Runtime) (*tools.ToolCallResult, error) {
 	if _, _, err := sessionplan.ReadContent(sessionplan.DefaultDir(), sess.ID); err != nil {
 		if errors.Is(err, sessionplan.ErrPlanNotFound) {
 			return tools.ResultError("no plan to mark ready; call write_session_plan before exit_plan_mode"), nil

--- a/pkg/runtime/skill_runner.go
+++ b/pkg/runtime/skill_runner.go
@@ -10,6 +10,7 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 
+	"github.com/docker/docker-agent/pkg/agent"
 	"github.com/docker/docker-agent/pkg/session"
 	"github.com/docker/docker-agent/pkg/telemetry/genai"
 	"github.com/docker/docker-agent/pkg/tools"
@@ -18,7 +19,7 @@ import (
 
 // handleRunSkill unmarshals the run_skill tool arguments and delegates to
 // runSkillFork.
-func (r *LocalRuntime) handleRunSkill(ctx context.Context, sess *session.Session, toolCall tools.ToolCall, evts EventSink, rt tools.Runtime) (*tools.ToolCallResult, error) {
+func (r *LocalRuntime) handleRunSkill(ctx context.Context, _ *agent.Agent, sess *session.Session, toolCall tools.ToolCall, evts EventSink, rt tools.Runtime) (*tools.ToolCallResult, error) {
 	var args skills.RunSkillArgs
 	if err := json.Unmarshal([]byte(toolCall.Function.Arguments), &args); err != nil {
 		return nil, fmt.Errorf("invalid arguments: %w", err)

--- a/pkg/runtime/tool_dispatch.go
+++ b/pkg/runtime/tool_dispatch.go
@@ -35,8 +35,8 @@ func (r *LocalRuntime) processToolCalls(ctx context.Context, sess *session.Sessi
 	// toolexec.ToolHandler doesn't.
 	handlers := make(map[string]toolexec.ToolHandler, len(r.toolMap))
 	for name, h := range r.toolMap {
-		handlers[name] = func(ctx context.Context, sess *session.Session, tc tools.ToolCall, rt tools.Runtime) (*tools.ToolCallResult, error) {
-			return h(ctx, sess, tc, events, rt)
+		handlers[name] = func(ctx context.Context, a *agent.Agent, sess *session.Session, tc tools.ToolCall, rt tools.Runtime) (*tools.ToolCallResult, error) {
+			return h(ctx, a, sess, tc, events, rt)
 		}
 	}
 

--- a/pkg/runtime/toolexec/dispatcher.go
+++ b/pkg/runtime/toolexec/dispatcher.go
@@ -137,7 +137,11 @@ type HookDispatcher interface {
 // ToolCall/ToolCallResponse themselves. Handlers that need to emit other
 // event types should be wired by the caller to capture the relevant
 // channel via closure when registering the handler.
-type ToolHandler func(ctx context.Context, sess *session.Session, tc tools.ToolCall, rt tools.Runtime) (*tools.ToolCallResult, error)
+//
+// a is the calling agent, already resolved by Process before the parallel
+// dispatch loop — handlers must use it instead of re-reading any shared
+// current-agent field, which may be mutated by a concurrent transfer.
+type ToolHandler func(ctx context.Context, a *agent.Agent, sess *session.Session, tc tools.ToolCall, rt tools.Runtime) (*tools.ToolCallResult, error)
 
 // ResumeRequest carries the user's response to a tool-confirmation prompt.
 // The runtime aliases this type publicly via runtime.ResumeRequest so the
@@ -1036,7 +1040,7 @@ func (c *call) runToolset(ctx context.Context) CallOutcome {
 func (c *call) runHandler(ctx context.Context, handler ToolHandler) CallOutcome {
 	_, stop := c.invoke(ctx, "runtime.tool.handler.runtime", func(ctx context.Context) (*tools.ToolCallResult, time.Duration, error) {
 		start := time.Now()
-		res, err := handler(ctx, c.sess, c.tc, callRuntime{c})
+		res, err := handler(ctx, c.a, c.sess, c.tc, callRuntime{c})
 		return res, time.Since(start), err
 	})
 	if stop != nil {

--- a/pkg/runtime/toolexec/dispatcher_test.go
+++ b/pkg/runtime/toolexec/dispatcher_test.go
@@ -270,7 +270,7 @@ func TestDispatcher_RoutesToRuntimeHandler(t *testing.T) {
 	d := &toolexec.Dispatcher{
 		AgentFor: func(*session.Session) *agent.Agent { return a },
 		Handlers: map[string]toolexec.ToolHandler{
-			"transfer_task": func(_ context.Context, _ *session.Session, _ tools.ToolCall, _ tools.Runtime) (*tools.ToolCallResult, error) {
+			"transfer_task": func(_ context.Context, _ *agent.Agent, _ *session.Session, _ tools.ToolCall, _ tools.Runtime) (*tools.ToolCallResult, error) {
 				handlerCalls++
 				return tools.ResultSuccess("transferred"), nil
 			},
@@ -306,7 +306,7 @@ func TestDispatcher_RuntimeHandlerPropagatesNestedStop(t *testing.T) {
 	d := &toolexec.Dispatcher{
 		AgentFor: func(*session.Session) *agent.Agent { return a },
 		Handlers: map[string]toolexec.ToolHandler{
-			"run_skill": func(ctx context.Context, _ *session.Session, _ tools.ToolCall, rt tools.Runtime) (*tools.ToolCallResult, error) {
+			"run_skill": func(ctx context.Context, _ *agent.Agent, _ *session.Session, _ tools.ToolCall, rt tools.Runtime) (*tools.ToolCallResult, error) {
 				_, err := rt.ConfirmAndRun(ctx, echoCommand, execDone)
 				if err != nil {
 					return nil, err


### PR DESCRIPTION
## what

When the root (foreground, unpinned) session emits two or more `transfer_task` calls in a single LLM response, the dispatcher runs them concurrently via `concurrent.MapSlice`. The second goroutine called `resolveSessionAgent(sess)` after the first had already invoked `swapCurrentAgent`, so it resolved the caller as the target agent instead of the root agent, failing validation with:

```
Agent drafter cannot transfer task to drafter:
target agent not in sub-agents list. No agents are configured in this list.
```

This produced a 19.2% "Review incomplete" spike in the review pipeline after bumping docker-agent from v1.121.0 to v1.131.0 (where multi-chunk PRs caused the LLM to emit parallel `transfer_task` calls more frequently).

## fix

Two cooperating changes:

1. **`toolexec.ToolHandler` and `runtime.ToolHandlerFunc`** now include `*agent.Agent` as the second parameter. `Dispatcher.Process` already resolves `a := d.AgentFor(sess)` once before the parallel loop; passing it to every handler ensures each goroutine uses the same pre-dispatch snapshot regardless of concurrent `r.current` mutations.

2. **`handleTaskTransfer`** uses the passed `*agent.Agent` directly for validation and passes it as `delegationRequest.Caller` so `runForwarding` also uses the pre-resolved identity for hook attribution and `SubSessionCompleted` events.

All other handlers accept the parameter but ignore it (marked `_`).

## test

`TestTransferTask_ConcurrentFromUnpinnedForegroundSession` - two concurrent `transfer_task` calls from the same unpinned foreground session (the exact pattern the pr-review root agent emits for multi-chunk diffs). Before the fix: second call fails with the drafter-self-delegation error. After: both pass validation and complete successfully.

Verified existing `TestTransferTask_ForegroundSwitchesAndRestoresCurrentAgent` and all delegation tests still pass.

Closes: the transfer_task race condition reported in the v2.0.6 "Review incomplete" regression.