### PR TITLE
feat(sandbox): add kubectl and aws cli to sbx-templates image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -86,6 +86,7 @@ apt-get clean
 rm -rf /var/lib/apt/lists/*
 EOF
 COPY --chmod=0755 --from=docker/mcp-gateway:v2 /docker-mcp /usr/local/lib/docker/cli-plugins/docker-mcp
+COPY --chmod=0755 --from=registry.k8s.io/kubectl:v1.37.0 /bin/kubectl /usr/local/bin/kubectl
 USER agent
 ENV DOCKER_AGENT_NO_TOUR=1 \
     DOCKER_AGENT_HIDE_TELEMETRY_BANNER=1 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -87,6 +87,9 @@ rm -rf /var/lib/apt/lists/*
 EOF
 COPY --chmod=0755 --from=docker/mcp-gateway:v2 /docker-mcp /usr/local/lib/docker/cli-plugins/docker-mcp
 COPY --chmod=0755 --from=registry.k8s.io/kubectl:v1.37.0 /bin/kubectl /usr/local/bin/kubectl
+COPY --chmod=0755 --from=amazon/aws-cli:2.36.42 /usr/local/aws-cli/ /usr/local/aws-cli/
+RUN ln -s /usr/local/aws-cli/v2/current/bin/aws /usr/local/bin/aws && \
+    ln -s /usr/local/aws-cli/v2/current/bin/aws_completer /usr/local/bin/aws_completer
 USER agent
 ENV DOCKER_AGENT_NO_TOUR=1 \
     DOCKER_AGENT_HIDE_TELEMETRY_BANNER=1 \

--- a/docs/configuration/sandbox/index.md
+++ b/docs/configuration/sandbox/index.md
@@ -207,6 +207,7 @@ layers onto `docker/sandbox-templates:shell-docker` and adds:
 - The `docker-agent` binary.
 - `vim` and `tmux`, for interactive debugging inside the VM.
 - `kubectl`, for interacting with Kubernetes clusters from inside the VM.
+- The **AWS CLI** (`aws`), for working with AWS from inside the VM.
 - The **`docker-mcp`** Docker CLI plugin, installed at `~/.docker/cli-plugins/docker-mcp`.
 
 The image carries the label `com.docker.sandboxes.flavor=docker-agent-docker`

--- a/docs/configuration/sandbox/index.md
+++ b/docs/configuration/sandbox/index.md
@@ -206,6 +206,7 @@ layers onto `docker/sandbox-templates:shell-docker` and adds:
 
 - The `docker-agent` binary.
 - `vim` and `tmux`, for interactive debugging inside the VM.
+- `kubectl`, for interacting with Kubernetes clusters from inside the VM.
 - The **`docker-mcp`** Docker CLI plugin, installed at `~/.docker/cli-plugins/docker-mcp`.
 
 The image carries the label `com.docker.sandboxes.flavor=docker-agent-docker`


### PR DESCRIPTION
Installing these at each sandboxes creation is quite annoying, I'd say it makes sense to include these in the template. WDYT?