### PR TITLE
ci: shorten the feedback loop (parallel jobs, warm Go cache, Build Cloud)

### DIFF
--- a/.github/actions/setup-go/action.yml
+++ b/.github/actions/setup-go/action.yml
@@ -1,0 +1,48 @@
+name: Set up Go
+description: >-
+  Installs Go and restores the module and build caches saved by the last main
+  run of the same job. setup-go's built-in cache is keyed on go.sum alone, so a
+  single snapshot is shared by every job and never refreshed once saved; keying
+  per job with the commit SHA as suffix keeps each job's build cache warm.
+  Pair with an actions/cache/save step at the end of the job.
+
+inputs:
+  cache-name:
+    description: Cache namespace; defaults to the job id.
+    required: false
+    default: ${{ github.job }}
+
+outputs:
+  cache-key:
+    description: Primary key to pass to actions/cache/save.
+    value: ${{ steps.restore.outputs.cache-primary-key }}
+  cache-path:
+    description: Paths to pass to actions/cache/save.
+    value: ${{ steps.paths.outputs.paths }}
+
+runs:
+  using: composite
+  steps:
+    - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
+      with:
+        go-version-file: go.mod
+        cache: false
+
+    - id: paths
+      shell: bash
+      run: |
+        {
+          echo "paths<<EOF"
+          go env GOMODCACHE
+          go env GOCACHE
+          echo "EOF"
+        } >> "$GITHUB_OUTPUT"
+
+    - id: restore
+      uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      with:
+        path: ${{ steps.paths.outputs.paths }}
+        key: go-${{ runner.os }}-${{ inputs.cache-name }}-${{ hashFiles('go.sum') }}-${{ github.sha }}
+        restore-keys: |
+          go-${{ runner.os }}-${{ inputs.cache-name }}-${{ hashFiles('go.sum') }}-
+          go-${{ runner.os }}-${{ inputs.cache-name }}-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -199,17 +199,9 @@ jobs:
       DOCKERHUB_OIDC_CONNECTION_ID: ${{ vars.DOCKERHUB_OIDC_CONNECTION_ID }}
       DOCKER_BUILD_RECORD_UPLOAD: 'true'
       DOCKER_BUILD_SUMMARY: 'true'
-    # Cloud workers compile each native platform in parallel; GitHub runners
-    # only orchestrate the builds.
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - platform: linux/amd64
-            runner: ubuntu-latest
-          - platform: linux/arm64
-            runner: ubuntu-24.04-arm
-    runs-on: ${{ matrix.runner }}
+    # Build Cloud compiles both platforms natively in parallel; one runner is
+    # enough to orchestrate the multi-platform build.
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -275,13 +267,15 @@ jobs:
           driver: cloud
           endpoint: ${{ env.DOCKER_BUILD_CLOUD_ENDPOINT }}
           version: lab:edge
+          # Downloading buildx takes seconds; caching it costs ~40 MB per branch.
+          cache-binary: false
 
       - name: Build image
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
         with:
           builder: ${{ steps.buildx.outputs.name }}
           context: .
-          platforms: ${{ matrix.platform }}
+          platforms: linux/amd64,linux/arm64
           outputs: type=cacheonly
           push: false
           load: false
@@ -298,7 +292,7 @@ jobs:
           builder: ${{ steps.buildx.outputs.name }}
           context: .
           target: template
-          platforms: ${{ matrix.platform }}
+          platforms: linux/amd64,linux/arm64
           outputs: type=cacheonly
           push: false
           load: false
@@ -319,10 +313,10 @@ jobs:
           github.ref == 'refs/heads/main' &&
           (inputs.image_mode == '' || inputs.image_mode == 'auto'))
       )
-    # Intentionally not gated on lint/tests: per-arch images are pushed by
-    # digest only (untagged), so building them in parallel with the test jobs
-    # shortens the pipeline without publishing anything user-visible. The
-    # merge jobs below hold the gate and are the only ones that move tags.
+    # Intentionally not gated on lint/tests: images are pushed by digest only
+    # (untagged), so building them in parallel with the test jobs shortens the
+    # pipeline without publishing anything user-visible. publish-tags below
+    # holds the gate and is the only job that moves tags.
     permissions:
       contents: read
       id-token: write
