### PR TITLE
ci: skip redundant main push checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,7 @@ jobs:
               - '**'
 
   lint:
+    if: github.event_name != 'push' || github.ref != 'refs/heads/main'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -182,7 +183,9 @@ jobs:
 
   licenses:
     needs: changes
-    if: needs.changes.outputs.code == 'true'
+    if: >-
+      needs.changes.outputs.code == 'true' &&
+      (github.event_name != 'push' || github.ref != 'refs/heads/main')
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:


### PR DESCRIPTION
Skip lint and license checks on pushes to main because those checks have already passed for the same SHA in the merge_group run. Main-push runs still retain publishing, cache seeding, and race testing.