### PR TITLE
feat(hooks): sequential pipeline for pre_tool_use, before_llm_call, and tool_response_transform

### DIFF
--- a/docs/configuration/hooks/index.md
+++ b/docs/configuration/hooks/index.md
@@ -394,7 +394,7 @@ The `hook_specific_output` for `pre_tool_use` (and `permission_request`) support
 | ---------------------------- | ------ | --------------------------------------- |
 | `permission_decision`        | string | `allow`, `deny`, or `ask`               |
 | `permission_decision_reason` | string | Explanation for the decision            |
-| `updated_input`              | object | Modified tool input (replaces original) |
+| `updated_input`              | object | Top-level patch to the current tool input (`pre_tool_use` default lane only); omitted keys are preserved |
 | `metadata`                   | object | (`permission_request` and `pre_tool_use` entries with `preempt_yolo: true` only) string key/value annotations merged onto the tool-call confirmation prompt — see below |
 
 ### Preempting auto-approval from `pre_tool_use`
@@ -459,6 +459,59 @@ The `hook_specific_output` for `tool_response_transform` supports:
 | `updated_tool_response` | string | Rewritten tool output (replaces the original) |
 
 This is the symmetric counterpart of `pre_tool_use`'s `updated_input`, applied to tool **results** instead of tool **arguments**. The rewrite reaches every downstream consumer — event subscribers, the persisted session file, the `post_tool_use` hook input, and the next LLM call. Use it to truncate excessive output, scrub PII, or normalise tool dialects. The built-in `redact_secrets` registers itself on this event as the third leg of the redact_secrets feature.
