### PR TITLE
chore: update docker-agent-action to v2.0.7

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -18,7 +18,7 @@ jobs:
     if: |
       github.event_name == 'issue_comment' ||
       github.event.workflow_run.conclusion == 'success'
-    uses: docker/docker-agent-action/.github/workflows/review-pr.yml@4dcb32aa716addc5ce33f8b4d33cb635ae174d7e # v2.0.6
+    uses: docker/docker-agent-action/.github/workflows/review-pr.yml@bd672e0d95c61bb79e899f1ea71d44e19b12f91f # v2.0.7
     # Scoped to the job so other jobs in this workflow aren't over-permissioned
     permissions:
       contents: read # Read repository files and PR diffs


### PR DESCRIPTION
## Summary
Updates `docker-agent-action` reference in `.github/workflows/pr-review.yml` to [v2.0.7](https://github.com/docker/docker-agent-action/releases/tag/v2.0.7).
- **Commit**: `bd672e0d95c61bb79e899f1ea71d44e19b12f91f`
- **Version**: `v2.0.7`
> Auto-generated by the [release](https://github.com/docker/gordon/actions/runs/34328897690) workflow.