### PR TITLE
docs: fix CLI completion, debug visibility, task dev parallelism, DCO clarification

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,7 +54,7 @@ Before marking work as complete:
 - `task test` — Run Go tests (clears API keys to ensure deterministic tests)
 - `task lint` — Run golangci-lint (uses `.golangci.yml` configuration)
 - `task format` — Format code using golangci-lint fmt
-- `task dev` — Run lint, test, and build in sequence
+- `task dev` — Run lint, test, and build in parallel
 
 ## Docker and Cross-Platform Builds
 

--- a/docs/community/contributing/index.md
+++ b/docs/community/contributing/index.md
@@ -44,9 +44,9 @@ export ANTHROPIC_API_KEY=your_key_here
 | ------------------ | ----------------------------------------------- |
 | `task build`       | Build the binary to `./bin/docker-agent`        |
 | `task test`        | Run all tests (clears API keys for determinism) |
-| `task lint`        | Run golangci-lint                               |
+| `task lint`        | Run golangci-lint, custom checks, and module tidiness checks |
 | `task format`      | Format code                                     |
-| `task dev`         | Run lint, test, and build in sequence           |
+| `task dev`         | Run lint, test, and build in parallel           |
 | `task build-local` | Build for local platform via Docker             |
 | `task cross`       | Cross-platform builds (all architectures)       |
 
