### PR TITLE
fix(tui): allow editing pending messages

### DIFF
--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	tea "charm.land/bubbletea/v2"
+	"github.com/google/uuid"
 
 	"github.com/docker/docker-agent/pkg/app/export"
 	"github.com/docker/docker-agent/pkg/app/transcript"
@@ -1148,26 +1149,49 @@ func (a *App) FollowUp(ctx context.Context, msg runtime.QueuedMessage) error {
 	return a.runtime.FollowUp(ctx, msg)
 }
 
+// CancelPendingMessage withdraws a queued steer or follow-up before the runtime
+// consumes it. Runtimes without queue cancellation support return false.
+func (a *App) CancelPendingMessage(ctx context.Context, msg runtime.QueuedMessage, followUp bool) bool {
+	canceler, ok := a.runtime.(runtime.PendingMessageCanceler)
+	if !ok {
+		return false
+	}
+	if followUp {
+		return canceler.CancelFollowUp(ctx, msg.ID)
+	}
+	return canceler.CancelSteer(ctx, msg.ID)
+}
+
 // SteerMessage resolves attachments into message parts and queues the result
-// for mid-turn injection into the running agent. The runtime appends the
-// message to the session (and emits the matching UserMessageEvent) when the
-// agent loop drains it.
+// for mid-turn injection into the running agent.
 func (a *App) SteerMessage(ctx context.Context, content string, attachments []messages.Attachment) error {
-	msg := runtime.QueuedMessage{Content: content}
+	_, err := a.QueueSteerMessage(ctx, content, attachments)
+	return err
+}
+
+// QueueSteerMessage is SteerMessage with the queue entry returned for cancellation.
+func (a *App) QueueSteerMessage(ctx context.Context, content string, attachments []messages.Attachment) (runtime.QueuedMessage, error) {
+	msg := runtime.QueuedMessage{ID: uuid.NewString(), Content: content}
 	if len(attachments) > 0 {
 		msg.MultiContent = a.buildUserMultiContent(ctx, a.session, content, attachments)
 	}
-	return a.runtime.Steer(ctx, msg)
+	return msg, a.runtime.Steer(ctx, msg)
 }
 
 // FollowUpMessage resolves attachments and queues a message for a separate turn
 // after the current agent turn finishes.
 func (a *App) FollowUpMessage(ctx context.Context, content string, attachments []messages.Attachment) error {
-	msg := runtime.QueuedMessage{Content: content}
+	_, err := a.QueueFollowUpMessage(ctx, content, attachments)
+	return err
+}
+
+// QueueFollowUpMessage is FollowUpMessage with the queue entry returned for cancellation.
+func (a *App) QueueFollowUpMessage(ctx context.Context, content string, attachments []messages.Attachment) (runtime.QueuedMessage, error) {
+	msg := runtime.QueuedMessage{ID: uuid.NewString(), Content: content}
 	if len(attachments) > 0 {
 		msg.MultiContent = a.buildUserMultiContent(ctx, a.session, content, attachments)
 	}
-	return a.runtime.FollowUp(ctx, msg)
+	return msg, a.runtime.FollowUp(ctx, msg)
 }
 
 // TogglePause toggles whether the runtime loop is paused at iteration

