### PR TITLE
fix(tui): close SQLite stores deterministically so Windows can delete t.TempDir

### DIFF
--- a/pkg/session/store.go
+++ b/pkg/session/store.go
@@ -16,7 +16,6 @@ import (
 
 	"github.com/docker/docker-agent/pkg/chat"
 	"github.com/docker/docker-agent/pkg/concurrent"
-	"github.com/docker/docker-agent/pkg/sqliteutil"
 )
 
 var (
@@ -1137,10 +1136,23 @@ func (s *SQLiteSessionStore) SetSessionStarred(ctx context.Context, id string, s
 	return nil
 }
 
+// closeDrainTimeout bounds how long Close waits for in-use connections.
+const closeDrainTimeout = 5 * time.Second
+
 // Close closes the database connection, waiting for in-flight statements to
-// release it so the file can be removed immediately afterwards.
+// release it so the file can be removed immediately afterwards. sql.DB.Close
+// only closes idle connections; a background persistence write still holding
+// one keeps the file open on Windows until it returns.
+//
+// Mirrors sqliteutil.CloseDB; duplicated so pkg/session stays free of the
+// SQLite driver (see pkg/session/sqlitestore).
 func (s *SQLiteSessionStore) Close() error {
-	return sqliteutil.CloseDB(s.db)
+	err := s.db.Close()
+	deadline := time.Now().Add(closeDrainTimeout)
+	for s.db.Stats().OpenConnections > 0 && time.Now().Before(deadline) {
+		time.Sleep(time.Millisecond)
+	}
+	return err
 }
 
 // AddMessage adds a message to a session at the next position.

--- a/pkg/session/store.go
+++ b/pkg/session/store.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/docker/docker-agent/pkg/chat"
 	"github.com/docker/docker-agent/pkg/concurrent"
+	"github.com/docker/docker-agent/pkg/sqliteutil"
 )
 
 var (
@@ -1136,9 +1137,10 @@ func (s *SQLiteSessionStore) SetSessionStarred(ctx context.Context, id string, s
 	return nil
 }
 
-// Close closes the database connection
+// Close closes the database connection, waiting for in-flight statements to
+// release it so the file can be removed immediately afterwards.
 func (s *SQLiteSessionStore) Close() error {
-	return s.db.Close()
+	return sqliteutil.CloseDB(s.db)
 }
 
 // AddMessage adds a message to a session at the next position.

--- a/pkg/session/store_close_test.go
+++ b/pkg/session/store_close_test.go
@@ -1,0 +1,48 @@
+package session
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/docker/docker-agent/pkg/sqliteutil"
+)
+
+func TestSQLiteSessionStore_CloseWaitsForInFlightConnection(t *testing.T) {
+	t.Parallel()
+
+	db, err := sqliteutil.OpenDB(t.Context(), filepath.Join(t.TempDir(), "close.db"))
+	require.NoError(t, err)
+	store, err := NewSQLiteSessionStoreFromDB(t.Context(), db)
+	require.NoError(t, err)
+
+	// Check out the single pooled connection and keep it busy until released.
+	conn, err := db.Conn(t.Context())
+	require.NoError(t, err)
+	released := make(chan struct{})
+	go func() {
+		<-released
+		_ = conn.Close()
+	}()
+
+	closed := make(chan error, 1)
+	go func() { closed <- store.Close() }()
+
+	select {
+	case <-closed:
+		t.Fatal("Close returned while a connection was still checked out")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	close(released)
+	select {
+	case err := <-closed:
+		require.NoError(t, err)
+	case <-time.After(closeDrainTimeout):
+		t.Fatal("Close did not return after the connection was released")
+	}
+	assert.Zero(t, db.Stats().OpenConnections)
+}

--- a/pkg/sqliteutil/sqlite.go
+++ b/pkg/sqliteutil/sqlite.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"time"
 
 	"modernc.org/sqlite"
 	sqlite3 "modernc.org/sqlite/lib"
@@ -67,6 +68,26 @@ func journalMode() string {
 		return "DELETE"
 	}
 	return "WAL"
+}
+
+// closeDrainTimeout bounds how long CloseDB waits for in-use connections.
+const closeDrainTimeout = 5 * time.Second
+
+// CloseDB closes db and waits until every connection has actually been
+// released. sql.DB.Close only closes idle connections: one checked out by an
+// in-flight statement is closed when that statement returns, after Close has
+// already come back. On Windows the database file cannot be deleted while
+// such a connection still holds it, so callers that remove the directory
+// right after closing (tests with t.TempDir, recovery paths) need the handle
+// gone before Close returns. Waiting is bounded so a wedged statement cannot
+// hang shutdown.
+func CloseDB(db *sql.DB) error {
+	err := db.Close()
+	deadline := time.Now().Add(closeDrainTimeout)
+	for db.Stats().OpenConnections > 0 && time.Now().Before(deadline) {
+		time.Sleep(time.Millisecond)
+	}
+	return err
 }
 
 // IsCantOpenError checks if the error is a SQLite CANTOPEN error (code 14).

