### PR TITLE
feat: add secure HTTP relay packages

### DIFF
--- a/pkg/config/httprelay/httprelay.go
+++ b/pkg/config/httprelay/httprelay.go
@@ -1,0 +1,155 @@
+// Package httprelay exposes a remote agent configuration through an HTTP handler.
+package httprelay
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"time"
+)
+
+const (
+	defaultMaxBytes = 1 << 20
+	defaultTimeout  = 30 * time.Second
+)
+
+// Source resolves the trusted upstream URL for a request. Implementations must
+// not return unvalidated user input.
+type Source func(*http.Request) (*url.URL, error)
+
+// Option configures a Handler.
+type Option func(*Handler)
+
+// Handler relays an agent configuration from a trusted HTTP endpoint.
+type Handler struct {
+	source   Source
+	client   *http.Client
+	maxBytes int64
+	timeout  time.Duration
+}
+
+// New creates a configuration relay. Redirects are always refused so request
+// credentials cannot be replayed to another endpoint.
+func New(source Source, opts ...Option) (*Handler, error) {
+	if source == nil {
+		return nil, errors.New("config relay source is required")
+	}
+	h := &Handler{source: source, maxBytes: defaultMaxBytes, timeout: defaultTimeout}
+	for _, opt := range opts {
+		opt(h)
+	}
+	if h.maxBytes <= 0 {
+		return nil, errors.New("config relay maximum size must be positive")
+	}
+	if h.timeout <= 0 {
+		return nil, errors.New("config relay timeout must be positive")
+	}
+	if h.client == nil {
+		h.client = &http.Client{}
+	} else {
+		clone := *h.client
+		h.client = &clone
+	}
+	h.client.CheckRedirect = func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse }
+	return h, nil
+}
+
+// WithClient sets the outbound client. Its redirect policy is replaced with a
+// no-redirect policy.
+func WithClient(client *http.Client) Option {
+	return func(h *Handler) { h.client = client }
+}
+
+// WithMaxBytes sets the maximum accepted configuration size.
+func WithMaxBytes(n int64) Option {
+	return func(h *Handler) { h.maxBytes = n }
+}
+
+// WithTimeout sets the end-to-end upstream request timeout.
+func WithTimeout(timeout time.Duration) Option {
+	return func(h *Handler) { h.timeout = timeout }
+}
+
+// ServeHTTP fetches and returns the configuration.
+func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	_ = h.Serve(w, r)
+}
+
+// Serve fetches and returns the configuration. It writes a generic error to
+// the client and returns the detailed cause for logging.
+func (h *Handler) Serve(w http.ResponseWriter, r *http.Request) error {
+	if r.Method != http.MethodGet && r.Method != http.MethodHead {
+		w.Header().Set("Allow", "GET, HEAD")
+		http.Error(w, http.StatusText(http.StatusMethodNotAllowed), http.StatusMethodNotAllowed)
+		return nil
+	}
+
+	target, err := h.source(r)
+	if err != nil {
+		http.Error(w, "agent configuration unavailable", http.StatusBadGateway)
+		return fmt.Errorf("resolve agent configuration: %w", err)
+	}
+	if !validTarget(target) {
+		http.Error(w, "agent configuration unavailable", http.StatusBadGateway)
+		return errors.New("resolve agent configuration: invalid upstream URL")
+	}
+
+	ctx, cancel := context.WithTimeout(r.Context(), h.timeout)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, target.String(), http.NoBody)
+	if err != nil {
+		http.Error(w, "agent configuration unavailable", http.StatusBadGateway)
+		return fmt.Errorf("create agent configuration request: %w", err)
+	}
+	resp, err := h.client.Do(req)
+	if err != nil {
+		http.Error(w, "agent configuration unavailable", http.StatusBadGateway)
+		return fmt.Errorf("fetch agent configuration: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		http.Error(w, "agent configuration unavailable", http.StatusBadGateway)
+		return fmt.Errorf("fetch agent configuration: upstream returned %s", resp.Status)
+	}
+
+	body, err := readBounded(resp.Body, h.maxBytes)
+	if err != nil {
+		http.Error(w, "agent configuration unavailable", http.StatusBadGateway)
+		return fmt.Errorf("read agent configuration: %w", err)
+	}
+	if len(body) == 0 {
+		http.Error(w, "agent configuration unavailable", http.StatusBadGateway)
+		return errors.New("read agent configuration: empty response")
+	}
+	contentType := resp.Header.Get("Content-Type")
+	if contentType == "" {
+		contentType = "application/yaml"
+	}
+	w.Header().Set("Content-Type", contentType)
+	w.Header().Set("Cache-Control", "no-store")
+	w.Header().Set("Content-Length", strconv.Itoa(len(body)))
+	if r.Method == http.MethodGet {
+		_, err = w.Write(body)
+	}
+	return err
+}
+
+func validTarget(target *url.URL) bool {
+	return target != nil && target.Host != "" && target.User == nil &&
+		(target.Scheme == "http" || target.Scheme == "https")
+}
+
+func readBounded(r io.Reader, maxBytes int64) ([]byte, error) {
+	body, err := io.ReadAll(io.LimitReader(r, maxBytes+1))
+	if err != nil {
+		return nil, err
+	}
+	if int64(len(body)) > maxBytes {
+		return nil, errors.New("response exceeds maximum size")
+	}
+	return body, nil
+}