@@ -331,17 +325,12 @@ jobs:
       DOCKERHUB_OIDC_CONNECTION_ID: ${{ vars.DOCKERHUB_OIDC_CONNECTION_ID }}
       DOCKER_BUILD_RECORD_UPLOAD: 'false'
       DOCKER_BUILD_SUMMARY: 'false'
-    # Cloud workers build each native platform in parallel and push by digest;
-    # the merge jobs below assemble the multi-arch manifests.
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - platform: linux/amd64
-            runner: ubuntu-latest
-          - platform: linux/arm64
-            runner: ubuntu-24.04-arm
-    runs-on: ${{ matrix.runner }}
+    # Build Cloud builds both platforms natively in parallel and pushes the
+    # untagged multi-arch index by digest; publish-tags adds the tags.
+    runs-on: ubuntu-latest
+    outputs:
+      image-digest: ${{ steps.build.outputs.digest }}
+      template-digest: ${{ steps.build-template.outputs.digest }}
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -387,11 +376,6 @@ jobs:
             exit 1
           fi
 
-      - name: Prepare platform name
-        run: echo "PLATFORM_PAIR=${platform//\//-}" >> "$GITHUB_ENV"
-        env:
-          platform: ${{ matrix.platform }}
-
       - name: Get Docker Hub OIDC token
         id: docker_oidc
         uses: docker/oidc-action@b048fb089ace3e15a5fbdd784f4784d284ce5e8d # v1.1.0
@@ -412,6 +396,8 @@ jobs:
           driver: cloud
           endpoint: ${{ env.DOCKER_BUILD_CLOUD_ENDPOINT }}
           version: lab:edge
+          # Downloading buildx takes seconds; caching it costs ~40 MB per branch.
+          cache-binary: false
 
       - name: Docker metadata
         id: meta
@@ -426,7 +412,7 @@ jobs:
         with:
           builder: ${{ steps.buildx.outputs.name }}
           context: .
-          platforms: ${{ matrix.platform }}
+          platforms: linux/amd64,linux/arm64
           labels: ${{ steps.meta.outputs.labels }}
           load: false
           github-token: ''
@@ -436,20 +422,6 @@ jobs:
           build-args: |
             GIT_TAG=${{ github.ref_name }}
             GIT_COMMIT=${{ github.sha }}