+
+### Composing transformations
+
+Hooks for the following events run **sequentially in configuration order**:
+
+| Event | Rewrite field | What the next hook receives |
+| ----- | ------------- | --------------------------- |
+| `pre_tool_use` (default lane) | `updated_input` | `tool_input` with the patch applied |
+| `before_llm_call` | `updated_messages` | The rewritten `messages` array |
+| `tool_response_transform` | `updated_tool_response` | The rewritten `tool_response` string |
+
+Every matching hook on these events participates in the sequence, whether it
+rewrites, observes, or returns a verdict. Each hook sees the most recent
+successful rewrite. Hooks that return no rewrite leave the current value
+unchanged; the runtime receives the final result of the sequence.
+
+`updated_input` patches replace only the top-level keys they supply. Other
+arguments are preserved; nested objects are replaced, not deep-merged. An empty
+patch does not clear the arguments. Omitting a key no longer removes it; this
+patch protocol does not support key deletion. `updated_messages` replaces the entire
+message array, with an empty array treated as no rewrite. An explicit empty
+`updated_tool_response` **does** clear the response.
+
+Verdicts still aggregate across all matching hooks: a later allow cannot undo
+a denial, and `pre_tool_use` keeps `deny > ask > allow` precedence. Blocking
+verdicts do not short-circuit the remaining hooks. Failed invocations contribute
+no rewrite and keep the existing error-policy behavior. Each hook retains its
+own timeout, so pipeline latency can add up across hooks.
+
+Other events, including `preempt_yolo: true` checks and `before_compaction`,
+continue to run concurrently. Preempting checks do not apply input rewrites;
+compaction summaries still use the first non-empty result in configuration order.
+
+The automatically injected `limit_large_tool_results` hook is appended after
+configured response transformers and automatic secret redaction. This lets
+redaction scrub the full response **before** the limiter writes it to disk and
+returns a bounded excerpt. For example:
+
+```yaml
+hooks:
+  tool_response_transform:
+    - matcher: "*"
+      hooks:
+        - type: builtin
+          command: redact_secrets
+        - type: command
+          command: ./normalize-output.sh
+# The automatic large-result limiter follows these hooks.
+```
+
+`normalize-output.sh` receives the redacted `tool_response` and can return its
+own `updated_tool_response`. Place redaction before any custom hook that must
+not receive raw secrets. See [the example configuration](https://github.com/docker/docker-agent/blob/main/examples/redact_secrets_hooks.yaml).
 
 ### Context-Contributing Events
 
@@ -949,4 +1002,4 @@ $ docker agent run myorg/coder \
 > [!NOTE]
 > **Merging behavior**
 >
-> Agent-config, global, drop-in, and CLI hooks are additive. For each event, hooks run in this order: agent-config hooks first, then global hooks from `settings.hooks`, then [hook drop-ins](#hook-drop-in-files-hooksd) from `hooks.d/`, then CLI hooks. No source replaces another, and individual agents cannot opt out of global hooks.
+> Agent-config, global, drop-in, and CLI hooks are additive. For each event, configuration order is: agent-config hooks first, then global hooks from `settings.hooks`, then [hook drop-ins](#hook-drop-in-files-hooksd) from `hooks.d/`, then CLI hooks. Transformation pipelines execute in this order; concurrent events aggregate results in this order. No source replaces another, and individual agents cannot opt out of global hooks.

--- a/examples/redact_secrets_hooks.yaml
+++ b/examples/redact_secrets_hooks.yaml
@@ -8,8 +8,8 @@
 #
 #   * scope the rewrite to a subset of tools (set `matcher:` to a
 #     regex instead of `*`),
-#   * stack additional rewriters in a specific order (e.g. truncate
-#     long outputs before scrubbing them),
+#   * stack additional rewriters in a specific order (e.g. redact
+#     secrets before truncating long outputs),
 #   * or inspect at a glance which leak vectors a given agent covers.
 #
 # All three legs of the feature share the SAME builtin name
@@ -53,3 +53,8 @@ agents:
           hooks:
             - type: builtin
               command: redact_secrets
+            # Receives the redacted response and spills only scrubbed content.
+            # Explicit here for clarity; the runtime also appends it automatically.
+            # Deduplication keeps this invocation and skips the automatic duplicate.
+            - type: builtin
+              command: limit_large_tool_results

--- a/pkg/hooks/builtins/builtins.go
+++ b/pkg/hooks/builtins/builtins.go
@@ -165,10 +165,6 @@ func ApplyAgentDefaults(cfg *hooks.Config, d AgentDefaults) *hooks.Config {
 	if cfg == nil {
 		cfg = &hooks.Config{}
 	}
-	cfg.ToolResponseTransform = append([]hooks.MatcherConfig{{
-		Matcher: "*",
-		Hooks:   []hooks.Hook{builtinHook(LimitLargeToolResults)},
-	}}, cfg.ToolResponseTransform...)
 	cfg.SessionEnd = append(cfg.SessionEnd, builtinHook(LimitLargeToolResults))
 	if d.AddDate {
 		cfg.TurnStart = append(cfg.TurnStart, builtinHook(AddDate))
@@ -201,6 +197,11 @@ func ApplyAgentDefaults(cfg *hooks.Config, d AgentDefaults) *hooks.Config {
 			Hooks:   []hooks.Hook{builtinHook(RedactSecrets)},
 		})
 	}
+	// Redact before the limiter writes oversized responses to disk.
+	cfg.ToolResponseTransform = append(cfg.ToolResponseTransform, hooks.MatcherConfig{
+		Matcher: "*",
+		Hooks:   []hooks.Hook{builtinHook(LimitLargeToolResults)},
+	})
 	if cfg.IsEmpty() {
 		return nil
 	}

--- a/pkg/hooks/builtins/builtins_test.go
+++ b/pkg/hooks/builtins/builtins_test.go
@@ -9,12 +9,14 @@ import (
 	"testing"
 	"time"
 
+	"github.com/docker/portcullis"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/docker/docker-agent/pkg/hooks"
 	"github.com/docker/docker-agent/pkg/hooks/builtins"
 	"github.com/docker/docker-agent/pkg/httpclient"
+	"github.com/docker/docker-agent/pkg/internal/portcullistest"
 )
 
 // TestRegisterInstallsAllBuiltins pins the public contract of [Register]:
@@ -816,4 +818,56 @@ func TestApplyAgentDefaultsAppendsToUserHooks(t *testing.T) {
 	require.Len(t, got.TurnStart, 2)
 	assert.Equal(t, user, got.TurnStart[0])
 	assert.Equal(t, builtins.AddDate, got.TurnStart[1].Command)
+}
+
+func TestApplyAgentDefaultsOrdersTransformsBeforeLimiter(t *testing.T) {
+	t.Parallel()
+
+	for _, redact := range []bool{false, true} {
+		cfg := builtins.ApplyAgentDefaults(&hooks.Config{
+			ToolResponseTransform: []hooks.MatcherConfig{{Hooks: []hooks.Hook{{Type: hooks.HookTypeBuiltin, Command: "custom"}}}},
+		}, builtins.AgentDefaults{RedactSecrets: redact})
+		var names []string
+		for _, matcher := range cfg.ToolResponseTransform {
+			for _, hook := range matcher.Hooks {
+				names = append(names, hook.Command)
+			}
+		}
+		want := []string{"custom"}
+		if redact {
+			want = append(want, builtins.RedactSecrets)
+		}
+		want = append(want, builtins.LimitLargeToolResults)
+		assert.Equal(t, want, names)
+	}
+}
+
+func TestTransformPipelineRedactsBeforeSpillingLargeOutput(t *testing.T) {
+	t.Setenv("TMPDIR", t.TempDir())
+
+	secret := portcullistest.FakeGitHubPAT("cxLeRrvbJfmYdUtr70xnNE3Q7Gvli4")
+	original := secret + "\n" + strings.Repeat("safe output\n", 6000) + secret + "\n"
+	for _, manual := range []bool{false, true} {
+		cfg := &hooks.Config{}
+		if manual {
+			cfg.ToolResponseTransform = []hooks.MatcherConfig{{Hooks: []hooks.Hook{{Type: hooks.HookTypeBuiltin, Command: builtins.RedactSecrets}}}}
+		}
+		cfg = builtins.ApplyAgentDefaults(cfg, builtins.AgentDefaults{RedactSecrets: !manual})
+		registry := hooks.NewRegistry()
+		require.NoError(t, builtins.Register(registry))
+		exec := hooks.NewExecutorWithRegistry(cfg, t.TempDir(), nil, registry)
+		result, err := exec.Dispatch(t.Context(), hooks.EventToolResponseTransform, &hooks.Input{
+			SessionID: "redaction-pipeline", ToolName: "shell", ToolCategory: "shell", ToolResponse: original,
+		})
+		require.NoError(t, err)
+		require.NotNil(t, result.UpdatedToolResponse)
+		updated := *result.UpdatedToolResponse
+		assert.Contains(t, updated, "Tool call result was too large")
+		assert.NotContains(t, updated, secret)
+		assert.Contains(t, updated, portcullis.Marker)
+
+		stored, err := os.ReadFile(extractLargeResultPath(t, updated))
+		require.NoError(t, err)
+		assert.Equal(t, portcullis.Redact(original), string(stored))
+	}
 }

--- a/pkg/hooks/builtins/redact_secrets.go
+++ b/pkg/hooks/builtins/redact_secrets.go
@@ -70,10 +70,7 @@ func redactSecrets(_ context.Context, in *hooks.Input, _ []string) (*hooks.Outpu
 // a nil [hooks.Output] so unaffected tool calls take the cheap path
 // through the executor.
 //
-// The returned UpdatedInput contains ONLY keys whose value was
-// actually rewritten. This matters because pre_tool_use hooks run
-// concurrently and aggregate via shallow maps.Copy: emitting unchanged
-// keys would clobber another hook's modifications on the same input.
+// UpdatedInput contains only changed top-level keys; the pipeline preserves the rest.
 func redactToolArgs(in *hooks.Input) *hooks.Output {
 	if len(in.ToolInput) == 0 {
 		return nil

--- a/pkg/hooks/builtins/redact_secrets_test.go
+++ b/pkg/hooks/builtins/redact_secrets_test.go
@@ -19,10 +19,7 @@ func fakeGitHubPAT() string {
 
 // TestRedactSecretsScrubsTopLevelStringValue: a recognised secret in
 // a top-level string argument is replaced and ONLY the rewritten key
-// is emitted in UpdatedInput. The latter is critical because
-// pre_tool_use hooks aggregate via shallow maps.Copy in config order
-// — returning unchanged keys would clobber concurrent hooks'
-// modifications.
+// is emitted in UpdatedInput.
 func TestRedactSecretsScrubsTopLevelStringValue(t *testing.T) {
 	t.Parallel()
 
@@ -48,7 +45,7 @@ func TestRedactSecretsScrubsTopLevelStringValue(t *testing.T) {
 	assert.NotContains(t, cmd, secret, "raw secret must be gone")
 	assert.Contains(t, cmd, portcullis.Marker)
 	assert.NotContains(t, updated, "timeout",
-		"unchanged keys must NOT appear in UpdatedInput (would clobber concurrent hooks)")
+		"unchanged keys need no patch")
 	assert.Equal(t, hooks.EventPreToolUse, out.HookSpecificOutput.HookEventName)
 }
 

--- a/pkg/hooks/executor.go
+++ b/pkg/hooks/executor.go
@@ -160,7 +160,8 @@ func (e *Executor) Has(event EventType) bool {
 // Dispatch runs the hooks registered for event and aggregates their
 // verdicts into a single [Result]. Sets input.HookEventName so handlers
 // don't have to remember. Defaults [Input.Cwd] to the executor's
-// working directory when the caller didn't supply one.
+// working directory when the caller didn't supply one. Rewrite-capable
+// events run sequentially; all other events run concurrently.
 //
 // EventPreToolUsePreYolo is an internal sentinel for the preempt-yolo
 // lane of pre_tool_use. Hooks on this lane see input.HookEventName =
@@ -215,11 +216,16 @@ func (e *Executor) Dispatch(ctx context.Context, event EventType, input *Input) 
 		return nil, fmt.Errorf("failed to serialize hook input: %w", err)
 	}
 
-	results := concurrent.MapSlice(hooks, func(hook Hook) hookResult {
-		return e.runHook(ctx, hook, inputJSON)
-	})
-
-	final := aggregate(results, event)
+	var final *Result
+	switch event {
+	case EventPreToolUse, EventBeforeLLMCall, EventToolResponseTransform:
+		final = e.runPipeline(ctx, event, hooks, *input, inputJSON)
+	default:
+		results := concurrent.MapSlice(hooks, func(hook Hook) hookResult {
+			return e.runHook(ctx, hook, inputJSON)
+		})
+		final = aggregate(results, event)
+	}
 	annotateHookSpan(span, event, final)
 	return final, nil
 }
@@ -523,22 +529,10 @@ func aggregate(results []hookResult, event EventType) *Result {
 				// is to skip the LLM entirely).
 				final.Summary = hso.Summary
 			}
-			if event == EventBeforeLLMCall && len(hso.UpdatedMessages) > 0 && final.UpdatedMessages == nil {
-				// First non-empty rewrite in CONFIG ORDER wins, same
-				// determinism guarantee as Summary above. Concurrent
-				// hooks all see the SAME input snapshot, so chaining two
-				// independent rewrites here would silently throw one
-				// away — callers wanting composition must do it inside
-				// a single hook.
+			if event == EventBeforeLLMCall && len(hso.UpdatedMessages) > 0 {
 				final.UpdatedMessages = hso.UpdatedMessages
 			}
-			if event == EventToolResponseTransform && hso.UpdatedToolResponse != nil && final.UpdatedToolResponse == nil {
-				// First non-nil rewrite in CONFIG ORDER wins (same
-				// determinism + composition trade-off as UpdatedMessages
-				// above). Pointer-typed: an explicit empty-string rewrite
-				// is honoured — the runtime applies *result =
-				// *UpdatedToolResponse verbatim, so a hook that wants to
-				// blank a leaky tool's output entirely can do so.
+			if event == EventToolResponseTransform && hso.UpdatedToolResponse != nil {
 				final.UpdatedToolResponse = hso.UpdatedToolResponse
 			}
 			if (event == EventPermissionRequest || event == EventPreToolUsePreYolo) && len(hso.Metadata) > 0 {

--- a/pkg/hooks/pipeline.go
+++ b/pkg/hooks/pipeline.go
@@ -1,0 +1,68 @@
+package hooks
+
+import (
+	"context"
+	"fmt"
+	"maps"
+)
+
+// runPipeline passes each accepted rewrite to the next hook without changing
+// the caller's input. Verdicts still aggregate across every matching hook.
+func (e *Executor) runPipeline(ctx context.Context, event EventType, hooks []Hook, input Input, inputJSON []byte) *Result {
+	results := make([]hookResult, 0, len(hooks))
+	for _, hook := range hooks {
+		results = append(results, e.runHook(ctx, hook, inputJSON))
+		r := &results[len(results)-1]
+		if r.err != nil || r.ExitCode != 0 || r.Output == nil || r.Output.HookSpecificOutput == nil {
+			continue
+		}
+
+		next, changed := rewrittenInput(input, event, r.Output.HookSpecificOutput)
+		if !changed {
+			continue
+		}
+		nextJSON, err := next.ToJSON()
+		if err != nil {
+			// Discard this failed hook's output, but retain all earlier verdicts and rewrites.
+			r.err = fmt.Errorf("hook %q: serialize rewritten input: %w", hook.DisplayName(), err)
+			r.ExitCode = -1
+			r.Output = nil
+			continue
+		}
+		input, inputJSON = next, nextJSON
+	}
+
+	final := aggregate(results, event)
+	if final.ModifiedInput != nil {
+		// The runtime replaces tool arguments with this complete, patched input.
+		final.ModifiedInput = input.ToolInput
+	}
+	return final
+}
+
+func rewrittenInput(input Input, event EventType, out *HookSpecificOutput) (Input, bool) {
+	switch event {
+	case EventPreToolUse:
+		if out.UpdatedInput == nil {
+			return input, false
+		}
+		input.ToolInput = maps.Clone(input.ToolInput)
+		if input.ToolInput == nil {
+			input.ToolInput = make(map[string]any)
+		}
+		maps.Copy(input.ToolInput, out.UpdatedInput)
+	case EventBeforeLLMCall:
+		if len(out.UpdatedMessages) == 0 {
+			return input, false
+		}
+		input.Messages = out.UpdatedMessages
+	case EventToolResponseTransform:
+		if out.UpdatedToolResponse == nil {
+			return input, false
+		}
+		input.ToolResponse = *out.UpdatedToolResponse
+	default:
+		return input, false
+	}
+	return input, true
+}

--- a/pkg/hooks/pipeline_test.go
+++ b/pkg/hooks/pipeline_test.go
@@ -1,0 +1,362 @@
+package hooks
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+	"testing/synctest"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/docker/docker-agent/pkg/chat"
+)
+
+func TestPipelineToolInputPatchesCompose(t *testing.T) {
+	t.Parallel()
+
+	registry := NewRegistry()
+	require.NoError(t, registry.RegisterBuiltin("append", func(_ context.Context, in *Input, args []string) (*Output, error) {
+		assert.Equal(t, "work", in.ToolInput["cwd"])
+		return &Output{HookSpecificOutput: &HookSpecificOutput{
+			UpdatedInput: map[string]any{"cmd": in.ToolInput["cmd"].(string) + args[0]},
+		}}, nil
+	}))
+	exec := NewExecutorWithRegistry(&Config{PreToolUse: []MatcherConfig{
+		{Matcher: "other", Hooks: []Hook{{Type: HookTypeCommand, Command: "exit 2"}}},
+		{Matcher: "shell", Hooks: []Hook{
+			{Type: HookTypeCommand, Command: `echo '{"hook_specific_output":{"updated_input":{"cmd":"ls"}}}'`},
+			{Type: HookTypeBuiltin, Command: "append", Args: []string{" -l"}},
+		}},
+		{Matcher: "*", Hooks: []Hook{{Type: HookTypeBuiltin, Command: "append", Args: []string{" -h"}}}},
+	}}, t.TempDir(), nil, registry)
+	original := map[string]any{"cmd": "original", "cwd": "work", "nested": map[string]any{"keep": true}}
+	in := &Input{ToolName: "shell", ToolInput: original}
+
+	result, err := exec.Dispatch(t.Context(), EventPreToolUse, in)
+	require.NoError(t, err)
+	assert.True(t, result.Allowed)
+	assert.Equal(t, map[string]any{"cmd": "ls -l -h", "cwd": "work", "nested": map[string]any{"keep": true}}, result.ModifiedInput)
+	assert.Equal(t, "original", original["cmd"])
+	assert.Equal(t, original, in.ToolInput)
+}
+
+func TestPipelineMessagesCompose(t *testing.T) {
+	t.Parallel()
+
+	registry := NewRegistry()
+	require.NoError(t, registry.RegisterBuiltin("append", func(_ context.Context, in *Input, args []string) (*Output, error) {
+		in.Messages[0].Content += args[0]
+		return &Output{HookSpecificOutput: &HookSpecificOutput{UpdatedMessages: in.Messages}}, nil
+	}))
+	require.NoError(t, registry.RegisterBuiltin("empty", func(_ context.Context, in *Input, _ []string) (*Output, error) {
+		assert.Equal(t, "original-a-b", in.Messages[0].Content)
+		return &Output{HookSpecificOutput: &HookSpecificOutput{UpdatedMessages: []chat.Message{}}}, nil
+	}))
+	exec := NewExecutorWithRegistry(&Config{BeforeLLMCall: []Hook{
+		{Type: HookTypeBuiltin, Command: "append", Args: []string{"-a"}},
+		{Type: HookTypeCommand, Command: "echo '{}'"},
+		{Type: HookTypeBuiltin, Command: "append", Args: []string{"-b"}},
+		{Type: HookTypeBuiltin, Command: "empty"},
+	}}, t.TempDir(), nil, registry)
+	in := &Input{Messages: []chat.Message{{Role: chat.MessageRoleUser, Content: "original"}}}
+
+	result, err := exec.Dispatch(t.Context(), EventBeforeLLMCall, in)
+	require.NoError(t, err)
+	require.Len(t, result.UpdatedMessages, 1)
+	assert.Equal(t, "original-a-b", result.UpdatedMessages[0].Content)
+	assert.Equal(t, "original", in.Messages[0].Content)
+}
+
+func TestPipelineToolResponseComposesAndPreservesEmptyRewrite(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name          string
+		clearResponse bool
+		want          string
+	}{
+		{name: "append", want: "first-second"},
+		{name: "clear", clearResponse: true, want: ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			registry := NewRegistry()
+			require.NoError(t, registry.RegisterBuiltin("rewrite", func(_ context.Context, in *Input, _ []string) (*Output, error) {
+				assert.Equal(t, "first", in.ToolResponse)
+				updated := in.ToolResponse.(string) + "-second"
+				if tc.clearResponse {
+					updated = ""
+				}
+				return &Output{HookSpecificOutput: &HookSpecificOutput{UpdatedToolResponse: &updated}}, nil
+			}))
+			require.NoError(t, registry.RegisterBuiltin("observe", func(_ context.Context, in *Input, _ []string) (*Output, error) {
+				assert.Equal(t, tc.want, in.ToolResponse)
+				return nil, nil
+			}))
+			exec := NewExecutorWithRegistry(&Config{ToolResponseTransform: []MatcherConfig{{Hooks: []Hook{
+				{Type: HookTypeCommand, Command: `echo '{"hook_specific_output":{"updated_tool_response":"first"}}'`},
+				{Type: HookTypeBuiltin, Command: "rewrite"},
+				{Type: HookTypeBuiltin, Command: "observe"},
+			}}}}, t.TempDir(), nil, registry)
+			in := &Input{ToolName: "shell", ToolResponse: "original"}
+
+			result, err := exec.Dispatch(t.Context(), EventToolResponseTransform, in)
+			require.NoError(t, err)
+			require.NotNil(t, result.UpdatedToolResponse)
+			assert.Equal(t, tc.want, *result.UpdatedToolResponse)
+			assert.Equal(t, "original", in.ToolResponse)
+		})
+	}
+}
+
+func TestPipelineToolInputEmptyPatch(t *testing.T) {
+	t.Parallel()
+
+	for _, input := range []map[string]any{nil, {"cmd": "original", "cwd": "work"}} {
+		exec := NewExecutor(&Config{PreToolUse: []MatcherConfig{{Hooks: []Hook{
+			{Type: HookTypeCommand, Command: `echo '{"hook_specific_output":{"updated_input":{}}}'`},
+		}}}}, t.TempDir(), nil)
+		result, err := exec.Dispatch(t.Context(), EventPreToolUse, &Input{ToolInput: input})
+		require.NoError(t, err)
+		require.NotNil(t, result.ModifiedInput)
+		assert.Len(t, result.ModifiedInput, len(input))
+		for key, value := range input {
+			assert.Equal(t, value, result.ModifiedInput[key])
+		}
+	}
+}
+
+func TestPipelineNoRewrite(t *testing.T) {
+	t.Parallel()
+
+	for _, event := range []EventType{EventPreToolUse, EventBeforeLLMCall, EventToolResponseTransform} {
+		t.Run(string(event), func(t *testing.T) {
+			t.Parallel()
+			exec := pipelineTestExecutor(t, event, []Hook{{Type: HookTypeCommand, Command: "echo '{}'"}}, NewRegistry())
+			result, err := exec.Dispatch(t.Context(), event, &Input{ToolInput: map[string]any{"cmd": "original"}})
+			require.NoError(t, err)
+			assert.Nil(t, result.ModifiedInput)
+			assert.Nil(t, result.UpdatedMessages)
+			assert.Nil(t, result.UpdatedToolResponse)
+		})
+	}
+}
+
+func TestPipelineFailuresKeepPriorRewriteAndRunRemainingHooks(t *testing.T) {
+	t.Parallel()
+
+	for _, event := range []EventType{EventPreToolUse, EventBeforeLLMCall, EventToolResponseTransform} {
+		for _, tc := range []struct {
+			name    string
+			result  HandlerResult
+			err     error
+			onError string
+			blocked bool
+		}{
+			{name: "execution error", err: errors.New("failed"), onError: "block", blocked: true},
+			{name: "canceled", err: context.Canceled, onError: "block", blocked: true},
+			{name: "nonblocking exit", result: HandlerResult{ExitCode: 1}},
+			{name: "blocking exit", result: HandlerResult{ExitCode: 2}, blocked: true},
+		} {
+			t.Run(string(event)+"/"+tc.name, func(t *testing.T) {
+				t.Parallel()
+				registry := NewRegistry()
+				lastRan := false
+				registry.Register("test", func(_ HandlerEnv, hook Hook) (Handler, error) {
+					return pipelineHandlerFunc(func(_ context.Context, data []byte) (HandlerResult, error) {
+						var in Input
+						if err := json.Unmarshal(data, &in); err != nil {
+							return HandlerResult{}, err
+						}
+						if hook.Command == "last" {
+							lastRan = true
+							assert.Equal(t, "first", in.ToolInput["cmd"])
+							assert.Equal(t, "first", in.Messages[0].Content)
+							assert.Equal(t, "first", in.ToolResponse)
+							return HandlerResult{}, nil
+						}
+						res := tc.result
+						response := "discarded"
+						res.Output = &Output{HookSpecificOutput: &HookSpecificOutput{
+							UpdatedInput: map[string]any{"cmd": response}, UpdatedMessages: []chat.Message{{Content: response}}, UpdatedToolResponse: &response,
+						}}
+						return res, tc.err
+					}), nil
+				})
+				exec := pipelineTestExecutor(t, event, []Hook{
+					{Type: HookTypeCommand, Command: `echo '{"hook_specific_output":{"updated_input":{"cmd":"first"},"updated_messages":[{"content":"first"}],"updated_tool_response":"first"}}'`},
+					{Type: "test", Command: "fail", OnError: tc.onError},
+					{Type: "test", Command: "last"},
+				}, registry)
+				result, err := exec.Dispatch(t.Context(), event, &Input{
+					ToolInput: map[string]any{"cmd": "first"}, Messages: []chat.Message{{Content: "first"}}, ToolResponse: "first",
+				})
+				require.NoError(t, err)
+				assert.True(t, lastRan)
+				assert.Equal(t, !tc.blocked, result.Allowed)
+				switch event {
+				case EventPreToolUse:
+					assert.Equal(t, "first", result.ModifiedInput["cmd"])
+				case EventBeforeLLMCall:
+					require.Len(t, result.UpdatedMessages, 1)
+					assert.Equal(t, "first", result.UpdatedMessages[0].Content)
+				case EventToolResponseTransform:
+					require.NotNil(t, result.UpdatedToolResponse)
+					assert.Equal(t, "first", *result.UpdatedToolResponse)
+				}
+			})
+		}
+	}
+}
+
+func TestPipelineInvalidRewritePreservesDenyAndInput(t *testing.T) {
+	t.Parallel()
+
+	registry := NewRegistry()
+	require.NoError(t, registry.RegisterBuiltin("invalid", func(_ context.Context, _ *Input, _ []string) (*Output, error) {
+		return &Output{HookSpecificOutput: &HookSpecificOutput{UpdatedInput: map[string]any{"bad": make(chan int)}}}, nil
+	}))
+	require.NoError(t, registry.RegisterBuiltin("last", func(_ context.Context, in *Input, _ []string) (*Output, error) {
+		assert.Equal(t, map[string]any{"cmd": "first", "cwd": "work"}, in.ToolInput)
+		return &Output{HookSpecificOutput: &HookSpecificOutput{PermissionDecision: DecisionAllow}}, nil
+	}))
+	exec := pipelineTestExecutor(t, EventPreToolUse, []Hook{
+		{Type: HookTypeCommand, Command: `echo '{"hook_specific_output":{"permission_decision":"deny","permission_decision_reason":"policy","updated_input":{"cmd":"first"}}}'`},
+		{Type: HookTypeBuiltin, Command: "invalid"},
+		{Type: HookTypeBuiltin, Command: "last"},
+	}, registry)
+	result, err := exec.Dispatch(t.Context(), EventPreToolUse, &Input{ToolInput: map[string]any{"cmd": "original", "cwd": "work"}})
+	require.NoError(t, err)
+	assert.False(t, result.Allowed)
+	assert.Equal(t, DecisionDeny, result.Decision)
+	assert.Equal(t, "policy", result.DecisionReason)
+	assert.Contains(t, result.Message, "serialize rewritten input")
+	assert.Equal(t, map[string]any{"cmd": "first", "cwd": "work"}, result.ModifiedInput)
+}
+
+func TestNonTransformEventsRemainConcurrent(t *testing.T) {
+	t.Parallel()
+
+	for _, event := range []EventType{EventSessionStart, EventPermissionRequest, EventBeforeCompaction, EventPreToolUsePreYolo} {
+		t.Run(string(event), func(t *testing.T) {
+			t.Parallel()
+			started := make(chan struct{}, 2)
+			release := make(chan struct{})
+			ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+			defer cancel()
+			go func() {
+				defer close(release)
+				for range 2 {
+					select {
+					case <-started:
+					case <-ctx.Done():
+						return
+					}
+				}
+			}()
+			registry := NewRegistry()
+			require.NoError(t, registry.RegisterBuiltin("wait", func(ctx context.Context, in *Input, args []string) (*Output, error) {
+				started <- struct{}{}
+				select {
+				case <-release:
+				case <-ctx.Done():
+					return nil, ctx.Err()
+				}
+				assert.Equal(t, "original", in.ToolInput["cmd"])
+				return &Output{HookSpecificOutput: &HookSpecificOutput{
+					UpdatedInput: map[string]any{"cmd": args[0]}, Summary: args[0], AdditionalContext: args[0],
+				}}, nil
+			}))
+			hookList := []Hook{
+				{Type: HookTypeBuiltin, Command: "wait", Args: []string{"first"}},
+				{Type: HookTypeBuiltin, Command: "wait", Args: []string{"second"}},
+			}
+			preempt := true
+			exec := NewExecutorWithRegistry(&Config{
+				SessionStart: hookList, BeforeCompaction: hookList,
+				PermissionRequest: []MatcherConfig{{Hooks: hookList}},
+				PreToolUse:        []MatcherConfig{{PreemptYolo: &preempt, Hooks: hookList}},
+			}, t.TempDir(), nil, registry)
+			result, err := exec.Dispatch(ctx, event, &Input{ToolInput: map[string]any{"cmd": "original"}})
+			require.NoError(t, err)
+			require.NoError(t, ctx.Err(), "both hooks must start before either finishes")
+			assert.Equal(t, "first\nsecond", result.AdditionalContext)
+			assert.Nil(t, result.ModifiedInput)
+			if event == EventBeforeCompaction {
+				assert.Equal(t, "first", result.Summary)
+			}
+		})
+	}
+}
+
+type pipelineHandlerFunc func(context.Context, []byte) (HandlerResult, error)
+
+func (f pipelineHandlerFunc) Run(ctx context.Context, input []byte) (HandlerResult, error) {
+	return f(ctx, input)
+}
+
+func pipelineTestExecutor(t *testing.T, event EventType, hookList []Hook, registry *Registry) *Executor {
+	t.Helper()
+	cfg := &Config{}
+	switch event {
+	case EventPreToolUse:
+		cfg.PreToolUse = []MatcherConfig{{Hooks: hookList}}
+	case EventBeforeLLMCall:
+		cfg.BeforeLLMCall = hookList
+	case EventToolResponseTransform:
+		cfg.ToolResponseTransform = []MatcherConfig{{Hooks: hookList}}
+	default:
+		t.Fatalf("unexpected event: %s", event)
+	}
+	return NewExecutorWithRegistry(cfg, t.TempDir(), nil, registry)
+}
+
+func TestPipelineTimeoutDoesNotCancelNextHook(t *testing.T) {
+	t.Parallel()
+
+	synctest.Test(t, func(t *testing.T) {
+		registry := NewRegistry()
+		require.NoError(t, registry.RegisterBuiltin("timeout", func(ctx context.Context, _ *Input, _ []string) (*Output, error) {
+			<-ctx.Done()
+			return nil, ctx.Err()
+		}))
+		ran := false
+		require.NoError(t, registry.RegisterBuiltin("next", func(ctx context.Context, in *Input, _ []string) (*Output, error) {
+			ran = true
+			assert.NoError(t, ctx.Err())
+			assert.Equal(t, "original", in.ToolInput["cmd"])
+			return &Output{HookSpecificOutput: &HookSpecificOutput{UpdatedInput: map[string]any{"cmd": "next"}}}, nil
+		}))
+		exec := NewExecutorWithRegistry(&Config{PreToolUse: []MatcherConfig{{Hooks: []Hook{
+			{Type: HookTypeBuiltin, Command: "timeout", Timeout: 1},
+			{Type: HookTypeBuiltin, Command: "next", Timeout: 1},
+		}}}}, "", nil, registry)
+		result, err := exec.Dispatch(t.Context(), EventPreToolUse, &Input{ToolInput: map[string]any{"cmd": "original"}})
+		require.NoError(t, err)
+		assert.True(t, ran)
+		assert.False(t, result.Allowed)
+		assert.Contains(t, result.Message, "timed out")
+		assert.Equal(t, "next", result.ModifiedInput["cmd"])
+	})
+}
+
+func TestPipelineModelJudgeSeesRewrittenInput(t *testing.T) {
+	t.Parallel()
+
+	client := &fakeClient{reply: `{"decision":"ask","reason":"review rewritten command"}`}
+	registry := NewRegistry()
+	registry.Register(HookTypeModel, NewModelFactory(client))
+	exec := pipelineTestExecutor(t, EventPreToolUse, []Hook{
+		{Type: HookTypeCommand, Command: `echo '{"hook_specific_output":{"updated_input":{"cmd":"rewritten"}}}'`},
+		{Type: HookTypeModel, Model: "test/judge", Prompt: `{{ .ToolInput.cmd }}`, Schema: ShapePreToolUseDecision},
+	}, registry)
+	result, err := exec.Dispatch(t.Context(), EventPreToolUse, &Input{ToolInput: map[string]any{"cmd": "original"}})
+	require.NoError(t, err)
+	assert.Equal(t, "rewritten", client.gotUser)
+	assert.Equal(t, DecisionAsk, result.Decision)
+	assert.Equal(t, "review rewritten command", result.DecisionReason)
+}

--- a/pkg/hooks/types.go
+++ b/pkg/hooks/types.go
@@ -532,9 +532,11 @@ type HookSpecificOutput struct {
 	HookEventName EventType `json:"hook_event_name,omitempty"`
 
 	// PreToolUse fields.
-	PermissionDecision       Decision       `json:"permission_decision,omitempty"`
-	PermissionDecisionReason string         `json:"permission_decision_reason,omitempty"`
-	UpdatedInput             map[string]any `json:"updated_input,omitempty"`
+	PermissionDecision       Decision `json:"permission_decision,omitempty"`
+	PermissionDecisionReason string   `json:"permission_decision_reason,omitempty"`
+
+	// UpdatedInput is a top-level patch; omitted keys are preserved.
+	UpdatedInput map[string]any `json:"updated_input,omitempty"`
 
 	// PostToolUse / SessionStart / TurnStart / Stop fields.
 	AdditionalContext  string               `json:"additional_context,omitempty"`
@@ -552,9 +554,8 @@ type HookSpecificOutput struct {
 	// scrubbing outbound chat content. Hooks for other events should
 	// leave it nil; aggregate() only honours it for before_llm_call.
 	//
-	// First non-empty wins when multiple before_llm_call hooks return
-	// rewrites concurrently — see aggregate(). Compose multiple
-	// rewriters into a single hook if you need them to chain.
+	// Hooks run in config order; each sees the preceding rewrite.
+	// The last non-empty rewrite is returned to the runtime.
 	UpdatedMessages []chat.Message `json:"updated_messages,omitempty"`
 
 	// UpdatedToolResponse, when non-nil on a
@@ -564,9 +565,8 @@ type HookSpecificOutput struct {
 	// call. Pointer-typed so an explicit empty string ("clear the
 	// output") is distinguishable from "don't touch it" (nil).
 	//
-	// First non-nil wins when multiple tool_response_transform hooks
-	// return rewrites concurrently — see aggregate(). Compose multiple
-	// rewriters into a single hook if you need them to chain.
+	// Hooks run in config order; each sees the preceding rewrite.
+	// The last non-nil rewrite, including an empty string, is returned.
 	UpdatedToolResponse *string `json:"updated_tool_response,omitempty"`
 
 	// Metadata is a set of key/value annotations a
@@ -589,7 +589,8 @@ type Result struct {
 	PermissionAllowed bool
 	// Message is feedback to include in the response.
 	Message string
-	// ModifiedInput contains modifications to tool input (PreToolUse).
+	// ModifiedInput is the complete tool input after applying PreToolUse patches.
+	// Nil means no hook supplied a patch.
 	ModifiedInput map[string]any
 	// AdditionalContext is context added by the hooks.
 	AdditionalContext  string

--- a/pkg/runtime/pre_tool_use_approval_test.go
+++ b/pkg/runtime/pre_tool_use_approval_test.go
@@ -2,6 +2,7 @@ package runtime
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -297,4 +298,42 @@ func TestPreToolUseHook_ReceivesAgentName(t *testing.T) {
 
 	assert.Equal(t, "root", gotAgentName,
 		"pre_tool_use hook Input must carry the dispatching agent's name")
+}
+
+func TestPreToolUseHookPipelinePreservesUnchangedArguments(t *testing.T) {
+	t.Parallel()
+
+	root := agent.New("root", "instr", agent.WithModel(&mockProvider{id: "test/mock-model", stream: &mockStream{}}), agent.WithHooks(&latest.HooksConfig{
+		PreToolUse: []latest.HookMatcherConfig{{Hooks: []latest.HookDefinition{
+			{Type: hooks.HookTypeBuiltin, Command: "rewrite"},
+			{Type: hooks.HookTypeBuiltin, Command: "approve"},
+		}}},
+	}))
+	rt, err := NewLocalRuntime(t.Context(), team.New(team.WithAgents(root)), WithSessionCompaction(false), WithModelStore(mockModelStore{}))
+	require.NoError(t, err)
+	require.NoError(t, rt.hooksRegistry.RegisterBuiltin("rewrite", func(_ context.Context, _ *hooks.Input, _ []string) (*hooks.Output, error) {
+		return &hooks.Output{HookSpecificOutput: &hooks.HookSpecificOutput{UpdatedInput: map[string]any{"cmd": "rewritten"}}}, nil
+	}))
+	require.NoError(t, rt.hooksRegistry.RegisterBuiltin("approve", func(_ context.Context, in *hooks.Input, _ []string) (*hooks.Output, error) {
+		assert.Equal(t, map[string]any{"cmd": "rewritten", "cwd": "work"}, in.ToolInput)
+		return &hooks.Output{HookSpecificOutput: &hooks.HookSpecificOutput{
+			PermissionDecision: hooks.DecisionAllow,
+			UpdatedInput:       map[string]any{"cmd": in.ToolInput["cmd"].(string) + " and approved"},
+		}}, nil
+	}))
+	var received map[string]any
+	agentTools := []tools.Tool{{Name: "the_tool", Handler: func(_ context.Context, tc tools.ToolCall, _ tools.Runtime) (*tools.ToolCallResult, error) {
+		if err := json.Unmarshal([]byte(tc.Function.Arguments), &received); err != nil {
+			return nil, err
+		}
+		return tools.ResultSuccess("ok"), nil
+	}}}
+	calls := []tools.ToolCall{{ID: "call", Type: "function", Function: tools.FunctionCall{
+		Name: "the_tool", Arguments: `{"cmd":"original","cwd":"work"}`,
+	}}}
+	events := make(chan Event, 32)
+	rt.processToolCalls(t.Context(), session.New(session.WithUserMessage("test")), calls, agentTools, NewChannelSink(events))
+	close(events)
+	assert.Equal(t, map[string]any{"cmd": "rewritten and approved", "cwd": "work"}, received)
+	assert.False(t, hasEventOfType[*ToolCallConfirmationEvent](collectClosedEvents(events)))
 }


### PR DESCRIPTION
Hooks for `pre_tool_use` (default lane), `before_llm_call`, and `tool_response_transform` previously ran concurrently and used a first-rewrite-wins strategy. This made it impossible for one hook to build on another's output: a redaction hook and a normalization hook on the same event would race, and whichever wrote first would see its work discarded or its changes overwritten silently. The only workaround was to bundle all logic into a single monolithic hook.

These three events now execute hooks sequentially in configuration order. Each hook receives the accumulated result of all prior accepted rewrites — the updated `tool_input`, `messages` array, or `tool_response` — and can further transform it. Verdicts continue to aggregate across the full sequence (`deny > ask > allow`), and a blocking verdict does not short-circuit remaining hooks. All other events, including `preempt_yolo` checks and `before_compaction`, remain concurrent.

The `updated_input` field for `pre_tool_use` changes from a full replacement to a shallow-merge patch: only the top-level keys present in the returned object are applied; omitted keys are preserved from the current input. This is a compatibility change — previously any omitted key was silently dropped. Key deletion is not supported by this patch protocol.

The automatic `limit_large_tool_results` builtin is now appended *after* all configured `tool_response_transform` hooks and automatic `redact_secrets` injection, so spill files written to disk already contain scrubbed content rather than raw secrets. This restores the correct ordering that was previously broken because the limiter was prepended before user-configured transforms.

The new `pkg/hooks/pipeline.go` implements the sequential executor. Tests added cover the argument-preservation invariant (a second hook sees the first hook's patch merged over the original), the redact-before-spill invariant (spill file on disk is clean), and the ordering of builtin injection in `ApplyAgentDefaults`. The docs and the `redact_secrets_hooks.yaml` example are updated to reflect the new composition semantics.