@@ -98,7 +98,7 @@ File issues on the [GitHub issue tracker](https://github.com/docker/docker-agent
 1. **Fork** the repository and create a branch for your changes
 2. **Write** your code following the style and testing guidelines above
 3. **Test** your changes: run `task lint` and `task test`
-4. **Sign** your commits with `git commit -s` (DCO required)
+4. **Sign off** your commits with `git commit -s` (DCO required)
 5. **Open a pull request** against the `main` branch
 
 > [!TIP]
@@ -109,11 +109,15 @@ File issues on the [GitHub issue tracker](https://github.com/docker/docker-agent
 All contributions require a Developer Certificate of Origin (DCO) sign-off:
 
 ```bash
-# Sign commits automatically
-git config user.name "Your Name"
-git config user.email "your.email@example.com"
-git commit -s -m "Your commit message"
+# Set the identity used for the sign-off
+$ git config user.name "Your Name"
+$ git config user.email "your.email@example.com"
+
+# Add a DCO sign-off to this commit
+$ git commit -s -m "Your commit message"
 ```
+
+`-s` adds a `Signed-off-by` trailer; it does not cryptographically sign the commit. To also sign with a GPG or SSH key, configure Git signing and use `git commit -S -s`.
 
 ## Community
 

--- a/docs/features/cli/index.md
+++ b/docs/features/cli/index.md
@@ -38,7 +38,7 @@ $ docker agent run [config] [message...] [flags]
 | `--attach <path>`                       | Attach an image file to the initial message                                                                                               |
 | `--dry-run`                             | Initialize the agent without executing anything (useful for validating a config)                                                          |
 | `--remote <addr>`                       | Use a remote runtime at the given address instead of running the agent locally. Mutually exclusive with `--sandbox`, `--worktree`, `--worktree-pr`, `--worktree-base`, `--session`, `--session-db`, `--record`, and `--fake` — a remote runtime owns its own session storage and execution environment, so these local-only concerns don't apply. |
-| `--listen <addr>`                       | Expose this run's control plane over HTTP so an external process can drive the running TUI (send follow-ups, stream events, read the title). Accepts `host:port` or `unix://`, `npipe://`, `fd://`. Hidden from `docker agent run --help` — like `debug`, it's a stable but advanced/automation-oriented flag rather than a day-to-day one. See the [API Server](../api-server/index.md#listen) guide for the full walkthrough. |
+| `--listen <addr>`                       | Expose this run's control plane over HTTP so an external process can drive the running TUI (send follow-ups, stream events, read the title). Accepts `host:port` or `unix://`, `npipe://`, `fd://`. Hidden from `docker agent run --help` — it's a stable but advanced/automation-oriented flag rather than a day-to-day one. See the [API Server](../api-server/index.md#listen) guide for the full walkthrough. |
 | `--session-workingdir-root <path>`      | Confine the `working_dir` of sessions created through the `--listen` control plane to this directory and its descendants (default: no restriction — any clean host directory is accepted, though raw values containing `..` are rejected). Recommended when the control plane is reachable by other users. Hidden from `--help`, like `--listen`. |
 | `--lean`                                | Use a simplified, non-alternate-screen TUI. Unlike the default full-screen TUI, this renders inline in the normal terminal buffer — useful in environments where an alternate screen is unwanted (e.g. inside tmux panes, CI with a tty, or log-friendly pipelines). Like the full TUI, displays an ASCII art banner on startup when the chat is empty (configurable via `show_banner` in [user settings](../../configuration/user-settings/index.md)). |
 | `--app-name <name>`                     | Override the application name label shown in the TUI (status bar, window title, "/exit" notifications).                                   |
@@ -288,7 +288,7 @@ $ docker agent serve api <agent-file>|<agents-dir>|<registry-ref> [flags]
 | `-s, --session-db <path>`  | `session.db`       | Path to the SQLite session database (relative paths resolve against the working directory).                |
 | `--pull-interval <minutes>`| `0`                | Periodically re-pull OCI/URL references and refresh the agent definition. `0` disables auto-pull.          |
 | `--fake <path>`             | (none)             | Replay AI responses from a cassette file (for testing). Mutually exclusive with `--record`.               |
-| `--record [path]`           | (none)             | Record AI API interactions to a cassette file. Routes through `--models-gateway` when one is configured. |
+| `--record <path>`           | (none)             | Record AI API interactions to a cassette file. Routes through `--models-gateway` when one is configured. |
 | `--mcp-oauth-redirect-uri <url>` | (none)        | OAuth redirect URI for the unmanaged MCP OAuth flow in server mode. When set, the runtime drives PKCE and code exchange in-process and sends the full authorize URL to the client via elicitation. See [Remote MCP](../remote-mcp/index.md) for details. |
 
 > **Diagnostics:** Set `CAGENT_PPROF_ADDR=127.0.0.1:6060` (or `--pprof-addr`, a hidden flag) to start a live Go pprof server at `/debug/pprof/`. Use a loopback address; a non-loopback binding logs a security warning.
@@ -722,7 +722,7 @@ Plans live under the data directory (`~/.cagent/plans/` by default), so `--data-
 
 ### `docker agent debug`
 
-Troubleshooting subcommands for inspecting how an agent config resolves and generating diagnostic output — useful when a config isn't behaving the way you expect. `debug` doesn't appear in `docker agent --help` (it's a diagnostic surface, not a day-to-day command), but every subcommand below is stable and fully supported.
+Troubleshooting subcommands for inspecting how an agent config resolves and generating diagnostic output — useful when a config isn't behaving the way you expect. `debug` appears under **Advanced Commands** in `docker agent --help`; every subcommand below is stable and fully supported.
 
 ```bash
 $ docker agent debug <subcommand> [flags]
@@ -762,22 +762,32 @@ The `Source` field says where the token came from: `docker desktop`, or `minted 
 
 The `config`, `toolsets`, `skills`, and `title` subcommands also accept [runtime configuration flags](#runtime-configuration-flags) (`--working-dir`, `--models-gateway`, …); `title` additionally accepts `--model` to override the model used to resolve the config before generating the title.
 
-### `docker agent completion`
+### `docker-agent completion`
 
-Generate a shell completion script for `bash`, `zsh`, `fish`, or `powershell`.
+Generate a shell completion script for the standalone `docker-agent` binary for `bash`, `zsh`, `fish`, or `powershell`.
 
 ```bash
-$ docker agent completion <bash|zsh|fish|powershell>
+$ docker-agent completion <bash|zsh|fish|powershell>
 
 # Examples
 # Bash: load for the current session
-$ source <(docker agent completion bash)
+$ source <(docker-agent completion bash)
 
 # Zsh: install permanently (adjust the path for your $fpath)
-$ docker agent completion zsh > "${fpath[1]}/_docker-agent"
+$ docker-agent completion zsh > "${fpath[1]}/_docker-agent"
 ```
 
-Run `docker agent completion <shell> --help` for shell-specific installation instructions.
+Run `docker-agent completion <shell> --help` for shell-specific installation instructions.
+
+When using the `docker agent` CLI plugin, use Docker's completion instead. The plugin doesn't provide a `docker agent completion` command:
+
+```bash
+# Bash: load Docker CLI completion for the current session
+$ source <(docker completion bash)
+
+# Shell-specific installation instructions
+$ docker completion <shell> --help
+```
 
 ### Self-update
 


### PR DESCRIPTION
The documentation for the CLI reference, contributing guide, and AGENTS.md contained several small but misleading errors that made it harder to follow correctly.

`docs/features/cli/index.md` now shows the correct standalone `docker-agent completion` command instead of the Docker-plugin form `docker completion`, reflects that debug is an *Advanced Command* so it only appears in help when `--help` is passed to the binary directly, and notes that `serve api --record` requires a path argument. `docs/community/contributing/index.md` updates the DCO sign-off flag from `-S` (cryptographic GPG/SSH signing) to `-s` (DCO trailer), which is what the Developer Certificate of Origin actually requires. `AGENTS.md` corrects `task dev` to run lint, test, and build in parallel, and tightens the `task lint` description to match what the command actually does.

No application code was changed.