### PR TITLE
docs: auto-update for merged PRs (2026-09-11)

### DIFF
--- a/docs/tools/filesystem/index.md
+++ b/docs/tools/filesystem/index.md
@@ -18,15 +18,12 @@ The filesystem tool gives agents the ability to explore codebases, read and edit
 Paths are resolved relative to the **working directory** (the directory where the agent session started, or the directory specified with `--working-dir`):
 
 - **Relative paths** (e.g., `src/main.go`, `../README.md`) are joined with the working directory.
-- **Absolute paths** must match the host operating system:
+- **Absolute paths** are used as-is, in the host operating system's own syntax:
   - Unix/Linux/macOS: `/home/user/project/file.txt`
   - Windows: `C:\Users\user\project\file.txt` or `C:/Users/user/project/file.txt`
 - **Home directory expansion**: paths starting with `~` or `~/` expand to the user's home directory.
 
-When a file is not found, error messages include the resolved absolute path to help diagnose incorrect base directories or path formats.
-
-> [!IMPORTANT]
-> Agents must use paths appropriate for the host OS. A Windows absolute path like `C:\file.txt` on a Unix system (or vice versa) is rejected with a clear error message.
+When a file is not found, the tool reports "not found" without further detail.
 
 ### Empty directory detection
 


### PR DESCRIPTION
## What and why

Keeps `/docs` in sync with code merged into `main` in the last 36 hours.

### Filesystem tool: remove stale foreign-OS path rejection docs (#4222)

PR #4222 reverted the foreign-OS absolute-path rejection and the
resolved-path "not found" error hint that a previous change had added to
the filesystem tool. `docs/tools/filesystem/index.md` still documented
both as current behavior:

- Removed the claim that absolute paths "must match the host operating
  system" and are rejected otherwise — absolute paths are now used as-is
  again, in whatever syntax the caller supplies.
- Removed the `[!IMPORTANT]` callout describing the rejection error.
- Corrected the "file not found" description: error messages no longer
  include the resolved absolute path/working directory hint.

### PRs reviewed with no doc changes needed

The rest of the PRs merged in the window either shipped their own doc
updates in the same PR (e.g. #4211 hooks, #4214 OpenAI service tier,
#4030/#4025 generated media, #4215, #4221's `docs/STYLE.md` fix), only
touched CI/tooling with no user-facing docs impact (#4219, #4220, #4223,
#4221, #4208), were changelog-only (#4226, #4212), or were internal
bugfixes/implementation details with no documented behavior to update
(#4224, #4182, #4028, #4026, #4027, #4029, #4024).

## Source PRs

- docker/docker-agent#4222 (doc fix in this PR)
- Reviewed, no changes needed: #4226, #4224, #4223, #4221, #4220, #4219,
  #4216, #4215, #4214, #4212, #4211, #4208, #4182, #4030, #4029, #4028,
  #4027, #4026, #4025, #4024