--- a/pkg/config/httprelay/httprelay_test.go
+++ b/pkg/config/httprelay/httprelay_test.go
@@ -1,0 +1,101 @@
+package httprelay
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func source(raw string) Source {
+	return func(*http.Request) (*url.URL, error) { return url.Parse(raw) }
+}
+
+func TestHandlerRelaysConfiguration(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		w.Header().Set("X-Internal", "secret")
+		w.Header().Set("Content-Type", "application/yaml")
+		_, _ = io.WriteString(w, "version: 1\n")
+	}))
+	defer upstream.Close()
+
+	h, err := New(source(upstream.URL), WithMaxBytes(64))
+	require.NoError(t, err)
+	for _, method := range []string{http.MethodGet, http.MethodHead} {
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, httptest.NewRequestWithContext(t.Context(), method, "/agent", http.NoBody))
+		assert.Equal(t, http.StatusOK, w.Code)
+		assert.Equal(t, "application/yaml", w.Header().Get("Content-Type"))
+		assert.Equal(t, "no-store", w.Header().Get("Cache-Control"))
+		assert.Empty(t, w.Header().Get("X-Internal"))
+		if method == http.MethodGet {
+			assert.Equal(t, "version: 1\n", w.Body.String())
+		} else {
+			assert.Empty(t, w.Body.String())
+		}
+	}
+}
+
+func TestHandlerRejectsInvalidResponses(t *testing.T) {
+	for name, handler := range map[string]http.HandlerFunc{
+		"empty":     func(http.ResponseWriter, *http.Request) {},
+		"oversized": func(w http.ResponseWriter, _ *http.Request) { _, _ = io.WriteString(w, strings.Repeat("x", 9)) },
+		"status":    func(w http.ResponseWriter, _ *http.Request) { http.Error(w, "private detail", http.StatusNotFound) },
+	} {
+		t.Run(name, func(t *testing.T) {
+			upstream := httptest.NewServer(handler)
+			defer upstream.Close()
+			h, err := New(source(upstream.URL), WithMaxBytes(8))
+			require.NoError(t, err)
+			w := httptest.NewRecorder()
+			h.ServeHTTP(w, httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/", http.NoBody))
+			assert.Equal(t, http.StatusBadGateway, w.Code)
+			assert.NotContains(t, w.Body.String(), "private detail")
+		})
+	}
+}
+
+func TestHandlerRefusesRedirects(t *testing.T) {
+	followed := false
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/target" {
+			followed = true
+		}
+		http.Redirect(w, r, "/target", http.StatusTemporaryRedirect)
+	}))
+	defer upstream.Close()
+
+	client := &http.Client{CheckRedirect: func(*http.Request, []*http.Request) error {
+		t.Fatal("caller redirect policy must be replaced")
+		return nil
+	}}
+	h, err := New(source(upstream.URL), WithClient(client))
+	require.NoError(t, err)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/", http.NoBody))
+	assert.Equal(t, http.StatusBadGateway, w.Code)
+	assert.False(t, followed)
+	assert.Empty(t, w.Header().Get("Location"))
+}
+
+func TestHandlerMethodAndOptions(t *testing.T) {
+	_, err := New(nil)
+	require.Error(t, err)
+	_, err = New(source("https://example.com"), WithMaxBytes(0))
+	require.Error(t, err)
+	_, err = New(source("https://example.com"), WithTimeout(0*time.Second))
+	require.Error(t, err)
+
+	h, err := New(source("https://example.com"))
+	require.NoError(t, err)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/", http.NoBody))
+	assert.Equal(t, http.StatusMethodNotAllowed, w.Code)
+}