-
-      - name: Export digest
-        run: |
-          mkdir -p "${RUNNER_TEMP}/digests"
-          digest="${{ steps.build.outputs.digest }}"
-          touch "${RUNNER_TEMP}/digests/${digest#sha256:}"
-
-      - name: Upload digest
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-        with:
-          name: digests-${{ env.PLATFORM_PAIR }}
-          path: ${{ runner.temp }}/digests/*
-          if-no-files-found: error
-          retention-days: 1
 
       # The sandbox template is a stage of the same Dockerfile with identical
       # build args, so it reuses the builder-linux layer from the image build
@@ -461,7 +433,7 @@ jobs:
           builder: ${{ steps.buildx.outputs.name }}
           context: .
           target: template
-          platforms: ${{ matrix.platform }}
+          platforms: linux/amd64,linux/arm64
           load: false
           github-token: ''
           sbom: true
@@ -471,22 +443,7 @@ jobs:
             GIT_TAG=${{ github.ref_name }}
             GIT_COMMIT=${{ github.sha }}
 
-      - name: Export template digest
-        env:
-          DIGEST: ${{ steps.build-template.outputs.digest }}
-        run: |
-          mkdir -p "${RUNNER_TEMP}/template-digests"
-          touch "${RUNNER_TEMP}/template-digests/${DIGEST#sha256:}"
-
-      - name: Upload template digest
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-        with:
-          name: template-digests-${{ env.PLATFORM_PAIR }}
-          path: ${{ runner.temp }}/template-digests/*
-          if-no-files-found: error
-          retention-days: 1
-
-  merge-and-push-image:
+  publish-tags:
     if: >-
       github.repository == 'docker/docker-agent' &&
       github.event.repository.fork == false && (
@@ -501,14 +458,10 @@ jobs:
       contents: read
       id-token: write
     runs-on: ubuntu-latest
+    env:
+      IMAGE_DIGEST: ${{ needs.build-and-push-image.outputs.image-digest }}
+      TEMPLATE_DIGEST: ${{ needs.build-and-push-image.outputs.template-digest }}
     steps:
-      - name: Download digests
-        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
-        with:
-          path: ${{ runner.temp }}/digests
-          pattern: digests-*
-          merge-multiple: true
-
       - name: Get Docker Hub OIDC token
         id: docker_oidc
         uses: docker/oidc-action@b048fb089ace3e15a5fbdd784f4784d284ce5e8d # v1.1.0
@@ -524,6 +477,8 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
+        with:
+          cache-binary: false
 
       - name: Docker metadata
         id: meta
@@ -536,75 +491,28 @@ jobs:
             type=edge
             type=ref,event=pr
 
-      - name: Create manifest list and push
-        working-directory: ${{ runner.temp }}/digests
+      - name: Tag image
+        env:
+          VERSION: ${{ steps.meta.outputs.version }}
         run: |
+          : "${IMAGE_DIGEST:?build-and-push-image produced no digest}"
           mapfile -t tags < <(jq -r '.tags[]' <<< "$DOCKER_METADATA_OUTPUT_JSON")
           args=()
           for tag in "${tags[@]}"; do args+=(-t "$tag"); done
-          for digest in *; do args+=("docker/docker-agent@sha256:${digest}"); done
-          docker buildx imagetools create "${args[@]}"
+          docker buildx imagetools create "${args[@]}" "docker/docker-agent@${IMAGE_DIGEST}"
+          docker buildx imagetools inspect "docker/docker-agent:${VERSION}"
 
-      - name: Inspect image
+      # On main only the edge tag moves; on a v* tag both the version tag and
+      # the floating latest tag that sandboxes pull by default.
+      - name: Tag template
         run: |
-          docker buildx imagetools inspect docker/docker-agent:${{ steps.meta.outputs.version }}
-
-  merge-and-push-template:
-    if: >-
-      github.repository == 'docker/docker-agent' &&
-      github.event.repository.fork == false && (
-        (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
-        (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')) ||
-        (github.event_name == 'workflow_dispatch' &&
-          github.ref == 'refs/heads/main' &&
-          (inputs.image_mode == '' || inputs.image_mode == 'auto'))
-      )
-    needs: [ lint, build-and-test, cross-compile-checks, windows-tests, license-check, build-and-push-image ]
-    permissions:
-      contents: read
-      id-token: write
-    runs-on: ubuntu-latest
-    steps:
-      - name: Download template digests
-        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
-        with:
-          path: ${{ runner.temp }}/template-digests
-          pattern: template-digests-*
-          merge-multiple: true
-
-      - name: Get Docker Hub OIDC token
-        id: docker_oidc
-        uses: docker/oidc-action@b048fb089ace3e15a5fbdd784f4784d284ce5e8d # v1.1.0
-        with:
-          connection-id: ${{ vars.DOCKERHUB_OIDC_CONNECTION_ID }}
-          expires-in: 3600
-
-      - name: Hub login
-        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
-        with:
-          username: docker
-          password: ${{ steps.docker_oidc.outputs.token }}
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
-
-      # Assemble the multi-arch manifest list from the per-arch digests pushed
-      # by build-and-push-image. On main only the edge tag moves; on a v* tag
-      # both the version tag and the floating latest tag that sandboxes pulls
-      # by default.
-      - name: Create manifest list and push
-        working-directory: ${{ runner.temp }}/template-digests
-        run: |
+          : "${TEMPLATE_DIGEST:?build-and-push-image produced no template digest}"
           if [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
-            tags=(-t "docker/docker-agent-sbx-templates:${GITHUB_REF_NAME#v}" -t "docker/docker-agent-sbx-templates:latest")
+            version="${GITHUB_REF_NAME#v}"
+            tags=(-t "docker/docker-agent-sbx-templates:${version}" -t "docker/docker-agent-sbx-templates:latest")
           else
+            version=edge
             tags=(-t "docker/docker-agent-sbx-templates:edge")
           fi
-          args=()
-          for digest in *; do args+=("docker/docker-agent-sbx-templates@sha256:${digest}"); done
-          docker buildx imagetools create "${tags[@]}" "${args[@]}"
-
-      - name: Inspect template
-        run: |
-          if [[ "${GITHUB_REF}" == refs/tags/v* ]]; then tag="${GITHUB_REF_NAME#v}"; else tag="edge"; fi
-          docker buildx imagetools inspect "docker/docker-agent-sbx-templates:${tag}"
+          docker buildx imagetools create "${tags[@]}" "docker/docker-agent-sbx-templates@${TEMPLATE_DIGEST}"
+          docker buildx imagetools inspect "docker/docker-agent-sbx-templates:${version}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,8 +152,8 @@ jobs:
     env:
       DOCKER_BUILD_CLOUD_ENDPOINT: docker/docker-agent
       DOCKERHUB_OIDC_CONNECTION_ID: ${{ vars.DOCKERHUB_OIDC_CONNECTION_ID }}
-      DOCKER_BUILD_RECORD_UPLOAD: 'false'
-      DOCKER_BUILD_SUMMARY: 'false'
+      DOCKER_BUILD_RECORD_UPLOAD: 'true'
+      DOCKER_BUILD_SUMMARY: 'true'
     # Cloud workers compile each native platform in parallel; GitHub runners
     # only orchestrate the builds.
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,13 +78,32 @@ jobs:
       - name: Build
         run: task build
 
-      - name: Cross-compile plan storage
-        run: task check-plan-cross
-
       - name: Run tests
         run: |
           task test
           task test-binary
+
+  # Compile-only checks that do not depend on the test run. Kept out of
+  # build-and-test so they run alongside it instead of extending its wall clock.
+  cross-compile-checks:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Set up Go
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
+        with:
+          go-version-file: go.mod
+          cache-dependency-path: go.sum
+
+      - name: Install Task
+        uses: go-task/setup-task@01a4adf9db2d14c1de7a560f09170b6e0df736aa # v2.1.0
+        with:
+          version: 3.51.1
+
+      - name: Cross-compile plan storage
+        run: task check-plan-cross
 
       - name: Test WASM provider registration
         run: task test-wasm-providers
@@ -274,7 +293,10 @@ jobs:
           github.ref == 'refs/heads/main' &&
           (inputs.image_mode == '' || inputs.image_mode == 'auto'))
       )
-    needs: [ lint, build-and-test, windows-tests, license-check ]
+    # Intentionally not gated on lint/tests: per-arch images are pushed by
+    # digest only (untagged), so building them in parallel with the test jobs
+    # shortens the pipeline without publishing anything user-visible. The
+    # merge jobs below hold the gate and are the only ones that move tags.
     permissions:
       contents: read
       id-token: write
@@ -448,7 +470,7 @@ jobs:
           github.ref == 'refs/heads/main' &&
           (inputs.image_mode == '' || inputs.image_mode == 'auto'))
       )
-    needs: [ build-and-push-image ]
+    needs: [ lint, build-and-test, cross-compile-checks, windows-tests, license-check, build-and-push-image ]
     permissions:
       contents: read
       id-token: write
@@ -511,7 +533,7 @@ jobs:
           github.ref == 'refs/heads/main' &&
           (inputs.image_mode == '' || inputs.image_mode == 'auto'))
       )
-    needs: [ build-and-push-image ]
+    needs: [ lint, build-and-test, cross-compile-checks, windows-tests, license-check, build-and-push-image ]
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,10 +36,8 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Set up Go
-        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
-        with:
-          go-version-file: go.mod
-          cache-dependency-path: go.sum
+        id: go
+        uses: ./.github/actions/setup-go
 
       - name: Lint
         uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
@@ -55,6 +53,13 @@ jobs:
       - name: Lint GitHub Workflows
         run: ./scripts/workflow-lint.sh
 
+      - name: Save Go caches
+        if: github.ref == 'refs/heads/main' && !cancelled()
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ${{ steps.go.outputs.cache-path }}
+          key: ${{ steps.go.outputs.cache-key }}
+
   build-and-test:
     runs-on: ubuntu-latest
     steps:
@@ -62,10 +67,8 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Set up Go
-        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
-        with:
-          go-version-file: go.mod
-          cache-dependency-path: go.sum
+        id: go
+        uses: ./.github/actions/setup-go
 
       - name: Install Task
         uses: go-task/setup-task@01a4adf9db2d14c1de7a560f09170b6e0df736aa # v2.1.0
@@ -83,6 +86,13 @@ jobs:
           task test
           task test-binary
 
+      - name: Save Go caches
+        if: github.ref == 'refs/heads/main' && !cancelled()
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ${{ steps.go.outputs.cache-path }}
+          key: ${{ steps.go.outputs.cache-key }}
+
   # Compile-only checks that do not depend on the test run. Kept out of
   # build-and-test so they run alongside it instead of extending its wall clock.
   cross-compile-checks:
@@ -92,10 +102,8 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Set up Go
-        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
-        with:
-          go-version-file: go.mod
-          cache-dependency-path: go.sum
+        id: go
+        uses: ./.github/actions/setup-go
 
       - name: Install Task
         uses: go-task/setup-task@01a4adf9db2d14c1de7a560f09170b6e0df736aa # v2.1.0
@@ -105,8 +113,16 @@ jobs:
       - name: Cross-compile plan storage
         run: task check-plan-cross
 
+      # The e2e dependency check is already covered by `task test` in build-and-test.
       - name: Test WASM provider registration
-        run: task test-wasm-providers
+        run: task test-wasm-js
+
+      - name: Save Go caches
+        if: github.ref == 'refs/heads/main' && !cancelled()
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ${{ steps.go.outputs.cache-path }}
+          key: ${{ steps.go.outputs.cache-key }}
 
   # Native Windows tests. Plan storage relies on OS-specific file locking and
   # path semantics, so the full Go test suite runs natively on Windows in a
@@ -119,10 +135,8 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Set up Go
-        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
-        with:
-          go-version-file: go.mod
-          cache-dependency-path: go.sum
+        id: go
+        uses: ./.github/actions/setup-go
 
       - name: Install Task
         uses: go-task/setup-task@01a4adf9db2d14c1de7a560f09170b6e0df736aa # v2.1.0
@@ -135,6 +149,13 @@ jobs:
       - name: Run tests
         run: task test
 
+      - name: Save Go caches
+        if: github.ref == 'refs/heads/main' && !cancelled()
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ${{ steps.go.outputs.cache-path }}
+          key: ${{ steps.go.outputs.cache-key }}
+
   license-check:
     runs-on: ubuntu-latest
     steps:
@@ -142,16 +163,21 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Set up Go
-        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
-        with:
-          go-version-file: go.mod
-          cache-dependency-path: go.sum
+        id: go
+        uses: ./.github/actions/setup-go
 
       - name: Install go-licences
         run: go install github.com/google/go-licenses@latest
 
       - name: Check licenses
         run: go-licenses check . --allowed_licenses=Apache-2.0,MIT,BSD-3-Clause,BSD-2-Clause --ignore modernc.org/mathutil --ignore github.com/hashicorp/hcl/v2
+
+      - name: Save Go caches
+        if: github.ref == 'refs/heads/main' && !cancelled()
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ${{ steps.go.outputs.cache-path }}
+          key: ${{ steps.go.outputs.cache-key }}
 
   build-image:
     if: >-

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -110,9 +110,16 @@ tasks:
   test-wasm-providers:
     desc: Test explicit provider registration in the WASM demo (requires Node)
     cmds:
+      - task: test-wasm-js
+      - go test ./e2e -run '^TestWasmProviderDependencies$'
+
+  # The GOOS=js half of test-wasm-providers; the e2e check above already runs
+  # under `task test`, so CI calls this to avoid recompiling the e2e package.
+  test-wasm-js:
+    desc: Run the GOOS=js provider registration tests (requires Node)
+    cmds:
       - GOOS=js GOARCH=wasm go test -exec="$(go env GOROOT)/lib/wasm/go_js_wasm_exec" ./cmd/wasm
       - GOOS=js GOARCH=wasm go test -exec="$(go env GOROOT)/lib/wasm/go_js_wasm_exec" pkg/model/provider/factory_js_openai_vendor_test.go
-      - go test ./e2e -run '^TestWasmProviderDependencies$'
 
   test-binary:
     desc: Run tests on build binary


### PR DESCRIPTION
## Why

A `main` run took ~13–15 min and a PR run ~8–10 min. Per-step timings showed the time goes to compiling, not testing: every job recompiled the whole dependency tree because the Go build cache was effectively cold (see commit 2), and the image pipeline used 2× the runners it needed.

## What (one commit each)

Runners are left as-is: on a public repo `ubuntu-latest`/`windows-latest` are already 4-core, and the org's larger runners are out of scope here.

1. **Parallelize compile-only checks and image builds** — `check-plan-cross` + `test-wasm-providers` move to a `cross-compile-checks` job; `build-and-push-image` no longer waits on tests (it pushes untagged digests only), the gate moves to the tag-publishing job.
2. **Per-job warm Go cache** — `setup-go`'s built-in cache is keyed on `go.sum` alone, so one snapshot per OS was saved on 2026-08-31 and every job since logged `Cache hit … not saving cache`. New composite `.github/actions/setup-go` restores `GOMODCACHE`+`GOCACHE` keyed `<os>-<job>-<go.sum>-<sha>` with prefix fallback; saved on `main` only. Also drops the redundant `go test ./e2e -run TestWasmProviderDependencies` from CI (already covered by `task test`; cold it cost ~2 min to compile e2e).
3. **One Build Cloud job per stage** — Build Cloud compiles both platforms natively, so the per-platform matrices only doubled runners. Digests flow as job outputs, no artifacts; the two merge jobs collapse into `publish-tags`. `cache-binary: false` on buildx stops a ~40 MB cache write per PR branch.

## Measured so far

PR run [34463832719](https://github.com/docker/docker-agent/actions/runs/34463832719) vs the last run on the previous layout ([34458544304](https://github.com/docker/docker-agent/actions/runs/34458544304)). Caches are not seeded yet (saves happen on `main` only), so every job here starts cold — this is the floor, not the target.

| job | before | this PR | note |
|---|---|---|---|
| **required checks green** | **8:15** | **~5:45** | |
| lint | 3:08 | 4:10 | cold module download until `main` seeds a cache |
| build-and-test | 8:15 | 5:44 | compile-only checks moved out |
| cross-compile-checks | (in build-and-test) | 4:31 | e2e trim; cold |
| windows-tests | 7:52–9:49 | 10:36 | `Set up Go` 2:19 → 0:23 (no stale 944 MB restore); `Run tests` 5:46 → 9:58 cold |
| license-check | 1:01 | 1:19 | cold |
| build-image | 2 runners | 1 runner, 1:07 | both platforms in one Build Cloud job |

After merge: the first `main` run seeds one cache per job; the next PR run is the real measurement (expected: build ~20 s, lint <1 min, cross-compile <1 min, Windows tests ~3–4 min). Windows cache size is the thing to check — if it lands well above 1 GB the restore eats into the gain.

## Tradeoffs

- A failed test run leaves untagged digests on Hub (nothing user-visible moves; GC'd eventually).
- Each `main` run saves 5 caches (~0.5–1 GB each). The repo is at the 10 GB cap (503 caches, mostly per-PR `buildx-dl-bin-*`), so stale entries should be purged once this lands.
- Windows cache restore is slow (2+ min for ~1 GB); net gain expected but to be confirmed.

## Follow-ups (repo settings, not in this PR)

- Add `cross-compile-checks` and `windows-tests` to the `main` ruleset's required checks (currently only `build-and-test`, `license-check`, `lint`).
- Purge stale caches: `gh cache list --limit 500 --json id,key --jq '.[] | select(.key|test("^(buildx-dl-bin|setup-go-)")) | .id' | xargs -n1 gh cache delete`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