--- a/pkg/sqliteutil/sqlite_test.go
+++ b/pkg/sqliteutil/sqlite_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -105,4 +106,50 @@ func TestIsTransientError_SQLiteBusy(t *testing.T) {
 	require.Error(t, err)
 	assert.True(t, IsTransientError(err), "SQLITE_BUSY should be transient: %v", err)
 	assert.False(t, IsCantOpenError(err))
+}
+
+func TestCloseDB_WaitsForInFlightConnection(t *testing.T) {
+	t.Parallel()
+
+	db, err := OpenDB(t.Context(), filepath.Join(t.TempDir(), "close.db"))
+	require.NoError(t, err)
+
+	// Check out the single pooled connection and keep it busy until released.
+	conn, err := db.Conn(t.Context())
+	require.NoError(t, err)
+	released := make(chan struct{})
+	go func() {
+		<-released
+		_ = conn.Close()
+	}()
+
+	closed := make(chan error, 1)
+	go func() { closed <- CloseDB(db) }()
+
+	select {
+	case <-closed:
+		t.Fatal("CloseDB returned while a connection was still checked out")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	close(released)
+	select {
+	case err := <-closed:
+		require.NoError(t, err)
+	case <-time.After(closeDrainTimeout):
+		t.Fatal("CloseDB did not return after the connection was released")
+	}
+	assert.Zero(t, db.Stats().OpenConnections)
+}
+
+func TestCloseDB_IdleReturnsImmediately(t *testing.T) {
+	t.Parallel()
+
+	db, err := OpenDB(t.Context(), filepath.Join(t.TempDir(), "idle.db"))
+	require.NoError(t, err)
+
+	start := time.Now()
+	require.NoError(t, CloseDB(db))
+	assert.Less(t, time.Since(start), time.Second)
+	assert.Zero(t, db.Stats().OpenConnections)
 }

--- a/pkg/tui/service/tuistate/store.go
+++ b/pkg/tui/service/tuistate/store.go
@@ -84,9 +84,10 @@ func (s *Store) migrate(ctx context.Context) error {
 	return nil
 }
 
-// Close closes the database connection.
+// Close closes the database connection, waiting for in-flight statements to
+// release it so the file can be removed immediately afterwards.
 func (s *Store) Close() error {
-	return s.db.Close()
+	return sqliteutil.CloseDB(s.db)
 }
 
 // AddTab adds a new tab to the store, placing it after all existing tabs.

--- a/pkg/tui/tui.go
+++ b/pkg/tui/tui.go
@@ -3259,6 +3259,18 @@ func (m *appModel) cleanupManagedResources() {
 	})
 }
 
+// Shutdown releases the resources the TUI owns (theme watcher, tab-state
+// store, session supervisor) and returns once they are closed. It is for
+// callers that stop the program without going through the exit dialogs —
+// notably the tuitest harness, which must have tui_state.db closed before
+// t.TempDir removes it (Windows cannot delete an open file). The context
+// watcher started by contextShutdownCmd performs the same once-guarded
+// cleanup, so calling both is safe: whichever runs second either finds the
+// work done or blocks until it is.
+func (m *appModel) Shutdown() {
+	m.cleanupManagedResources()
+}
+
 // cleanupAll cleans up all sessions, editors, and resources. It is invoked
 // from several message handlers (ExitSessionMsg, ExitConfirmedMsg, …) and may
 // be called more than once on the same model; the entire shutdown sequence is

--- a/pkg/tui/tuitest/driver.go
+++ b/pkg/tui/tuitest/driver.go
@@ -107,9 +107,20 @@ type programReady interface {
 	SetProgram(p *tea.Program)
 }
 
+// resourceOwner is implemented by models that hold resources outliving the
+// tea.Program (tui.New's model: the tui_state.db store, theme watcher,
+// session supervisor). Quit alone does not release them — the model relies on
+// context cancellation, which in tests races t.Cleanup. The driver closes them
+// synchronously after the program stops so files under t.TempDir can be
+// deleted, which Windows refuses while a handle is open.
+type resourceOwner interface {
+	Shutdown()
+}
+
 // New starts model in a real, renderer-less tea.Program and returns a Driver.
 // width and height seed the initial window size. The program is stopped and
-// awaited automatically via t.Cleanup.
+// awaited automatically via t.Cleanup, and a model implementing Shutdown has
+// its resources released right after.
 //
 // model is typically the value returned by tui.New. If it implements
 // SetProgram (as the docker-agent TUI does) the running program is wired into
@@ -164,6 +175,9 @@ func New(tb testing.TB, model tea.Model, width, height int, opts ...Option) *Dri
 
 	tb.Cleanup(func() {
 		d.stop()
+		if ro, ok := model.(resourceOwner); ok {
+			ro.Shutdown()
+		}
 		restoreClipboard()
 	})
 	return d

--- a/pkg/tui/tuitest/driver_test.go
+++ b/pkg/tui/tuitest/driver_test.go
@@ -93,6 +93,50 @@ func TestDriver_SendSyncReturnsWhenMessageQuitsProgram(t *testing.T) {
 	d.Press('q') // must not hang or fail even though no frame follows
 }
 