--- a/pkg/leantui/ui/keys.go
+++ b/pkg/leantui/ui/keys.go
@@ -16,6 +16,7 @@ const (
 	KeyEnter
 	KeyShiftEnter // insert a literal newline (multi-line input)
 	KeyAltEnter   // submit an end-of-turn follow-up
+	KeyAltUp      // edit the newest pending steer or follow-up
 	KeyTab
 	KeyShiftTab
 	KeyBackspace
@@ -226,6 +227,9 @@ func parseCSI(b []byte) (int, Key) {
 
 	switch final {
 	case 'A':
+		if modifier() == "3" {
+			return consumed, Key{Typ: KeyAltUp}
+		}
 		return consumed, Key{Typ: KeyUp}
 	case 'B':
 		return consumed, Key{Typ: KeyDown}

--- a/pkg/leantui/ui/keys_test.go
+++ b/pkg/leantui/ui/keys_test.go
@@ -43,6 +43,7 @@ func TestParseRunes(t *testing.T) {
 func TestParseEscapeSequences(t *testing.T) {
 	t.Parallel()
 	assert.Equal(t, KeyUp, singleKey(t, "\x1b[A").Typ)
+	assert.Equal(t, KeyAltUp, singleKey(t, "\x1b[1;3A").Typ)
 	assert.Equal(t, KeyDown, singleKey(t, "\x1b[B").Typ)
 	assert.Equal(t, KeyRight, singleKey(t, "\x1b[C").Typ)
 	assert.Equal(t, KeyLeft, singleKey(t, "\x1b[D").Typ)
@@ -67,6 +68,7 @@ func TestParseKittyKeyboardSequences(t *testing.T) {
 		{sequence: "\x1b[9;2u", want: KeyShiftTab},
 		{sequence: "\x1b[13;2u", want: KeyShiftEnter},
 		{sequence: "\x1b[13;3u", want: KeyAltEnter},
+		{sequence: "\x1b[1;3A", want: KeyAltUp},
 		{sequence: "\x1b[27u", want: KeyEsc},
 		{sequence: "\x1b[27;1u", want: KeyEsc},
 		{sequence: "\x1b[127;3u", want: KeyCtrlW},

--- a/pkg/leantui/ui/transcript.go
+++ b/pkg/leantui/ui/transcript.go
@@ -25,6 +25,7 @@ const (
 )
 
 type PendingUserMessage struct {
+	ID      string
 	Display string
 	Content string
 	Kind    PendingUserKind

--- a/pkg/leantui/update.go
+++ b/pkg/leantui/update.go
@@ -10,6 +10,7 @@ import (
 
 	"charm.land/lipgloss/v2"
 	"github.com/atotto/clipboard"
+	"github.com/google/uuid"
 
 	"github.com/docker/docker-agent/pkg/chat"
 	"github.com/docker/docker-agent/pkg/effort"
@@ -48,6 +49,8 @@ func (m *model) handleKey(ctx context.Context, k ui.Key) {
 		m.screen.Editor.Insert([]rune{'\n'})
 	case ui.KeyAltEnter:
 		m.submitEditorMode(ctx, m.screen.Editor.Text(), busySubmitFollowUp)
+	case ui.KeyAltUp:
+		m.cancelPendingMessages(ctx)
 	case ui.KeyTab:
 		m.handleTab()
 	case ui.KeyShiftTab:
@@ -99,6 +102,31 @@ func (m *model) handleKey(ctx context.Context, k ui.Key) {
 	}
 
 	m.screen.Autocomplete.Sync(m.screen.Editor.Text())
+}
+
+func (m *model) cancelPendingMessages(ctx context.Context) bool {
+	if m.app == nil || len(m.pendingUsers) == 0 {
+		return false
+	}
+
+	cancelled := make([]string, 0, len(m.pendingUsers))
+	remaining := make([]ui.PendingUserMessage, 0, len(m.pendingUsers))
+	for _, pending := range m.pendingUsers {
+		followUp := pending.Kind == ui.PendingUserFollowUp
+		if pending.ID == "" || !m.app.CancelPendingMessage(ctx, runtime.QueuedMessage{ID: pending.ID}, followUp) {
+			remaining = append(remaining, pending)
+			continue
+		}
+		cancelled = append(cancelled, pending.Display)
+	}
+	if len(cancelled) == 0 {
+		return false
+	}
+
+	m.pendingUsers = remaining
+	m.screen.Editor.SetText(strings.Join(cancelled, "\n"))
+	m.screen.Autocomplete.Sync(m.screen.Editor.Text())
+	return true
 }
 
 func (m *model) handleInterrupt() {
@@ -551,18 +579,20 @@ func (m *model) dispatchUserMessage(ctx context.Context, display, content string
 	if m.busy {
 		switch mode {
 		case busySubmitSteer:
-			if err := m.app.Steer(ctx, runtime.QueuedMessage{Content: content}); err != nil {
+			msg := runtime.QueuedMessage{ID: uuid.NewString(), Content: content}
+			if err := m.app.Steer(ctx, msg); err != nil {
 				m.addNotice("⚠ ", "Could not steer current response: "+err.Error(), ui.StWarning())
 				return
 			}
-			m.addPendingUser(display, content, ui.PendingUserSteer)
+			m.addPendingUser(msg.ID, display, content, ui.PendingUserSteer)
 			return
 		case busySubmitFollowUp:
-			if err := m.app.FollowUp(ctx, runtime.QueuedMessage{Content: content}); err != nil {
+			msg := runtime.QueuedMessage{ID: uuid.NewString(), Content: content}
+			if err := m.app.FollowUp(ctx, msg); err != nil {
 				m.addNotice("⚠ ", "Could not enqueue follow-up: "+err.Error(), ui.StWarning())
 				return
 			}
-			m.addPendingUser(display, content, ui.PendingUserFollowUp)
+			m.addPendingUser(msg.ID, display, content, ui.PendingUserFollowUp)
 			return
 		default:
 			m.enqueueFollowUp(display, content)
@@ -722,8 +752,8 @@ func (m *model) addUserEcho(text string) {
 	m.screen.Transcript.AddBlock(func(w int) []string { return ui.RenderUserLines(text, w) })
 }
 
-func (m *model) addPendingUser(display, content string, kind ui.PendingUserKind) {
-	m.pendingUsers = append(m.pendingUsers, ui.PendingUserMessage{Display: display, Content: content, Kind: kind})
+func (m *model) addPendingUser(id, display, content string, kind ui.PendingUserKind) {
+	m.pendingUsers = append(m.pendingUsers, ui.PendingUserMessage{ID: id, Display: display, Content: content, Kind: kind})
 }
 
 func (m *model) consumePendingUser(kind ui.PendingUserKind, content string) (ui.PendingUserMessage, bool) {
@@ -778,6 +808,7 @@ func (m *model) commitHelp() {
 			ui.StMuted().Render("  Enter      send             Shift+Enter insert newline"),
 			ui.StMuted().Render("  Alt+Enter  follow up        Up/Down     history"),
 			ui.StMuted().Render("  Tab        complete command Shift+Tab   cycle thinking"),
+			ui.StMuted().Render("  Option+Up  edit all pending messages"),
 			ui.StMuted().Render("  Esc        interrupt         Ctrl+C     cancel / quit"),
 			ui.StMuted().Render("  Ctrl+W     delete previous word"),
 		}

--- a/pkg/leantui/update_test.go
+++ b/pkg/leantui/update_test.go
@@ -113,6 +113,26 @@ func (r *cycleThinkingRuntime) FollowUp(_ context.Context, msg runtime.QueuedMes
 	r.followUps = append(r.followUps, msg)
 	return nil
 }
+
+func (r *cycleThinkingRuntime) CancelSteer(_ context.Context, id string) bool {
+	for i, msg := range r.steered {
+		if msg.ID == id {
+			r.steered = append(r.steered[:i], r.steered[i+1:]...)
+			return true
+		}
+	}
+	return false
+}
+
+func (r *cycleThinkingRuntime) CancelFollowUp(_ context.Context, id string) bool {
+	for i, msg := range r.followUps {
+		if msg.ID == id {
+			r.followUps = append(r.followUps[:i], r.followUps[i+1:]...)
+			return true
+		}
+	}
+	return false
+}
 func (r *cycleThinkingRuntime) QueueStatus() runtime.QueueStatus { return runtime.QueueStatus{} }
 
 func (r *cycleThinkingRuntime) TogglePause(context.Context) (bool, error) {
@@ -510,6 +530,82 @@ func TestAltEnterWhileBusyQueuesRuntimeFollowUp(t *testing.T) {
 	assert.True(t, m.screen.Editor.IsEmpty())
 }
 
+func TestOptionUpCancelsPendingSteerAndRestoresEditor(t *testing.T) {
+	t.Parallel()
+	rt := &cycleThinkingRuntime{}
+	m := bareModel(24)
+	m.app = app.New(t.Context(), rt, session.New())
+	m.busy = true
+	m.screen.Editor.SetText("turn left")
+	m.handleEnter(t.Context())
+
+	m.handleKey(t.Context(), ui.Key{Typ: ui.KeyAltUp})
+
+	assert.Empty(t, rt.steered)
+	assert.Empty(t, m.pendingUsers)
+	assert.Equal(t, "turn left", m.screen.Editor.Text())
+	assert.True(t, m.busy)
+}
+
+func TestOptionUpCancelsPendingFollowUpAndRestoresEditor(t *testing.T) {
+	t.Parallel()
+	rt := &cycleThinkingRuntime{}
+	m := bareModel(24)
+	m.app = app.New(t.Context(), rt, session.New())
+	m.busy = true
+	m.screen.Editor.SetText("do this next")
+	m.handleKey(t.Context(), ui.Key{Typ: ui.KeyAltEnter})
+
+	m.handleKey(t.Context(), ui.Key{Typ: ui.KeyAltUp})
+
+	assert.Empty(t, rt.followUps)
+	assert.Empty(t, m.pendingUsers)
+	assert.Equal(t, "do this next", m.screen.Editor.Text())
+	assert.True(t, m.busy)
+}
+
+func TestOptionUpCancelsAllPendingMessagesAndConcatenatesThem(t *testing.T) {
+	t.Parallel()
+	rt := &cycleThinkingRuntime{}
+	m := bareModel(24)
+	m.app = app.New(t.Context(), rt, session.New())
+	m.busy = true
+
+	m.screen.Editor.SetText("first steer")
+	m.handleEnter(t.Context())
+	m.screen.Editor.SetText("then follow up")
+	m.handleKey(t.Context(), ui.Key{Typ: ui.KeyAltEnter})
+	m.screen.Editor.SetText("second steer")
+	m.handleEnter(t.Context())
+
+	m.handleKey(t.Context(), ui.Key{Typ: ui.KeyAltUp})
+
+	assert.Empty(t, rt.steered)
+	assert.Empty(t, rt.followUps)
+	assert.Empty(t, m.pendingUsers)
+	assert.Equal(t, "first steer\nthen follow up\nsecond steer", m.screen.Editor.Text())
+	assert.True(t, m.busy)
+}
+
+func TestOptionUpRestoresOnlyMessagesStillCancelable(t *testing.T) {
+	t.Parallel()
+	rt := &cycleThinkingRuntime{}
+	m := bareModel(24)
+	m.app = app.New(t.Context(), rt, session.New())
+	m.busy = true
+	m.pendingUsers = []ui.PendingUserMessage{
+		{ID: "consumed", Display: "already sent", Kind: ui.PendingUserSteer},
+		{ID: "pending", Display: "still pending", Kind: ui.PendingUserFollowUp},
+	}
+	rt.followUps = []runtime.QueuedMessage{{ID: "pending", Content: "still pending"}}
+
+	m.handleKey(t.Context(), ui.Key{Typ: ui.KeyAltUp})
+
+	assert.Empty(t, rt.followUps)
+	assert.Equal(t, "still pending", m.screen.Editor.Text())
+	assert.Equal(t, []ui.PendingUserMessage{{ID: "consumed", Display: "already sent", Kind: ui.PendingUserSteer}}, m.pendingUsers)
+}
+
 func TestEditorSubmitWhileBusySteersAndRendersAtStreamEnd(t *testing.T) {
 	t.Parallel()
 	rt := &cycleThinkingRuntime{}
@@ -541,7 +637,7 @@ func TestSteeredUserEventConfirmsPendingAfterAssistant(t *testing.T) {
 	m := bareModel(24)
 	m.busy = true
 	m.screen.Transcript.AppendAssistant("assistant response")
-	m.addPendingUser("/change", "resolved steering prompt", ui.PendingUserSteer)
+	m.addPendingUser("", "/change", "resolved steering prompt", ui.PendingUserSteer)
 
 	m.handleEvent(t.Context(), runtime.UserMessage("resolved steering prompt\n", "session", nil, 1))
 

--- a/pkg/runtime/message_queue.go
+++ b/pkg/runtime/message_queue.go
@@ -2,6 +2,7 @@ package runtime
 
 import (
 	"context"
+	"sync"
 
 	"github.com/docker/docker-agent/pkg/chat"
 )
@@ -10,8 +11,16 @@ import (
 // either mid-turn (via the steer queue) or at end-of-turn (via the follow-up
 // queue).
 type QueuedMessage struct {
+	ID           string
 	Content      string
 	MultiContent []chat.MessagePart
+}
+
+// PendingMessageCanceler is implemented by runtimes that can withdraw queued
+// messages before the agent loop consumes them.
+type PendingMessageCanceler interface {
+	CancelSteer(ctx context.Context, id string) bool
+	CancelFollowUp(ctx context.Context, id string) bool
 }
 
 // RecallHandler delivers a tool-produced message through an embedder-owned
@@ -40,9 +49,16 @@ type MessageQueue interface {
 	Drain(ctx context.Context) []QueuedMessage
 }
 
-// inMemoryMessageQueue is the default MessageQueue backed by a buffered channel.
+type cancelableMessageQueue interface {
+	MessageQueue
+	Cancel(id string) bool
+}
+
+// inMemoryMessageQueue is the default MessageQueue.
 type inMemoryMessageQueue struct {
-	ch chan QueuedMessage
+	mu       sync.Mutex
+	messages []QueuedMessage
+	capacity int
 }
 
 const (
@@ -53,40 +69,65 @@ const (
 	defaultFollowUpQueueCapacity = 20
 )
 
-// NewInMemoryMessageQueue creates a MessageQueue backed by a buffered channel
-// with the given capacity.
+// NewInMemoryMessageQueue creates an in-memory FIFO queue with the given capacity.
 func NewInMemoryMessageQueue(capacity int) MessageQueue {
-	return &inMemoryMessageQueue{ch: make(chan QueuedMessage, capacity)}
+	return &inMemoryMessageQueue{capacity: capacity}
 }
 
-func (q *inMemoryMessageQueue) Enqueue(_ context.Context, msg QueuedMessage) bool {
-	select {
-	case q.ch <- msg:
-		return true
-	default:
+func (q *inMemoryMessageQueue) Enqueue(ctx context.Context, msg QueuedMessage) bool {
+	if ctx.Err() != nil {
 		return false
 	}
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	if len(q.messages) >= q.capacity {
+		return false
+	}
+	q.messages = append(q.messages, msg)
+	return true
 }
 
 func (q *inMemoryMessageQueue) Dequeue(_ context.Context) (QueuedMessage, bool) {
-	select {
-	case m := <-q.ch:
-		return m, true
-	default:
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	if len(q.messages) == 0 {
 		return QueuedMessage{}, false
 	}
+	msg := q.messages[0]
+	q.messages[0] = QueuedMessage{}
+	q.messages = q.messages[1:]
+	return msg, true
 }
 
 func (q *inMemoryMessageQueue) Drain(_ context.Context) []QueuedMessage {
-	var msgs []QueuedMessage
-	for {
-		select {
-		case m := <-q.ch:
-			msgs = append(msgs, m)
-		default:
-			return msgs
-		}
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	msgs := q.messages
+	q.messages = nil
+	return msgs
+}
+
+func (q *inMemoryMessageQueue) Cancel(id string) bool {
+	if id == "" {
+		return false
 	}
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	for i, msg := range q.messages {
+		if msg.ID != id {
+			continue
+		}
+		q.messages[i] = QueuedMessage{}
+		q.messages = append(q.messages[:i], q.messages[i+1:]...)
+		return true
+	}
+	return false
+}
+
+func (q *inMemoryMessageQueue) status() (depth, capacity int) {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	return len(q.messages), q.capacity
 }
 
 // QueueStatus represents the current depth and capacity of message queues

--- a/pkg/runtime/message_queue_test.go
+++ b/pkg/runtime/message_queue_test.go
@@ -1,0 +1,36 @@
+package runtime
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInMemoryMessageQueueCancel(t *testing.T) {
+	t.Parallel()
+	q := NewInMemoryMessageQueue(3).(*inMemoryMessageQueue)
+	require.True(t, q.Enqueue(t.Context(), QueuedMessage{ID: "first", Content: "one"}))
+	require.True(t, q.Enqueue(t.Context(), QueuedMessage{ID: "second", Content: "two"}))
+	require.True(t, q.Enqueue(t.Context(), QueuedMessage{ID: "third", Content: "three"}))
+
+	assert.True(t, q.Cancel("second"))
+	assert.False(t, q.Cancel("second"))
+	assert.False(t, q.Cancel(""))
+	assert.Equal(t, []QueuedMessage{
+		{ID: "first", Content: "one"},
+		{ID: "third", Content: "three"},
+	}, q.Drain(t.Context()))
+}
+
+func TestInMemoryMessageQueueRejectsCanceledContext(t *testing.T) {
+	t.Parallel()
+	q := NewInMemoryMessageQueue(1)
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	assert.False(t, q.Enqueue(ctx, QueuedMessage{Content: "nope"}))
+	_, ok := q.Dequeue(t.Context())
+	assert.False(t, ok)
+}

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -2073,6 +2073,16 @@ func (r *LocalRuntime) FollowUp(ctx context.Context, msg QueuedMessage) error {
 	return nil
 }
 
+func (r *LocalRuntime) CancelSteer(_ context.Context, id string) bool {
+	q, ok := r.steerQueue.(cancelableMessageQueue)
+	return ok && q.Cancel(id)
+}
+
+func (r *LocalRuntime) CancelFollowUp(_ context.Context, id string) bool {
+	q, ok := r.followUpQueue.(cancelableMessageQueue)
+	return ok && q.Cancel(id)
+}
+
 // SetRecallHandler registers an embedder-owned wake-up path for tool recalls.
 // When unset, recalls fall back to the steer queue and are consumed by the next
 // active RunStream.
@@ -2102,12 +2112,10 @@ func (r *LocalRuntime) recall(ctx context.Context, msg QueuedMessage) error {
 func (r *LocalRuntime) QueueStatus() QueueStatus {
 	status := QueueStatus{}
 	if steerQ, ok := r.steerQueue.(*inMemoryMessageQueue); ok {
-		status.SteerDepth = len(steerQ.ch)
-		status.SteerCapacity = cap(steerQ.ch)
+		status.SteerDepth, status.SteerCapacity = steerQ.status()
 	}
 	if followupQ, ok := r.followUpQueue.(*inMemoryMessageQueue); ok {
-		status.FollowupDepth = len(followupQ.ch)
-		status.FollowupCapacity = cap(followupQ.ch)
+		status.FollowupDepth, status.FollowupCapacity = followupQ.status()
 	}
 	return status
 }

--- a/pkg/tui/messages/session.go
+++ b/pkg/tui/messages/session.go
@@ -102,6 +102,9 @@ type (
 	// ClearQueueMsg clears all queued messages.
 	ClearQueueMsg struct{}
 
+	// RestorePendingMessagesMsg restores canceled pending messages to the editor.
+	RestorePendingMessagesMsg struct{ Content string }
+
 	// ToggleSplitDiffMsg toggles split diff view mode.
 	ToggleSplitDiffMsg struct{}
 

--- a/pkg/tui/page/chat/chat.go
+++ b/pkg/tui/page/chat/chat.go
@@ -1,9 +1,11 @@
 package chat
 
 import (
+	"cmp"
 	"context"
 	"fmt"
 	"log/slog"
+	"slices"
 	"strings"
 	"time"
 
@@ -14,6 +16,7 @@ import (
 
 	"github.com/docker/docker-agent/pkg/app"
 	"github.com/docker/docker-agent/pkg/chat"
+	"github.com/docker/docker-agent/pkg/runtime"
 	"github.com/docker/docker-agent/pkg/tui/animation"
 	tuibanner "github.com/docker/docker-agent/pkg/tui/banner"
 	"github.com/docker/docker-agent/pkg/tui/commands"
@@ -187,8 +190,12 @@ func (p *chatPage) SidebarVisualGeneration() uint64 {
 }
 
 type queuedMessage struct {
-	content     string
-	attachments []msgtypes.Attachment
+	id             string
+	content        string
+	runtimeContent string
+	attachments    []msgtypes.Attachment
+	followUp       bool
+	order          uint64
 }
 
 // maxQueuedMessages is the maximum number of messages that can be queued
@@ -243,7 +250,9 @@ type chatPage struct {
 	hideBanner bool
 
 	// Message queue for enqueuing messages while agent is working
-	messageQueue []queuedMessage
+	messageQueue    []queuedMessage
+	pendingMessages []queuedMessage
+	pendingSequence uint64
 
 	// Editing state for branching sessions
 	editing          bool
@@ -607,6 +616,7 @@ func (p *chatPage) update(msg tea.Msg) (layout.Model, tea.Cmd) {
 		return p.handleSendMsg(msg)
 
 	case steerSentMsg:
+		p.addPendingMessage(msg.pending)
 		return p, notification.InfoCmd("Message sent to the working agent · /settings to queue instead")
 
 	case steerFailedMsg:
@@ -621,6 +631,7 @@ func (p *chatPage) update(msg tea.Msg) (layout.Model, tea.Cmd) {
 		)
 
 	case followUpSentMsg:
+		p.addPendingMessage(msg.pending)
 		return p, notification.InfoCmd("Follow-up queued for the next turn")
 
 	case followUpFailedMsg:
@@ -643,6 +654,9 @@ func (p *chatPage) update(msg tea.Msg) (layout.Model, tea.Cmd) {
 
 	case msgtypes.ClearQueueMsg:
 		return p.handleClearQueue()
+
+	case msgtypes.RestorePendingMessagesMsg:
+		return p, nil
 
 	case generatedMediaResolvedMsg:
 		return p, p.messages.UpdateAssistantMedia(msg.media)
@@ -1053,9 +1067,11 @@ func (p *chatPage) enqueueMessage(msg msgtypes.SendMsg) tea.Cmd {
 	}
 
 	// Add to queue
+	p.pendingSequence++
 	p.messageQueue = append(p.messageQueue, queuedMessage{
 		content:     msg.Content,
 		attachments: msg.Attachments,
+		order:       p.pendingSequence,
 	})
 	p.syncQueueToSidebar()
 
@@ -1069,9 +1085,13 @@ func (p *chatPage) enqueueMessage(msg msgtypes.SendMsg) tea.Cmd {
 // queue; steerFailedMsg carries the message back for local queueing when
 // steering was rejected (e.g. steer queue full).
 type (
-	steerSentMsg      struct{}
-	steerFailedMsg    struct{ original msgtypes.SendMsg }
-	followUpSentMsg   struct{}
+	steerSentMsg struct {
+		pending queuedMessage
+	}
+	steerFailedMsg  struct{ original msgtypes.SendMsg }
+	followUpSentMsg struct {
+		pending queuedMessage
+	}
 	followUpFailedMsg struct{ original msgtypes.SendMsg }
 )
 
@@ -1082,25 +1102,31 @@ type (
 // which is the moment the agent actually sees it.
 func (p *chatPage) steerMessage(msg msgtypes.SendMsg) tea.Cmd {
 	ctx := p.ctx()
+	p.pendingSequence++
+	order := p.pendingSequence
 	return func() tea.Msg {
 		content := p.app.ResolveInput(ctx, msg.Content)
-		if err := p.app.SteerMessage(ctx, content, msg.Attachments); err != nil {
+		queued, err := p.app.QueueSteerMessage(ctx, content, msg.Attachments)
+		if err != nil {
 			slog.Warn("Failed to steer message; falling back to queue", "error", err)
 			return steerFailedMsg{original: msg}
 		}
-		return steerSentMsg{}
+		return steerSentMsg{pending: queuedMessage{id: queued.ID, content: msg.Content, runtimeContent: content, attachments: msg.Attachments, order: order}}
 	}
 }
 
 func (p *chatPage) followUpMessage(msg msgtypes.SendMsg) tea.Cmd {
 	ctx := p.ctx()
+	p.pendingSequence++
+	order := p.pendingSequence
 	return func() tea.Msg {
 		content := p.app.ResolveInput(ctx, msg.Content)
-		if err := p.app.FollowUpMessage(ctx, content, msg.Attachments); err != nil {
+		queued, err := p.app.QueueFollowUpMessage(ctx, content, msg.Attachments)
+		if err != nil {
 			slog.Warn("Failed to enqueue follow-up; falling back to local queue", "error", err)
 			return followUpFailedMsg{original: msg}
 		}
-		return followUpSentMsg{}
+		return followUpSentMsg{pending: queuedMessage{id: queued.ID, content: msg.Content, runtimeContent: content, attachments: msg.Attachments, followUp: true, order: order}}
 	}
 }
 
@@ -1240,6 +1266,58 @@ func (p *chatPage) extractAttachmentsFromSession(position int) []msgtypes.Attach
 	}
 
 	return attachments
+}
+
+func (p *chatPage) addPendingMessage(msg queuedMessage) {
+	if msg.order == 0 {
+		p.pendingSequence++
+		msg.order = p.pendingSequence
+	}
+	p.pendingMessages = append(p.pendingMessages, msg)
+}
+
+func (p *chatPage) consumePendingMessage(content string) {
+	for i, msg := range p.pendingMessages {
+		if msg.runtimeContent != content && msg.runtimeContent != strings.TrimSuffix(content, "\n") {
+			continue
+		}
+		p.pendingMessages = append(p.pendingMessages[:i], p.pendingMessages[i+1:]...)
+		return
+	}
+}
+
+func (p *chatPage) restorePendingMessages() tea.Cmd {
+	pending := append([]queuedMessage(nil), p.pendingMessages...)
+	pending = append(pending, p.messageQueue...)
+	if len(pending) == 0 {
+		return notification.InfoCmd("No pending messages")
+	}
+	slices.SortStableFunc(pending, func(a, b queuedMessage) int { return cmp.Compare(a.order, b.order) })
+
+	restored := make([]string, 0, len(pending))
+	remaining := make([]queuedMessage, 0, len(p.pendingMessages))
+	for _, msg := range pending {
+		if msg.id == "" {
+			restored = append(restored, msg.content)
+			continue
+		}
+		if !p.app.CancelPendingMessage(p.ctx(), runtime.QueuedMessage{ID: msg.id}, msg.followUp) {
+			remaining = append(remaining, msg)
+			continue
+		}
+		restored = append(restored, msg.content)
+	}
+	if len(restored) == 0 {
+		return notification.InfoCmd("No pending messages")
+	}
+
+	p.pendingMessages = remaining
+	p.messageQueue = nil
+	p.syncQueueToSidebar()
+	return tea.Batch(
+		core.CmdHandler(msgtypes.RestorePendingMessagesMsg{Content: strings.Join(restored, "\n")}),
+		core.CmdHandler(msgtypes.RequestFocusMsg{Target: msgtypes.PanelEditor}),
+	)
 }
 
 // processNextQueuedMessage pops the next message from the queue and processes it.

--- a/pkg/tui/page/chat/input_handlers.go
+++ b/pkg/tui/page/chat/input_handlers.go
@@ -40,6 +40,10 @@ func (p *chatPage) handleKeyPress(msg tea.KeyPressMsg) (layout.Model, tea.Cmd) {
 	}
 
 	switch {
+	case key.Matches(msg, key.NewBinding(key.WithKeys("alt+up"))):
+		cmd := p.restorePendingMessages()
+		return p, cmd
+
 	case key.Matches(msg, p.keyMap.Cancel):
 		// If inline editing is active, cancel the edit first
 		if p.messages.IsInlineEditing() {

--- a/pkg/tui/page/chat/queue_test.go
+++ b/pkg/tui/page/chat/queue_test.go
@@ -23,6 +23,7 @@ import (
 	mcptools "github.com/docker/docker-agent/pkg/tools/mcp"
 	"github.com/docker/docker-agent/pkg/tui/animation"
 	"github.com/docker/docker-agent/pkg/tui/commands"
+	"github.com/docker/docker-agent/pkg/tui/components/notification"
 	"github.com/docker/docker-agent/pkg/tui/components/sidebar"
 	"github.com/docker/docker-agent/pkg/tui/core"
 	"github.com/docker/docker-agent/pkg/tui/messages"
@@ -583,6 +584,32 @@ func (r *steerRecordingRuntime) FollowUp(_ context.Context, msg runtime.QueuedMe
 	return nil
 }
 
+func (r *steerRecordingRuntime) CancelSteer(_ context.Context, id string) bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for i, msg := range r.steers {
+		if msg.ID != id {
+			continue
+		}
+		r.steers = append(r.steers[:i], r.steers[i+1:]...)
+		return true
+	}
+	return false
+}
+
+func (r *steerRecordingRuntime) CancelFollowUp(_ context.Context, id string) bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for i, msg := range r.followUps {
+		if msg.ID != id {
+			continue
+		}
+		r.followUps = append(r.followUps[:i], r.followUps[i+1:]...)
+		return true
+	}
+	return false
+}
+
 func (r *steerRecordingRuntime) followedUp() []runtime.QueuedMessage {
 	r.mu.Lock()
 	defer r.mu.Unlock()
@@ -636,6 +663,52 @@ func TestSteerFlow_BusyAgent_SteersMessage(t *testing.T) {
 	steered := rt.steered()
 	require.Len(t, steered, 1)
 	assert.Equal(t, "extra context", steered[0].Content)
+}
+
+func TestOptionUpRestoresAllPendingMessageTypes(t *testing.T) {
+	t.Parallel()
+
+	rt := &steerRecordingRuntime{}
+	sess := session.New()
+	p := New(animation.NewRuntime(), t.Context(), app.New(t.Context(), rt, sess), service.NewSessionState(sess)).(*chatPage)
+	p.working = true
+
+	_, steerCmd := p.handleSendMsg(messages.SendMsg{Content: "first steer"})
+	steerResult := steerCmd()
+	_, _ = p.Update(steerResult)
+	_, followCmd := p.handleSendMsg(messages.SendMsg{Content: "then follow up", FollowUp: true})
+	followResult := followCmd()
+	_, _ = p.Update(followResult)
+	p.enqueueMessage(messages.SendMsg{Content: "locally queued", Queue: true})
+
+	_, cmd := p.handleKeyPress(tea.KeyPressMsg{Code: tea.KeyUp, Mod: tea.ModAlt})
+
+	assert.Empty(t, rt.steered())
+	assert.Empty(t, rt.followedUp())
+	assert.Empty(t, p.pendingMessages)
+	assert.Empty(t, p.messageQueue)
+	msgs := runTimerCmd(t, cmd)
+	assert.Contains(t, msgs, messages.RestorePendingMessagesMsg{Content: "first steer\nthen follow up\nlocally queued"})
+	assert.Contains(t, msgs, messages.RequestFocusMsg{Target: messages.PanelEditor})
+}
+
+func TestConsumedSteerIsNotRestored(t *testing.T) {
+	t.Parallel()
+
+	rt := &steerRecordingRuntime{}
+	sess := session.New()
+	p := New(animation.NewRuntime(), t.Context(), app.New(t.Context(), rt, sess), service.NewSessionState(sess)).(*chatPage)
+	p.working = true
+
+	_, steerCmd := p.handleSendMsg(messages.SendMsg{Content: "already consumed"})
+	_, _ = p.Update(steerCmd())
+	require.Len(t, p.pendingMessages, 1)
+	p.consumePendingMessage("already consumed")
+
+	_, cmd := p.handleKeyPress(tea.KeyPressMsg{Code: tea.KeyUp, Mod: tea.ModAlt})
+
+	assert.Empty(t, p.pendingMessages)
+	assert.Contains(t, runTimerCmd(t, cmd), notification.ShowMsg{Text: "No pending messages", Type: notification.TypeInfo})
 }
 
 // TestSteerFlow_ExplicitQueue_SkipsSteering verifies the internal Queue

--- a/pkg/tui/page/chat/runtime_events.go
+++ b/pkg/tui/page/chat/runtime_events.go
@@ -85,6 +85,7 @@ func (p *chatPage) handleRuntimeEvent(msg tea.Msg) (bool, tea.Cmd) {
 	// ===== Content Events =====
 	case *runtime.UserMessageEvent:
 		p.showStartupBanner = false
+		p.consumePendingMessage(msg.Message)
 		return true, p.messages.ReplaceLoadingWithUser(msg.Message, msg.SessionPosition)
 
 	case *runtime.AgentChoiceEvent:

--- a/pkg/tui/tui.go
+++ b/pkg/tui/tui.go
@@ -1227,6 +1227,10 @@ func (m *appModel) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	// --- SendMsg from editor ---
 
+	case messages.RestorePendingMessagesMsg:
+		m.editor.SetValue(msg.Content)
+		return m, m.editor.Focus()
+
 	case messages.SendMsg:
 		// Forward send messages to the active content view
 		if m.history != nil && !msg.BypassQueue {


### PR DESCRIPTION
## Summary

- add Option+Up to withdraw all unconsumed steering and follow-up messages
- restore withdrawn messages to the editor in submission order for correction and resending
- support the behavior in both the lean and normal TUIs
- keep already-consumed messages untouched

## Validation

- `task build`
- `task test`
- `task lint`