--- a/pkg/modelsgateway/relay/relay.go
+++ b/pkg/modelsgateway/relay/relay.go
@@ -1,0 +1,353 @@
+// Package relay securely relays model API requests to a trusted upstream gateway.
+package relay
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+const (
+	defaultMaxRequestBytes = 1 << 20
+	defaultMaxStreamLine   = 1 << 20
+	defaultTimeout         = 5 * time.Minute
+)
+
+// TokenSource supplies and invalidates upstream credentials.
+type TokenSource interface {
+	Token(ctx context.Context) (string, error)
+	Invalidate(token string)
+}
+
+// RequestInfo describes the validated request fields needed by the relay.
+type RequestInfo struct {
+	Stream bool
+	Values map[string]string
+}
+
+// Credentials applies an upstream token to a request.
+type Credentials func(header http.Header, token string)
+
+// Validator validates the request body and query before credentials are used.
+type Validator interface {
+	Validate(body []byte, query url.Values) (RequestInfo, error)
+}
+
+// StreamObserver inspects SSE data fields and verifies stream completion.
+type StreamObserver interface {
+	Observe(data []byte)
+	Complete() bool
+}
+
+// Target resolves a trusted upstream base URL for a request. Implementations
+// must not return unvalidated user input.
+type Target func(*http.Request) (*url.URL, error)
+
+// Result reports the upstream response and validator metadata.
+type Result struct {
+	Status int
+	Info   RequestInfo
+}
+
+// Option configures a Relay.
+type Option func(*Relay)
+
+// Relay forwards validated requests to a models gateway.
+type Relay struct {
+	target          Target
+	path            string
+	tokens          TokenSource
+	validator       Validator
+	client          *http.Client
+	maxRequestBytes int64
+	maxStreamLine   int
+	timeout         time.Duration
+	requestHeaders  []string
+	responseHeaders []string
+	newObserver     func() StreamObserver
+	streamError     []byte
+	credentials     Credentials
+}
+
+// New creates a relay with restrictive defaults. The target, path, token
+// source, and request validator are required.
+func New(target Target, path string, tokens TokenSource, validator Validator, opts ...Option) (*Relay, error) {
+	r := &Relay{
+		target: target, path: path, tokens: tokens, validator: validator,
+		maxRequestBytes: defaultMaxRequestBytes,
+		maxStreamLine:   defaultMaxStreamLine,
+		timeout:         defaultTimeout,
+		requestHeaders:  []string{"Content-Type", "Accept"},
+		responseHeaders: []string{"Content-Type", "Request-Id"},
+		credentials: func(header http.Header, token string) {
+			header.Set("Authorization", "Bearer "+token)
+		},
+	}
+	for _, opt := range opts {
+		opt(r)
+	}
+	if r.target == nil || r.tokens == nil || r.validator == nil {
+		return nil, errors.New("gateway relay target, token source, and validator are required")
+	}
+	if path == "" || !strings.HasPrefix(path, "/") {
+		return nil, errors.New("gateway relay path must be absolute")
+	}
+	if r.maxRequestBytes <= 0 || r.maxStreamLine <= 0 || r.timeout <= 0 {
+		return nil, errors.New("gateway relay limits must be positive")
+	}
+	if r.credentials == nil {
+		return nil, errors.New("gateway relay credentials function is required")
+	}
+	for _, name := range append(append([]string(nil), r.requestHeaders...), r.responseHeaders...) {
+		if !allowedHeader(name) {
+			return nil, fmt.Errorf("gateway relay header %q is not allowed", name)
+		}
+	}
+	if r.client == nil {
+		r.client = &http.Client{}
+	} else {
+		clone := *r.client
+		r.client = &clone
+	}
+	r.client.CheckRedirect = func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse }
+	return r, nil
+}
+
+// WithClient sets the outbound client. Its redirect policy is always replaced.
+func WithClient(client *http.Client) Option { return func(r *Relay) { r.client = client } }
+
+// WithTimeout sets the timeout for one upstream call.
+func WithTimeout(timeout time.Duration) Option { return func(r *Relay) { r.timeout = timeout } }
+
+// WithMaxRequestBytes sets the request body limit.
+func WithMaxRequestBytes(n int64) Option { return func(r *Relay) { r.maxRequestBytes = n } }
+
+// WithMaxStreamLineBytes sets the maximum SSE line size.
+func WithMaxStreamLineBytes(n int) Option { return func(r *Relay) { r.maxStreamLine = n } }
+
+// WithRequestHeaders replaces the request header allowlist.
+func WithRequestHeaders(headers ...string) Option {
+	return func(r *Relay) { r.requestHeaders = append([]string(nil), headers...) }
+}
+
+// WithResponseHeaders replaces the response header allowlist.
+func WithResponseHeaders(headers ...string) Option {
+	return func(r *Relay) { r.responseHeaders = append([]string(nil), headers...) }
+}
+
+// WithCredentials sets how the upstream token is represented. By default it
+// is sent only as an Authorization bearer token.
+func WithCredentials(credentials Credentials) Option {
+	return func(r *Relay) { r.credentials = credentials }
+}
+
+// WithStreamObserver enables SSE observation and completion validation.
+func WithStreamObserver(newObserver func() StreamObserver) Option {
+	return func(r *Relay) { r.newObserver = newObserver }
+}
+
+// WithStreamInterruptedEvent sets bytes appended when a streamed response is incomplete.
+func WithStreamInterruptedEvent(event []byte) Option {
+	return func(r *Relay) { r.streamError = append([]byte(nil), event...) }
+}
+
+// Serve forwards one POST. It always writes a client response; returned errors
+// are intended for server logs and may contain upstream details.
+func (r *Relay) Serve(w http.ResponseWriter, req *http.Request) (Result, error) {
+	var result Result
+	if req.Method != http.MethodPost {
+		result.Status = http.StatusMethodNotAllowed
+		w.Header().Set("Allow", http.MethodPost)
+		http.Error(w, http.StatusText(http.StatusMethodNotAllowed), http.StatusMethodNotAllowed)
+		return result, nil
+	}
+	body, err := io.ReadAll(http.MaxBytesReader(w, req.Body, r.maxRequestBytes))
+	if err != nil {
+		if _, ok := errors.AsType[*http.MaxBytesError](err); ok {
+			result.Status = http.StatusRequestEntityTooLarge
+			http.Error(w, "request body too large", result.Status)
+		} else {
+			result.Status = http.StatusBadRequest
+			http.Error(w, "invalid request body", result.Status)
+		}
+		return result, nil
+	}
+	query, err := url.ParseQuery(req.URL.RawQuery)
+	if err != nil {
+		result.Status = http.StatusBadRequest
+		http.Error(w, "invalid request query", result.Status)
+		return result, nil
+	}
+	result.Info, err = r.validator.Validate(body, query)
+	if err != nil {
+		result.Status = http.StatusBadRequest
+		http.Error(w, err.Error(), result.Status)
+		return result, nil
+	}
+	base, err := r.target(req)
+	if err != nil || !validTarget(base) {
+		result.Status = http.StatusBadGateway
+		http.Error(w, "gateway request failed", result.Status)
+		return result, err
+	}
+
+	ctx, cancel := context.WithTimeout(req.Context(), r.timeout)
+	defer cancel()
+	resp, err := r.call(ctx, req, base, body, query)
+	if err != nil {
+		result.Status = http.StatusBadGateway
+		http.Error(w, "gateway request failed", result.Status)
+		return result, err
+	}
+	defer resp.Body.Close()
+	result.Status = resp.StatusCode
+
+	for _, name := range r.responseHeaders {
+		if allowedHeader(name) {
+			copyHeader(w.Header(), resp.Header, name)
+		}
+	}
+	w.Header().Set("Cache-Control", "no-store")
+	w.Header().Set("X-Accel-Buffering", "no")
+	w.WriteHeader(resp.StatusCode)
+
+	if result.Info.Stream && resp.StatusCode == http.StatusOK {
+		var observer StreamObserver
+		if r.newObserver != nil {
+			observer = r.newObserver()
+		}
+		err = r.relayStream(w, resp.Body, observer)
+		if err != nil && len(r.streamError) != 0 {
+			_, _ = w.Write(r.streamError)
+			flush(w)
+		}
+		return result, err
+	}
+	_, err = io.Copy(w, resp.Body)
+	return result, err
+}
+
+func (r *Relay) call(ctx context.Context, incoming *http.Request, base *url.URL, body []byte, query url.Values) (*http.Response, error) {
+	token, err := r.tokens.Token(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("get gateway token: %w", err)
+	}
+	resp, err := r.do(ctx, incoming, base, body, query, token)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode != http.StatusUnauthorized {
+		if resp.StatusCode >= 300 && resp.StatusCode < 400 {
+			resp.Body.Close()
+			return nil, errors.New("gateway returned a redirect")
+		}
+		return resp, nil
+	}
+	_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 64<<10))
+	resp.Body.Close()
+	r.tokens.Invalidate(token)
+	fresh, err := r.tokens.Token(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("refresh gateway token: %w", err)
+	}
+	if fresh == token {
+		return nil, errors.New("gateway token refresh returned the rejected credential")
+	}
+	resp, err = r.do(ctx, incoming, base, body, query, fresh)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode == http.StatusUnauthorized {
+		resp.Body.Close()
+		return nil, errors.New("gateway rejected refreshed credentials")
+	}
+	if resp.StatusCode >= 300 && resp.StatusCode < 400 {
+		resp.Body.Close()
+		return nil, errors.New("gateway returned a redirect")
+	}
+	return resp, nil
+}
+
+func (r *Relay) do(ctx context.Context, incoming *http.Request, base *url.URL, body []byte, query url.Values, token string) (*http.Response, error) {
+	target := *base
+	target.Path = strings.TrimRight(target.Path, "/") + r.path
+	targetQuery := target.Query()
+	for name, values := range query {
+		targetQuery[name] = append([]string(nil), values...)
+	}
+	target.RawQuery = targetQuery.Encode()
+	out, err := http.NewRequestWithContext(ctx, http.MethodPost, target.String(), bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	for _, name := range r.requestHeaders {
+		if allowedHeader(name) {
+			copyHeader(out.Header, incoming.Header, name)
+		}
+	}
+	r.credentials(out.Header, token)
+	resp, err := r.client.Do(out)
+	if err != nil {
+		return nil, fmt.Errorf("call gateway: %w", err)
+	}
+	return resp, nil
+}
+
+func (r *Relay) relayStream(w http.ResponseWriter, body io.Reader, observer StreamObserver) error {
+	scanner := bufio.NewScanner(body)
+	scanner.Buffer(make([]byte, 0, 64<<10), r.maxStreamLine)
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		if _, err := w.Write(append(line, '\n')); err != nil {
+			return err
+		}
+		if len(line) == 0 {
+			flush(w)
+		} else if observer != nil {
+			if data, ok := bytes.CutPrefix(line, []byte("data:")); ok {
+				observer.Observe(bytes.TrimSpace(data))
+			}
+		}
+	}
+	flush(w)
+	if err := scanner.Err(); err != nil {
+		return err
+	}
+	if observer != nil && !observer.Complete() {
+		return errors.New("gateway stream ended before completion")
+	}
+	return nil
+}
+
+func validTarget(target *url.URL) bool {
+	return target != nil && target.Host != "" && target.User == nil &&
+		(target.Scheme == "http" || target.Scheme == "https")
+}
+
+func allowedHeader(name string) bool {
+	switch http.CanonicalHeaderKey(name) {
+	case "Authorization", "Proxy-Authorization", "Cookie", "Set-Cookie", "X-Api-Key", "X-Goog-Api-Key", "X-Csrf-Token", "X-Cagent-Forward":
+		return false
+	default:
+		return true
+	}
+}
+
+func copyHeader(dst, src http.Header, name string) {
+	for _, value := range src.Values(name) {
+		dst.Add(name, value)
+	}
+}
+
+func flush(w http.ResponseWriter) {
+	if f, ok := w.(http.Flusher); ok {
+		f.Flush()
+	}
+}