+// shutdownModel records whether the harness released its resources, and
+// whether the program had already stopped when it did.
+type shutdownModel struct {
+	echoModel
+
+	shutdownCalls   int
+	programWasDone  bool
+	programDone     <-chan struct{}
+	shutdownEntered chan struct{}
+}
+
+func (m *shutdownModel) Shutdown() {
+	m.shutdownCalls++
+	select {
+	case <-m.programDone:
+		m.programWasDone = true
+	default:
+	}
+	close(m.shutdownEntered)
+}
+
+func TestDriver_CleanupShutsDownModelAfterProgramStops(t *testing.T) {
+	m := &shutdownModel{shutdownEntered: make(chan struct{})}
+	var d *Driver
+	t.Run("driven", func(t *testing.T) {
+		d = New(t, m, 80, 24)
+		m.programDone = d.runDone
+		d.Type("hi").Assert(Contains("echo: hi"))
+	})
+
+	// t.Run returns only after the subtest's cleanups ran.
+	select {
+	case <-m.shutdownEntered:
+	default:
+		t.Fatal("Shutdown was not called by the driver's cleanup")
+	}
+	if m.shutdownCalls != 1 {
+		t.Fatalf("Shutdown called %d times, want 1", m.shutdownCalls)
+	}
+	if !m.programWasDone {
+		t.Fatal("Shutdown ran before the program had stopped")
+	}
+}
+
 func TestDriver_MouseHelpers(t *testing.T) {
 	d := New(t, &echoModel{}, 80, 24)
 	d.Type("target")


### PR DESCRIPTION
> 🤖 **Automated architect agent** — *this comment was posted by the architect bot from Docker Agentic Platform, not by a human engineer*

## Problem

`windows-tests` flakes (~6 % of `ci` runs over the last 100) with, in 3 of the 6 Windows-only failures:

```
--- FAIL: TestBackgroundAgent_PerAgentContextInSidebar (2.65s)
    testing.go:1617: TempDir RemoveAll cleanup: unlinkat C:\...\Temp\...\data\tui_state.db:
    The process cannot access the file because it is being used by another process.
```
(also `session.db` in `TestChat_DegenerateResizeDoesNotPanic`). Runs: 34329154242, 34194019096, 34325172091.

Windows refuses to delete a file with an open handle; Go's `t.TempDir()` cleanup retries sharing violations for only 2 s. Two SQLite handles in the `tuitest`-driven `e2e/tui` tests outlived that window:

- **`tui_state.db`** is closed only by the detached goroutine armed in `contextShutdownCmd` (`<-ctx.Done(); cleanupManagedResources()`), which nothing joins. `tuitest`'s cleanup quits the program but never releases the model's resources, so a WAL checkpoint + fsync on a slow runner races `t.TempDir`. In-package unit tests already work around this with `t.Cleanup(m.cleanupManagedResources)`; the external `e2e/tui` package couldn't.
- **`session.db`**: `sql.DB.Close()` only closes *idle* connections. One checked out by an in-flight persistence write (token usage / title, on the runtime observer goroutine) is released after `Close` returned — the `Failed to persist token usage … sql: database is closed` warnings in the logs are the same writers landing a moment later.

## Fix

- `sqliteutil.CloseDB(db)`: `Close()` then wait (bounded, 5 s) until `db.Stats().OpenConnections == 0`. Used by `tuistate.Store.Close`. `session.SQLiteSessionStore.Close` gets the same `database/sql`-only drain inline, because `pkg/session` must stay free of the SQLite driver (`e2e/dependencies_test.go`; see `pkg/session/sqlitestore`).
- `appModel.Shutdown()` (exported, wraps the `sync.Once`-guarded `cleanupManagedResources`); `tuitest.New` calls it right after the program stops when the model implements it — same optional-interface pattern as `SetProgram`.

Result: every driver-based test closes `tui_state.db` synchronously before `rt.Close`, `store.Close` and `t.TempDir` run, and store closes don't return until the file handle is gone.

## Validation

- `go build ./...`, `golangci-lint run` on touched packages: clean
- `go test ./pkg/sqliteutil/... ./pkg/session/... ./pkg/tui/... ./e2e/tui/... ./pkg/app/... ./pkg/runtime/ ./cmd/root/`: pass (Linux)
- New tests: `TestCloseDB_WaitsForInFlightConnection`, `TestCloseDB_IdleReturnsImmediately`, `TestSQLiteSessionStore_CloseWaitsForInFlightConnection`, `TestDriver_CleanupShutsDownModelAfterProgramStops`
- Windows: cannot be exercised locally; the `windows-tests` job on this PR is the check.

## Not in this PR

The other 3 Windows-only flakes are timing budgets (PowerShell start-up under load: `pkg/hooks` `TestExecuteStop`, `backgroundjobs` recall test; `pkg/userconfig` 5 s lock timeout falling back to unlocked writes). Diagnosis and a prioritized plan for those are in the linked task report.

