### PR TITLE
fix(test): load HCL examples in live models check

### DIFF
--- a/pkg/config/examples_test.go
+++ b/pkg/config/examples_test.go
@@ -167,7 +167,7 @@ func TestExamplesAgainstLiveModelsDev(t *testing.T) {
 
 	var drifted []string
 	for _, file := range collectExamples(t) {
-		cfg, err := Load(t.Context(), NewFileSource(file))
+		cfg, err := Load(t.Context(), hcl.NewSource(NewFileSource(file)))
 		require.NoError(t, err)
 
 		for _, id := range catalogModelRefs(cfg) {


### PR DESCRIPTION
## Summary
- wrap file sources with `hcl.NewSource` in `TestExamplesAgainstLiveModelsDev`
- ensure `.hcl` examples are decoded through the HCL loader during the live models.dev check

## Root cause
The live catalog check passed `NewFileSource(file)` directly to `Load`, so HCL examples were not adapted to the config source format expected by the loader. This made the opt-in check fail while iterating HCL examples.

## Validation
- `go test ./pkg/config -run 'TestExamplesAgainstLiveModelsDev|TestParseExamples' -count=1`\n- `CHECK_MODELS_DEV_LIVE=1 go test ./pkg/config -run '^TestExamplesAgainstLiveModelsDev$' -count=1`\n- `task dev`