--- a/pkg/modelsgateway/relay/relay_test.go
+++ b/pkg/modelsgateway/relay/relay_test.go
@@ -1,0 +1,185 @@
+package relay
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type tokens struct {
+	values      []string
+	invalidated []string
+}
+
+func (t *tokens) Token(context.Context) (string, error) {
+	if len(t.values) == 0 {
+		return "", errors.New("no token")
+	}
+	value := t.values[0]
+	t.values = t.values[1:]
+	return value, nil
+}
+func (t *tokens) Invalidate(value string) { t.invalidated = append(t.invalidated, value) }
+
+type validator struct{}
+
+func (validator) Validate(body []byte, query url.Values) (RequestInfo, error) {
+	if query.Get("allowed") != "true" {
+		return RequestInfo{}, errors.New("query is not allowed")
+	}
+	var request struct {
+		Stream bool `json:"stream"`
+	}
+	if err := json.Unmarshal(body, &request); err != nil {
+		return RequestInfo{}, errors.New("invalid JSON")
+	}
+	return RequestInfo{Stream: request.Stream, Values: map[string]string{"kind": "test"}}, nil
+}
+
+type observer struct{ complete bool }
+
+func (o *observer) Observe(data []byte) { o.complete = o.complete || string(data) == "done" }
+func (o *observer) Complete() bool      { return o.complete }
+
+func target(raw string) Target {
+	return func(*http.Request) (*url.URL, error) { return url.Parse(raw) }
+}
+
+func TestRelayForwardsValidatedRequest(t *testing.T) {
+	var received *http.Request
+	var receivedBody string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		received = r.Clone(r.Context())
+		body, _ := io.ReadAll(r.Body)
+		receivedBody = string(body)
+		w.Header().Set("Request-Id", "req-1")
+		w.Header().Set("X-Internal", "secret")
+		_, _ = io.WriteString(w, `{"ok":true}`)
+	}))
+	defer upstream.Close()
+
+	r, err := New(target(upstream.URL+"/proxy"), "/v1/messages", &tokens{values: []string{"token"}}, validator{},
+		WithRequestHeaders("Content-Type", "X-Custom"))
+	require.NoError(t, err)
+	request := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/relay?allowed=true", strings.NewReader(`{"stream":false}`))
+	request.Header.Set("Content-Type", "application/json")
+	request.Header.Set("X-Custom", "value")
+	request.Header.Set("Cookie", "session=secret")
+	request.Header.Set("Authorization", "Bearer attacker")
+	w := httptest.NewRecorder()
+	result, err := r.Serve(w, request)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, `{"ok":true}`, w.Body.String())
+	assert.Equal(t, http.StatusOK, result.Status)
+	assert.Equal(t, "test", result.Info.Values["kind"])
+	assert.Equal(t, "/proxy/v1/messages", received.URL.Path)
+	assert.Equal(t, "allowed=true", received.URL.RawQuery)
+	assert.Equal(t, `{"stream":false}`, receivedBody)
+	assert.Equal(t, "Bearer token", received.Header.Get("Authorization"))
+	assert.Empty(t, received.Header.Get("X-Api-Key"))
+	assert.Equal(t, "value", received.Header.Get("X-Custom"))
+	assert.Empty(t, received.Header.Get("Cookie"))
+	assert.Equal(t, "req-1", w.Header().Get("Request-Id"))
+	assert.Empty(t, w.Header().Get("X-Internal"))
+}
+
+func TestRelayRefreshesOnceAndHidesPersistentUnauthorized(t *testing.T) {
+	var calls int
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		if r.Header.Get("Authorization") != "Bearer fresh" {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		_, _ = io.WriteString(w, "ok")
+	}))
+	defer upstream.Close()
+	toks := &tokens{values: []string{"stale", "fresh"}}
+	r, err := New(target(upstream.URL), "/messages", toks, validator{})
+	require.NoError(t, err)
+	w := httptest.NewRecorder()
+	_, err = r.Serve(w, httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/?allowed=true", strings.NewReader(`{}`)))
+	require.NoError(t, err)
+	assert.Equal(t, "ok", w.Body.String())
+	assert.Equal(t, []string{"stale"}, toks.invalidated)
+	assert.Equal(t, 2, calls)
+
+	always401 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusUnauthorized) }))
+	defer always401.Close()
+	r, err = New(target(always401.URL), "/messages", &tokens{values: []string{"one", "two"}}, validator{})
+	require.NoError(t, err)
+	w = httptest.NewRecorder()
+	_, err = r.Serve(w, httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/?allowed=true", strings.NewReader(`{}`)))
+	require.Error(t, err)
+	assert.Equal(t, http.StatusBadGateway, w.Code)
+	assert.NotContains(t, w.Body.String(), "credentials")
+}
+
+func TestRelayStreamsAndDetectsTruncation(t *testing.T) {
+	for name, body := range map[string]string{
+		"complete":  "data: hello\n\ndata: done\n\n",
+		"truncated": "data: hello\n\n",
+	} {
+		t.Run(name, func(t *testing.T) {
+			upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { _, _ = io.WriteString(w, body) }))
+			defer upstream.Close()
+			r, err := New(target(upstream.URL), "/messages", &tokens{values: []string{"token"}}, validator{},
+				WithStreamObserver(func() StreamObserver { return &observer{} }),
+				WithStreamInterruptedEvent([]byte("data: interrupted\n\n")))
+			require.NoError(t, err)
+			w := httptest.NewRecorder()
+			_, err = r.Serve(w, httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/?allowed=true", strings.NewReader(`{"stream":true}`)))
+			if name == "complete" {
+				require.NoError(t, err)
+				assert.Equal(t, body, w.Body.String())
+			} else {
+				require.Error(t, err)
+				assert.Equal(t, body+"data: interrupted\n\n", w.Body.String())
+			}
+		})
+	}
+}
+
+func TestRelayRefusesRedirectsAndBadInput(t *testing.T) {
+	followed := false
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/target" {
+			followed = true
+		}
+		http.Redirect(w, r, "/target", http.StatusTemporaryRedirect)
+	}))
+	defer upstream.Close()
+	r, err := New(target(upstream.URL), "/messages", &tokens{values: []string{"token"}}, validator{}, WithClient(&http.Client{
+		CheckRedirect: func(*http.Request, []*http.Request) error { t.Fatal("must be replaced"); return nil },
+	}))
+	require.NoError(t, err)
+	w := httptest.NewRecorder()
+	_, err = r.Serve(w, httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/?allowed=true", strings.NewReader(`{}`)))
+	require.Error(t, err)
+	assert.Equal(t, http.StatusBadGateway, w.Code)
+	assert.False(t, followed)
+	assert.Empty(t, w.Header().Get("Location"))
+
+	for _, tc := range []struct {
+		method, path, body string
+		status             int
+	}{
+		{http.MethodGet, "/?allowed=true", "", http.StatusMethodNotAllowed},
+		{http.MethodPost, "/?no=true", `{}`, http.StatusBadRequest},
+		{http.MethodPost, "/?allowed=true", `{`, http.StatusBadRequest},
+	} {
+		w := httptest.NewRecorder()
+		_, _ = r.Serve(w, httptest.NewRequestWithContext(t.Context(), tc.method, tc.path, strings.NewReader(tc.body)))
+		assert.Equal(t, tc.status, w.Code)
+	}
+}


