### PR TITLE
fix: always clone RuntimeConfig in LoadWithConfig to prevent race

### DIFF
--- a/pkg/config/runtime.go
+++ b/pkg/config/runtime.go
@@ -27,9 +27,9 @@ type RuntimeConfig struct {
 	modelsDevStoreOnce     sync.Once
 
 	// ProviderRegistry instantiates model providers for toolsets that build
-	// providers at load time (e.g. RAG embeddings/reranking). It is populated
-	// by the team loader with the same registry used for agent models. When
-	// nil, ProviderRegistryOrDefault falls back to provider.DefaultRegistry.
+	// providers at load time (e.g. RAG embeddings/reranking). The team loader
+	// sets it on its per-load clone with the registry used for agent models.
+	// When nil, ProviderRegistryOrDefault falls back to provider.DefaultRegistry.
 	ProviderRegistry *provider.Registry
 }
 

--- a/pkg/teamloader/teamloader.go
+++ b/pkg/teamloader/teamloader.go
@@ -56,11 +56,9 @@ type loadOptions struct {
 
 type Opt func(*loadOptions) error
 
-// WithWorkingDir overrides the working directory toolsets are built with,
-// without touching the caller's RuntimeConfig. Callers that share one
-// RuntimeConfig across concurrent loads (the API server, one per session)
-// need this to keep each session's shell, filesystem and git tools rooted in
-// that session's directory.
+// WithWorkingDir overrides the working directory toolsets are built with.
+// Callers that share one RuntimeConfig across sessions use it to root each
+// session's shell, filesystem and git tools in that session's directory.
 func WithWorkingDir(dir string) Opt {
 	return func(opts *loadOptions) error {
 		opts.workingDir = dir
@@ -256,13 +254,11 @@ func LoadWithConfig(ctx context.Context, agentSource config.Source, runConfig *c
 		}
 	}
 
-	// Toolsets read runConfig.WorkingDir, and the load below writes the
-	// resolved models, providers and provider registry back onto runConfig.
-	// Callers that load several agents from one RuntimeConfig (the API server
-	// shares a single one across concurrent sessions) must not see those
-	// writes, so take a copy when an explicit working directory is supplied.
-	if loadOpts.workingDir != "" && loadOpts.workingDir != runConfig.WorkingDir {
-		runConfig = runConfig.Clone()
+	// Loading resolves per-agent state into RuntimeConfig for toolset creators.
+	// Keep it isolated from the caller so concurrent loads can safely share a
+	// RuntimeConfig.
+	runConfig = runConfig.Clone()
+	if loadOpts.workingDir != "" {
 		runConfig.WorkingDir = loadOpts.workingDir
 	}
 

--- a/pkg/teamloader/teamloader.go
+++ b/pkg/teamloader/teamloader.go
@@ -254,7 +254,7 @@ func LoadWithConfig(ctx context.Context, agentSource config.Source, runConfig *c
 		}
 	}
 
-	// Loading resolves per-agent state into RuntimeConfig for toolset creators.
+	// Loading resolves per-load state into RuntimeConfig for toolset creators.
 	// Keep it isolated from the caller so concurrent loads can safely share a
 	// RuntimeConfig.
 	runConfig = runConfig.Clone()

--- a/pkg/teamloader/teamloader_test.go
+++ b/pkg/teamloader/teamloader_test.go
@@ -1696,9 +1696,14 @@ func TestLoadCapturesEncryptedConfigFromSource(t *testing.T) {
 `)
 	src := encConfigSource{name: "agent.yaml", data: data, enc: "ENCRYPTED-FROM-HEADER"}
 
-	result, err := LoadWithConfig(t.Context(), src, &config.RuntimeConfig{}, withTestProviderRegistry()...)
+	rc := &config.RuntimeConfig{}
+	result, err := LoadWithConfig(t.Context(), src, rc, withTestProviderRegistry()...)
 	require.NoError(t, err)
 	assert.Equal(t, "ENCRYPTED-FROM-HEADER", result.EncryptedConfig)
+	assert.Empty(t, rc.EncryptedConfig)
+	assert.Nil(t, rc.Models)
+	assert.Nil(t, rc.Providers)
+	assert.Nil(t, rc.ProviderRegistry)
 }
 
 // TestLoadExplicitEncryptedConfigWins verifies an explicit

--- a/pkg/teamloader/teamloader_test.go
+++ b/pkg/teamloader/teamloader_test.go
@@ -1669,6 +1669,39 @@ func TestLoadWithConfig_WithWorkingDirIsConcurrencySafe(t *testing.T) {
 		"the shared RuntimeConfig must never be mutated")
 }
 
+func TestLoadWithConfig_SharedRuntimeConfigIsConcurrencySafe(t *testing.T) {
+	t.Setenv("OPENAI_API_KEY", "dummy")
+
+	data := []byte(`agents:
+  root:
+    model: openai/gpt-4o
+    instruction: test
+`)
+	runConfig := &config.RuntimeConfig{}
+
+	const loads = 8
+	var wg sync.WaitGroup
+	errs := make([]error, loads)
+	for i := range loads {
+		wg.Go(func() {
+			_, errs[i] = LoadWithConfig(
+				t.Context(),
+				config.NewBytesSource("t.yaml", data),
+				runConfig,
+				withTestProviderRegistry()...,
+			)
+		})
+	}
+	wg.Wait()
+
+	for i, err := range errs {
+		require.NoErrorf(t, err, "load %d", i)
+	}
+	assert.Nil(t, runConfig.Models)
+	assert.Nil(t, runConfig.Providers)
+	assert.Nil(t, runConfig.ProviderRegistry)
+}
+
 // encConfigSource is a config.Source that also implements
 // config.EncryptedConfigSource, standing in for a trusted Docker URL that
 // returned the X-Cagent-Encrypted-Config response header.


### PR DESCRIPTION
## Summary

- clone `RuntimeConfig` for every `LoadWithConfig` invocation so resolved models, providers, provider registry, and encrypted config remain per-load
- add direct regression coverage for concurrent loads sharing one runtime config
- clarify comments describing per-load state and working-directory overrides

Closes #4239.

## Validation

- `task test`
- `task lint`
- `task build`
- `go test -race -shuffle=on -count=10 ./pkg/teamloader/...`