### PR DESCRIPTION
Two new packages handle the different relay concerns that had previously been mixed together. `pkg/config/httprelay` provides a thin, generic handler that fetches agent configuration from a trusted URL callback — the caller decides what URL is valid, and the handler ensures it is well-formed, uses an explicit scheme, and carries no embedded credentials. `pkg/modelsgateway/relay` handles the richer model-API forwarding path: request validation, upstream credential injection, SSE streaming with line-by-line flush, and optional stream-completion verification.

Both packages share a small set of design constraints applied consistently. The `Target`/`Source` callbacks are the only entry points for resolving upstream URLs, which means no user-supplied URL ever reaches the outbound client. Request and response headers are passed through strict allowlists that exclude `Authorization`, `Cookie`, credential-style keys, and the internal `X-Cagent-Forward` header. Body sizes are bounded before any bytes are sent upstream. Redirects are unconditionally refused at the `http.Client` level so that a redirect response from a misbehaving upstream cannot replay credentials to a third-party host. Errors sent to browsers are deliberately vague; detail stays on the server side.

The relay package adds one further layer: when the upstream returns 401, the token is invalidated and fetched exactly once more. If the fresh token matches the rejected one, the request fails immediately rather than looping. Streaming responses are forwarded line by line with an `http.Flusher` flush on each SSE boundary, and an optional `StreamObserver` can validate that the stream ended in a recognized completion state — emitting a caller-supplied error event if it did not.

Validation: `task lint`, `task test`, `task build` all pass.